### PR TITLE
Make floater tools use Dejavu with old font size #2

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_tools.xml
+++ b/indra/newview/skins/default/xui/en/floater_tools.xml
@@ -877,8 +877,8 @@
      open_tabs_on_drag_and_drop="true"
      top="173"
      width="295"
-     font="SansSerif"
-     font.size="Monospace">
+     font="DejaVu"
+     font.size="LSmall">
 	
 <panel
 	 border="false"

--- a/indra/newview/skins/default/xui/en/panel_conversation_list_item.xml
+++ b/indra/newview/skins/default/xui/en/panel_conversation_list_item.xml
@@ -78,7 +78,7 @@
 		     left="5"
 		     name="conversation_title"
 		     parse_urls="false"
-		     top="6"
+		     top="4"
 		     use_ellipses="true"
 		     value="(loading)"
 		     width="35" />
@@ -86,6 +86,7 @@
 		     auto_update="true"
 		     follows="top|right"
 		     draw_border="false"
+		     top="6"
 		     height="16"
 		     layout="topleft"
 		     left_pad="5"


### PR DESCRIPTION
Switch floater tools' tabs to use Dejavu with old font size
Fix missed conversation item having label that is too low.