### PR TITLE
UI controls adjustments and selection color update

### DIFF
--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -51,6 +51,9 @@ const F32   CURSOR_FLASH_DELAY = 1.0f;  // in seconds
 const S32   CURSOR_THICKNESS = 2;
 const F32   TRIPLE_CLICK_INTERVAL = 0.3f;   // delay between double and triple click.
 
+constexpr F32 FOCUSED_SELECTION_BG_ALPHA = 1;
+constexpr F32 UNFOCUSED_SELECTION_BG_ALPHA = 0.7f;
+
 LLTextBase::line_info::line_info(S32 index_start, S32 index_end, LLRect rect, S32 line_num)
 :   mDocIndexStart(index_start),
     mDocIndexEnd(index_end),
@@ -529,7 +532,7 @@ void LLTextBase::drawSelectionBackground()
         // Draw the selection box (we're using a box instead of reversing the colors on the selected text).
         gGL.getTexUnit(0)->unbind(LLTexUnit::TT_TEXTURE);
         const LLColor4& color = mSelectedBGColor;
-        F32 alpha = hasFocus() ? 1 : 0.7f;
+        F32 alpha = hasFocus() ? FOCUSED_SELECTION_BG_ALPHA : UNFOCUSED_SELECTION_BG_ALPHA;
         alpha *= getDrawContext().mAlpha;
 
         LLColor4 selection_color(color.mV[VRED], color.mV[VGREEN], color.mV[VBLUE], alpha);

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -529,7 +529,7 @@ void LLTextBase::drawSelectionBackground()
         // Draw the selection box (we're using a box instead of reversing the colors on the selected text).
         gGL.getTexUnit(0)->unbind(LLTexUnit::TT_TEXTURE);
         const LLColor4& color = mSelectedBGColor;
-        F32 alpha = hasFocus() ? 0.7f : 0.3f;
+        F32 alpha = hasFocus() ? 1 : 0.7f;
         alpha *= getDrawContext().mAlpha;
 
         LLColor4 selection_color(color.mV[VRED], color.mV[VGREEN], color.mV[VBLUE], alpha);

--- a/indra/newview/skins/default/colors.xml
+++ b/indra/newview/skins/default/colors.xml
@@ -11,6 +11,9 @@
 	<color
 	 name="EmphasisColor_35"
 	 value="0.426 0.729 1.0 0.368" />
+    <color
+     name="SelectionColor"
+     value="0.706 0.851 1 1" />
 	<color
 	 name="BeaconColor"
     value="0.749 0.298 0 1" />	 

--- a/indra/newview/skins/default/xui/en/floater_about_land.xml
+++ b/indra/newview/skins/default/xui/en/floater_about_land.xml
@@ -974,7 +974,7 @@
              layout="topleft"
              left="28"
              name="Set to group:"
-             top_pad="5"
+             top_pad="9"
              width="176">
                 Set to group:
             </text>
@@ -1022,7 +1022,7 @@
              layout="topleft"
              left="28"
              name="Owned by others:"
-             top_pad="5"
+             top_pad="9"
              width="176">
                 Owned by others:
             </text>

--- a/indra/newview/skins/default/xui/en/floater_inventory_settings.xml
+++ b/indra/newview/skins/default/xui/en/floater_inventory_settings.xml
@@ -145,7 +145,7 @@
    font="SansSerifMedium"
    text_color="White"
    top_delta="1"
-   width="300">
+   width="310">
    Clicking on "Show in inventory" or "Find original"
  </text>
  <radio_group

--- a/indra/newview/skins/default/xui/en/floater_model_preview.xml
+++ b/indra/newview/skins/default/xui/en/floater_model_preview.xml
@@ -1879,7 +1879,7 @@ Analysed:
       top="5"
       left_pad="20"
       name="label_display"
-      width="50">
+      width="53">
       Display...
     </text>
     <check_box
@@ -1889,7 +1889,7 @@ Analysed:
       layout="topleft"
       left_delta="0"
       name="show_edges"
-      top_pad="8">
+      top_pad="10">
     </check_box>
     <check_box
       follows="top|left"
@@ -1897,7 +1897,7 @@ Analysed:
       label_text.text_color="White"
       layout="topleft"
       name="show_physics"
-      top_pad="8">
+      top_pad="10">
     </check_box>
     <check_box
       follows="top|left"
@@ -1905,7 +1905,7 @@ Analysed:
       label_text.text_color="White"
       layout="topleft"
       name="show_textures"
-      top_pad="8">
+      top_pad="10">
     </check_box>
     <check_box
       follows="top|left"
@@ -1913,7 +1913,7 @@ Analysed:
       label_text.text_color="White"
       layout="topleft"
       name="show_skin_weight"
-      top_pad="8">
+      top_pad="10">
     </check_box>
     <check_box
       follows="top|left"
@@ -1923,7 +1923,7 @@ Analysed:
       width="130"
       layout="topleft"
       name="show_joint_overrides"
-      top_pad="8">
+      top_pad="10">
     </check_box>
     <check_box
       follows="top|left"
@@ -1931,7 +1931,7 @@ Analysed:
       label_text.text_color="White"
       layout="topleft"
       name="show_joint_positions"
-      top_pad="17">
+      top_pad="21">
     </check_box>
     <text
       follows="top|left"

--- a/indra/newview/skins/default/xui/en/floater_world_map.xml
+++ b/indra/newview/skins/default/xui/en/floater_world_map.xml
@@ -167,7 +167,7 @@
      follows="top|right"
      halign="left"
      height="16"
-     top_delta="-2"
+     top_delta="-5"
      left_pad="7"
      layout="topleft"
      name="person_label"
@@ -181,9 +181,9 @@
      layout="topleft"
      left="3"
      name="infohub_chk"
-     top_pad="3"
+     top_pad="7"
      width="22" />
-         <icon
+    <icon
      follows="top|right"
      height="16"
      image_name="map_infohub.tga"
@@ -191,7 +191,7 @@
      left_pad="0"
      mouse_opaque="true"
      name="infohub"
-     top_delta="0"
+     top_delta="-3"
      width="16" />
  <text
      type="string"
@@ -199,7 +199,7 @@
      follows="top|right"
      halign="left"
      height="16"
-     top_delta="2"
+     top_delta="0"
      left_pad="3"
      layout="topleft"
      name="infohub_label"
@@ -213,7 +213,7 @@
      layout="topleft"
      left="3"
      name="land_for_sale_chk"
-     top_pad="2"
+     top_pad="8"
      width="22" />
     <icon
      follows="top|right"
@@ -222,16 +222,16 @@
      layout="topleft"
      mouse_opaque="true"
      name="landforsale"
-     top_delta="0"
+     top_delta="-3"
      left_pad="0"
      width="16" />
-         <text
+    <text
      type="string"
      length="1"
      follows="top|right"
      halign="left"
      height="16"
-     top_delta="2"
+     top_delta="1"
      left_pad="3"
      layout="topleft"
      name="land_sale_label"
@@ -257,7 +257,7 @@
      layout="topleft"
      left_pad="0"
      name="auction_label"
-     top_delta="3"
+     top_delta="1"
      width="170">
         land auction
     </text>
@@ -270,7 +270,7 @@
      mouse_opaque="true"
      name="square2_owner"
      left="20"
-     top_pad="-5"
+     top_pad="-2"
      width="16" />
     <text
      type="string"
@@ -280,7 +280,7 @@
      layout="topleft"
      left_pad="0"
      name="by_owner_label"
-     top_delta="3"
+     top_delta="0"
      width="100">
        by owner
     </text>
@@ -290,7 +290,7 @@
      control_name="MapShowGridCoords"
      layout="topleft"
      follows="top|right"
-     top_pad="2"
+     top_pad="5"
      left="3"
      height="16"
      width="22"
@@ -300,8 +300,8 @@
      type="string"
      layout="topleft"
      follows="top|right"
-     top_delta="2"
-     left_pad="3"
+     top_delta="-2"
+     left_pad="2"
      height="16"
      width="220"
      halign="left"
@@ -357,7 +357,7 @@
      height="16"
      layout="topleft"
      left="135"
-     top_pad="1"
+     top_pad="5"
      name="event_chk"
      width="22" />
          <icon
@@ -367,6 +367,7 @@
      layout="topleft"
      mouse_opaque="true"
      name="event"
+     top_delta="-2"
      left_pad="0"
      width="18" />
       <text
@@ -375,7 +376,7 @@
      follows="top|right"
      halign="left"
      height="16"
-     top_delta="2"
+     top_delta="0"
      left_pad="3"
      layout="topleft"
      name="pg_label"
@@ -391,7 +392,7 @@
      layout="topleft"
      left="135"
      name="events_mature_chk"
-     top_pad="3"
+     top_pad="7"
      width="22" />
     <icon
      follows="top|right"
@@ -400,16 +401,16 @@
      layout="topleft"
      mouse_opaque="true"
      name="events_mature_icon"
-     top_delta="0"
+     top_delta="-2"
      left_pad="0"
      width="18" />
-           <text
+    <text
      type="string"
      length="1"
      follows="top|right"
      halign="left"
      height="16"
-     top_delta="2"
+     top_delta="0"
      left_pad="3"
      layout="topleft"
      name="events_mature_label"
@@ -424,7 +425,7 @@
      layout="topleft"
      left="135"
      name="events_adult_chk"
-     top_pad="3"
+     top_pad="7"
      width="22" />
     <icon
      follows="top|right"
@@ -434,15 +435,15 @@
      left_pad="0"
      mouse_opaque="true"
      name="events_adult_icon"
-     top_delta="0"
+     top_delta="-2"
      width="18" />
-                <text
+    <text
      type="string"
      length="1"
      follows="top|right"
      halign="left"
      height="16"
-     top_delta="2"
+     top_delta="0"
      left_pad="3"
      layout="topleft"
      name="events_adult_label"

--- a/indra/newview/skins/default/xui/en/inspect_group.xml
+++ b/indra/newview/skins/default/xui/en/inspect_group.xml
@@ -9,7 +9,7 @@
  bg_opaque_image="Inspector_Background" 
  can_close="false"
  can_minimize="false"
- height="158"
+ height="178"
  layout="topleft"
  name="inspect_group"
  single_instance="true"
@@ -47,7 +47,7 @@
   </text>
   <text
    follows="all"
-   height="45"
+   height="65"
    left="8"
    name="group_details"
    use_ellipses="true"
@@ -80,7 +80,7 @@ L$123 to join
    height="23"
    label="Join"
    left="8"
-   top="125"
+   top="146"
    name="join_btn"
    width="103"
    commit_callback.function="InspectGroup.Join"/>
@@ -89,7 +89,7 @@ L$123 to join
    height="23"
    label="Leave"
    left="8"
-   top="125"
+   top="146"
    name="leave_btn"
    width="103"
    commit_callback.function="InspectGroup.Leave"/>
@@ -98,7 +98,7 @@ L$123 to join
      height="23"
      label="View Profile"
      name="view_profile_btn"
-     top="125"
+     top="146"
      left="117"
      width="103"
      commit_callback.function="InspectGroup.ViewProfile" />

--- a/indra/newview/skins/default/xui/en/panel_group_notices.xml
+++ b/indra/newview/skins/default/xui/en/panel_group_notices.xml
@@ -28,7 +28,7 @@ You can turn off Notices on the General tab.
      left="5"
      name="lbl2"
      right="-1"
-     top="5"
+     top="3"
      width="300">
      Notices are kept for 14 days.
 Maximum 200 per group daily
@@ -42,7 +42,7 @@ Maximum 200 per group daily
      left="0"
      right="-1"
      name="notice_list"
-     top_pad="0"
+     top_pad="6"
      width="304">
         <scroll_list.columns
          label=""

--- a/indra/newview/skins/default/xui/en/panel_notification_list_item.xml
+++ b/indra/newview/skins/default/xui/en/panel_notification_list_item.xml
@@ -63,7 +63,8 @@
                     use_ellipses="true" word_wrap="false" mouse_opaque="false" name="sender_or_fee_box" visible="false">
                     Sender: "Resident R e s i d e n t R e s i d e n t"
                   </text>
-                  <text allow_scroll="false" font="SansSerifSmall" top="0" right="-5" width="95" height="13" follows="right" halign="right" layout="topleft" left_pad="5"
+                  <!-- Old DejaVu font is used to avoid overlapping with sender name -->
+                  <text allow_scroll="false" font="DejaVu" font.size="LSmall" top="0" right="-5" width="100" height="13" follows="right" halign="right" layout="topleft" left_pad="5"
                     name="notification_time" value="2014/12/24 23:30" />
                 </panel>
               </panel>
@@ -105,7 +106,8 @@
                         use_ellipses="true" word_wrap="false" mouse_opaque="false" name="sender_or_fee_box_exp" visible="false">
                         Sender: "Resident R e s i d e n t R e s i d e n t"
                       </text>
-                      <text allow_scroll="false" font="SansSerifSmall" top="0" right="-1" width="95" height="13" follows="right" halign="right" layout="topleft" left_pad="5"
+                      <!-- Old DejaVu font is used to avoid overlapping with sender name -->
+                      <text allow_scroll="false" font="DejaVu" font.size="LSmall" top="0" right="-1" width="100" height="13" follows="right" halign="right" layout="topleft" left_pad="5"
                         name="notification_time_exp" value="2014/12/24 23:30" />
                     </panel>
                     <panel border="false" left="0" height="115" width="230" bevel_style="none" follows="all" layout="topleft" name="notification_text_panel_exp" visible="true">

--- a/indra/newview/skins/default/xui/en/panel_people.xml
+++ b/indra/newview/skins/default/xui/en/panel_people.xml
@@ -183,6 +183,7 @@ Learn about [https://community.secondlife.com/knowledgebase/joining-and-particip
               increment="1"
               follows="left|top"
               left="5"
+              top_pad="5"
               min_val="0"
               max_val="4096"
               label="Range:"
@@ -199,13 +200,13 @@ Learn about [https://community.secondlife.com/knowledgebase/joining-and-particip
          <layout_stack
            clip="false"
            follows="all"
-           height="410"
+           height="406"
            layout="topleft"
            left="0"
            mouse_opaque="false"
            orientation="vertical"
            right="-1"
-           top_pad="0">
+           top_pad="3">
            <layout_panel
              height="142"
              layout="topleft"

--- a/indra/newview/skins/default/xui/en/panel_performance_preferences.xml
+++ b/indra/newview/skins/default/xui/en/panel_performance_preferences.xml
@@ -91,7 +91,7 @@
    layout="topleft"
    left_pad="40"
    name="fastest_lbl"
-   width="40">
+   width="42">
     Fastest
   </text>
   <radio_group
@@ -240,7 +240,7 @@
    left_pad="10"
    top_delta="1"
    name="farther_lbl"
-   width="40">
+   width="45">
     Farther
   </text>
   <text
@@ -284,7 +284,7 @@
    top_delta="0"
    left="160"
    name="enhancements_desc"
-   width="350">
+   width="375">
     Shadows significantly improve visual quality but can reduce speed.
   </text>
   <text
@@ -307,7 +307,8 @@
    left_delta="150"
    top_delta="0"
    name="ShadowDetail"
-   width="150">
+   width="153">
+    <combo_box.drop_down_button pad_right="20" />
     <combo_box.item
       label="None"
       name="0"
@@ -417,7 +418,7 @@
    top_delta="3"
    left_pad="10"
    name="photo_dist_det_desc"
-   width="180">
+   width="192">
       (Enter value between 0.0 and 4.0)
   </text>
   <text
@@ -426,7 +427,7 @@
    height="18"
    layout="topleft"
    top="80"
-   left="213"
+   left="215"
    name="0_lbl"
    width="7">
     0
@@ -446,7 +447,7 @@
    font="SansSerifSmall"
    height="18"
    layout="topleft"
-   left_pad="30"
+   left_pad="29"
    name="2_lbl"
    width="7">
     2
@@ -468,7 +469,7 @@
    layout="topleft"
    left_pad="30"
    name="4_lbl"
-   width="7">
+   width="8">
     4
   </text>
   <text
@@ -476,7 +477,7 @@
    font="SansSerifSmall"
    height="18"
    layout="topleft"
-   left_pad="30"
+   left_pad="29"
    name="5_lbl"
    width="7">
     5

--- a/indra/newview/skins/default/xui/en/panel_preferences_advanced.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_advanced.xml
@@ -13,18 +13,6 @@
      name="aspect_ratio_text">
         [NUM]:[DEN]
     </panel.string>
-  <text
-   type="string"
-   length="1"
-   follows="left|top"
-   height="12"
-   layout="topleft"
-   left="33"
-   name="Cache:"
-   top_pad="10"
-   width="100">
-    Cache:
-  </text>
   <spinner
    control_name="CacheSize"
    decimal_digits="0"
@@ -33,9 +21,9 @@
    increment="64"
    initial_value="1024"
    label="Cache size (896 - 32768MB)"
-   label_width="150"
+   label_width="159"
    layout="topleft"
-   left="80"
+   left="33"
    max_val="32768"
    min_val="896"
    top_pad="10"
@@ -72,7 +60,7 @@
    follows="left|top"
    height="10"
    layout="topleft"
-   left="80"
+   left="33"
    name="Cache location"
    top_pad="5"
    width="300">
@@ -86,7 +74,7 @@
    font="SansSerif"
    height="23"
    layout="topleft"
-   left="80"
+   left="33"
    max_length_bytes="4096"
    name="cache_location"
    top_pad="5"
@@ -113,7 +101,7 @@
     left_pad="3"
     name="default_cache_location"
     top_delta="0"
-    width="100">
+    width="104">
     <button.commit_callback
      function="Pref.ResetCache" />
   </button>

--- a/indra/newview/skins/default/xui/en/panel_preferences_general.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_general.xml
@@ -110,7 +110,8 @@
      left="255"
      max_chars="135"
      name="time_format_combobox"
-     width="70">
+     width="71">
+        <combo_box.drop_down_button pad_right="22" />
         <combo_box.item
          enabled="true"
          label="1:00 PM"
@@ -244,7 +245,7 @@
      height="20"
      layout="topleft"
      left="35"
-     top_pad="0" 
+     top_pad="5" 
      name="Name_Tag_Preference">
         <radio_item
          label="Off"
@@ -304,7 +305,7 @@
      width="100" 
      name="show_all_title_checkbox1"
 	 tool_tip="Show group titles, like Officer or Member"
-     top_pad="3" />
+     top_pad="5" />
     <check_box
      control_name="NameTagShowFriends"
 	 enabled_control="AvatarNameTagMode"
@@ -324,7 +325,7 @@
 	 name="display_names_check"
 	 width="237"
 	 tool_tip="Check to use display names in chat, IM, name tags, etc."
-	 top_pad="3"/>
+	 top_pad="5"/>
 	 
 	<text
 	 type="string"
@@ -343,7 +344,7 @@
      height="34"
      layout="topleft"
      left="35"
-     top_pad="0" 
+     top_pad="5" 
      name="inworld_typing_preference">
         <radio_item
          label="Starts local chat"

--- a/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
@@ -104,7 +104,7 @@
     layout="topleft"
     left="65"
     name="FasterText"
-    top_pad="4"
+    top_pad="10"
     width="80">
       Faster
   </text>
@@ -216,7 +216,7 @@
     min_val="64"
     max_val="512"
     name="DrawDistance"
-    top_delta="40"
+    top_delta="34"
     width="427" />
   <text
     type="string"

--- a/indra/newview/skins/default/xui/en/panel_preferences_privacy.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_privacy.xml
@@ -10,6 +10,7 @@
     top="1"
     width="517">
 
+  <!-- remove "hide_tabs" param when Discord tab is actually used -->
   <tab_container
     top_pad="0"
     enabled="true"
@@ -18,6 +19,7 @@
     width="517"
     left_delta="0"
     name="privacy_tab_container"
+    hide_tabs="true"
     tab_position="top"
     tab_stop="false">
   <panel

--- a/indra/newview/skins/default/xui/en/widgets/line_editor.xml
+++ b/indra/newview/skins/default/xui/en/widgets/line_editor.xml
@@ -11,7 +11,7 @@
 			 text_pad_left="2"
              text_readonly_color="TextFgReadOnlyColor"
              text_tentative_color="TextFgTentativeColor"
-			 highlight_color="EmphasisColor"
+			 highlight_color="SelectionColor"
 			 preedit_bg_color="White"
              mouse_opaque="true"
              name="line_editor"

--- a/indra/newview/skins/default/xui/en/widgets/simple_text_editor.xml
+++ b/indra/newview/skins/default/xui/en/widgets/simple_text_editor.xml
@@ -21,6 +21,6 @@
   bg_visible="true"
   bg_readonly_color="TextBgReadOnlyColor"
   bg_writeable_color="TextBgWriteableColor"
-  bg_selected_color="EmphasisColor"
+  bg_selected_color="SelectionColor"
   bg_focus_color="TextBgFocusColor">
 </simple_text_editor>


### PR DESCRIPTION
Mostly adjustments for UI controls but some changes are worth mentioning:

- Set default alpha to 1 for `LLTextBase` selection background. After that `LLLineEditor` and `LLTextEditor` will have the same behavior and it's finally possible to assign the same selection background color and actually to get it.
- Hide 'General' button in Preferences>Privacy as we currenly doesn't show Discord tab at all
- Use old font for notification date/time - this is the only way to avoid overlaps with sender name (the width of date time is quite significant considering AM/PM addition),