### PR TITLE
Performance optimizations to resolve long stalls

### DIFF
--- a/indra/llmessage/llcorehttputil.cpp
+++ b/indra/llmessage/llcorehttputil.cpp
@@ -37,6 +37,7 @@
 #include "llsdserialize.h"
 #include "boost/json.hpp" // Boost.Json
 #include "llfilesystem.h"
+#include "workqueue.h"
 
 #include "message.h" // for getting the port
 
@@ -295,41 +296,73 @@ void HttpCoroHandler::onCompleted(LLCore::HttpHandle handle, LLCore::HttpRespons
     }
     else
     {
-        try
+        constexpr size_t MAX_BODY_SIZE_THRESHOLD = 65536;
+        bool posted = false;
+        // Some messsages (ex: AISAPI) can return large bodies.
+        // If the body is larger than our threshold, post the
+        // parsing to the general queue to avoid stalling the
+        // main thread.
+        if (response->getBodySize() > MAX_BODY_SIZE_THRESHOLD)
         {
-            result = this->handleSuccess(response, status);
+            response->addRef();
+
+            LL::WorkQueue::ptr_t main_queue = LL::WorkQueue::getInstance("mainloop");
+            LL::WorkQueue::ptr_t general_queue = LL::WorkQueue::getInstance("General");
+            posted  = main_queue->postTo(
+                general_queue,
+                [handler = shared_from_this(), response, status]() // Work done on general queue
+                {
+                    std::pair<LLSD, LLCore::HttpStatus> result;
+                    result.second = status;
+                    try
+                    {
+                        result.first = handler->handleSuccess(response, result.second);
+                    }
+                    catch (std::bad_alloc&)
+                    {
+                        LLError::LLUserWarningMsg::showOutOfMemory();
+                        LL_ERRS("CoreHTTP") << "Failed to allocate memory for response handling (threaded)." << LL_ENDL;
+                    }
+                    // LLSD is not thread safe! Be carefull with moving the result around.
+                    return result;
+                },
+                [handler = shared_from_this(), response](std::pair<LLSD, LLCore::HttpStatus> result) mutable // Callback to main thread
+                {
+                    handler->replyPost(response, result.second, result.first);
+                    response->release();
+                });
+
+            if (posted)
+            {
+                // Thread will do the cleanup and notify the pump. Done.
+                return;
+            }
+            else
+            {
+                // For whatever reason, failed to post, clean up and
+                // do the work on the main thread.
+                response->release();
+            }
         }
-        catch (std::bad_alloc&)
+
+        if (!posted)
         {
-            LLError::LLUserWarningMsg::showOutOfMemory();
-            LL_ERRS("CoreHTTP") << "Failed to allocate memory for response handling." << LL_ENDL;
+            try
+            {
+                result = this->handleSuccess(response, status);
+            }
+            catch (std::bad_alloc&)
+            {
+                LLError::LLUserWarningMsg::showOutOfMemory();
+                LL_ERRS("CoreHTTP") << "Failed to allocate memory for response handling." << LL_ENDL;
+            }
         }
     }
 
-    buildStatusEntry(response, status, result);
-
-    if (!status)
-    {
-        LLSD &httpStatus = result[HttpCoroutineAdapter::HTTP_RESULTS];
-
-        LLCore::BufferArray *body = response->getBody();
-        LLCore::BufferArrayStream bas(body);
-        LLSD::String bodyData;
-        bodyData.reserve(response->getBodySize());
-        bas >> std::noskipws;
-        bodyData.assign(std::istream_iterator<U8>(bas), std::istream_iterator<U8>());
-        httpStatus["error_body"] = LLSD(bodyData);
-        if (getBoolSetting(HTTP_LOGBODY_KEY))
-        {
-            // commenting out, but keeping since this can be useful for debugging
-            LL_WARNS("CoreHTTP") << "Returned body=" << std::endl << httpStatus["error_body"].asString() << LL_ENDL;
-        }
-    }
-
-    mReplyPump.post(result);
+    replyPost(response, status, result);
 }
 
-void HttpCoroHandler::buildStatusEntry(LLCore::HttpResponse *response, LLCore::HttpStatus status, LLSD &result)
+void HttpCoroHandler::buildStatusEntry(LLCore::HttpResponse *response, LLCore::HttpStatus status, LLSD &result) const
 {
     LLSD httpresults = LLSD::emptyMap();
 
@@ -355,6 +388,31 @@ void HttpCoroHandler::buildStatusEntry(LLCore::HttpResponse *response, LLCore::H
 
     httpresults[HttpCoroutineAdapter::HTTP_RESULTS_HEADERS] = httpHeaders;
     result[HttpCoroutineAdapter::HTTP_RESULTS] = httpresults;
+}
+
+void HttpCoroHandler::replyPost(LLCore::HttpResponse* response, LLCore::HttpStatus &status, LLSD& result)
+{
+    buildStatusEntry(response, status, result);
+
+    if (!status)
+    {
+        LLSD& httpStatus = result[HttpCoroutineAdapter::HTTP_RESULTS];
+
+        LLCore::BufferArray* body = response->getBody();
+        LLCore::BufferArrayStream bas(body);
+        LLSD::String bodyData;
+        bodyData.reserve(response->getBodySize());
+        bas >> std::noskipws;
+        bodyData.assign(std::istream_iterator<U8>(bas), std::istream_iterator<U8>());
+        httpStatus["error_body"] = LLSD(bodyData);
+        if (getBoolSetting(HTTP_LOGBODY_KEY))
+        {
+            // commenting out, but keeping since this can be useful for debugging
+            LL_WARNS("CoreHTTP") << "Returned body=" << std::endl << httpStatus["error_body"].asString() << LL_ENDL;
+        }
+    }
+
+    mReplyPump.post(result);
 }
 
 void HttpCoroHandler::writeStatusCodes(LLCore::HttpStatus status, const std::string &url, LLSD &result)
@@ -389,8 +447,8 @@ public:
     HttpCoroLLSDHandler(LLEventStream &reply);
 
 protected:
-    virtual LLSD handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status);
-    virtual LLSD parseBody(LLCore::HttpResponse *response, bool &success);
+    virtual LLSD handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status) const;
+    virtual LLSD parseBody(LLCore::HttpResponse *response, bool &success) const;
 };
 
 //-------------------------------------------------------------------------
@@ -400,7 +458,7 @@ HttpCoroLLSDHandler::HttpCoroLLSDHandler(LLEventStream &reply):
 }
 
 
-LLSD HttpCoroLLSDHandler::handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status)
+LLSD HttpCoroLLSDHandler::handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status) const
 {
     LLSD result;
 
@@ -465,7 +523,7 @@ LLSD HttpCoroLLSDHandler::handleSuccess(LLCore::HttpResponse * response, LLCore:
     return result;
 }
 
-LLSD HttpCoroLLSDHandler::parseBody(LLCore::HttpResponse *response, bool &success)
+LLSD HttpCoroLLSDHandler::parseBody(LLCore::HttpResponse *response, bool &success) const
 {
     success = true;
     if (response->getBodySize() == 0)
@@ -496,8 +554,8 @@ class HttpCoroRawHandler : public HttpCoroHandler
 public:
     HttpCoroRawHandler(LLEventStream &reply);
 
-    virtual LLSD handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status);
-    virtual LLSD parseBody(LLCore::HttpResponse *response, bool &success);
+    virtual LLSD handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status) const;
+    virtual LLSD parseBody(LLCore::HttpResponse *response, bool &success) const;
 };
 
 //-------------------------------------------------------------------------
@@ -506,7 +564,7 @@ HttpCoroRawHandler::HttpCoroRawHandler(LLEventStream &reply):
 {
 }
 
-LLSD HttpCoroRawHandler::handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status)
+LLSD HttpCoroRawHandler::handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status) const
 {
     LLSD result = LLSD::emptyMap();
 
@@ -552,7 +610,7 @@ LLSD HttpCoroRawHandler::handleSuccess(LLCore::HttpResponse * response, LLCore::
     return result;
 }
 
-LLSD HttpCoroRawHandler::parseBody(LLCore::HttpResponse *response, bool &success)
+LLSD HttpCoroRawHandler::parseBody(LLCore::HttpResponse *response, bool &success) const
 {
     success = true;
     return LLSD();
@@ -571,8 +629,8 @@ class HttpCoroJSONHandler : public HttpCoroHandler
 public:
     HttpCoroJSONHandler(LLEventStream &reply);
 
-    virtual LLSD handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status);
-    virtual LLSD parseBody(LLCore::HttpResponse *response, bool &success);
+    virtual LLSD handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status) const;
+    virtual LLSD parseBody(LLCore::HttpResponse *response, bool &success) const;
 };
 
 //-------------------------------------------------------------------------
@@ -581,7 +639,7 @@ HttpCoroJSONHandler::HttpCoroJSONHandler(LLEventStream &reply) :
 {
 }
 
-LLSD HttpCoroJSONHandler::handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status)
+LLSD HttpCoroJSONHandler::handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status) const
 {
     LLSD result = LLSD::emptyMap();
 
@@ -607,7 +665,7 @@ LLSD HttpCoroJSONHandler::handleSuccess(LLCore::HttpResponse * response, LLCore:
     return result;
 }
 
-LLSD HttpCoroJSONHandler::parseBody(LLCore::HttpResponse *response, bool &success)
+LLSD HttpCoroJSONHandler::parseBody(LLCore::HttpResponse *response, bool &success) const
 {
     success = true;
     BufferArray * body(response->getBody());

--- a/indra/llmessage/llcorehttputil.h
+++ b/indra/llmessage/llcorehttputil.h
@@ -259,7 +259,7 @@ inline LLCore::HttpHandle requestPatchWithLLSD(LLCore::HttpRequest::ptr_t & requ
 ///                      +- ["url"]     - The URL used to make the call.
 ///                      +- ["headers"] - A map of name name value pairs with the HTTP headers.
 ///
-class HttpCoroHandler : public LLCore::HttpHandler
+class HttpCoroHandler : public LLCore::HttpHandler, public std::enable_shared_from_this<HttpCoroHandler>
 {
 public:
 
@@ -279,11 +279,12 @@ public:
 
 protected:
     /// this method may modify the status value
-    virtual LLSD handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status) = 0;
-    virtual LLSD parseBody(LLCore::HttpResponse *response, bool &success) = 0;
+    virtual LLSD handleSuccess(LLCore::HttpResponse * response, LLCore::HttpStatus &status) const = 0;
+    virtual LLSD parseBody(LLCore::HttpResponse *response, bool &success) const = 0;
 
 private:
-    void buildStatusEntry(LLCore::HttpResponse *response, LLCore::HttpStatus status, LLSD &result);
+    void buildStatusEntry(LLCore::HttpResponse *response, LLCore::HttpStatus status, LLSD &result) const;
+    void replyPost(LLCore::HttpResponse* response, LLCore::HttpStatus& status, LLSD& result);
 
     LLEventStream &mReplyPump;
 };

--- a/indra/newview/lltexturecache.cpp
+++ b/indra/newview/lltexturecache.cpp
@@ -875,7 +875,7 @@ std::string LLTextureCache::getTextureFileName(const LLUUID& id)
 //debug
 bool LLTextureCache::isInCache(const LLUUID& id)
 {
-    LLMutexLock lock(&mHeaderMutex);
+    LLMutexLock lock(&mHeaderIDMapMutex);
     id_map_t::const_iterator iter = mHeaderIDMap.find(id);
 
     return (iter != mHeaderIDMap.end()) ;
@@ -1117,10 +1117,13 @@ S32 LLTextureCache::openAndReadEntry(const LLUUID& id, Entry& entry, bool create
 {
     S32 idx = -1;
 
-    id_map_t::iterator iter1 = mHeaderIDMap.find(id);
-    if (iter1 != mHeaderIDMap.end())
     {
-        idx = iter1->second;
+        LLMutexLock lock(&mHeaderIDMapMutex);
+        id_map_t::iterator iter1 = mHeaderIDMap.find(id);
+        if (iter1 != mHeaderIDMap.end())
+        {
+            idx = iter1->second;
+        }
     }
 
     if (idx < 0)
@@ -1148,10 +1151,19 @@ S32 LLTextureCache::openAndReadEntry(const LLUUID& id, Entry& entry, bool create
                     // Erase entry from LRU regardless
                     mLRU.erase(curiter2);
                     // Look up entry and use it if it is valid
-                    id_map_t::iterator iter3 = mHeaderIDMap.find(oldid);
-                    if (iter3 != mHeaderIDMap.end() && iter3->second >= 0)
+
+                    S32 found_idx = -1;
                     {
-                        idx = iter3->second;
+                        LLMutexLock lock(&mHeaderIDMapMutex);
+                        id_map_t::iterator iter3 = mHeaderIDMap.find(oldid);
+                        if (iter3 != mHeaderIDMap.end() && iter3->second >= 0)
+                        {
+                            found_idx = iter3->second;
+                        }
+                    }
+                    if (found_idx >= 0)
+                    {
+                        idx = found_idx;
                         removeCachedTexture(oldid) ;//remove the existing cached texture to release the entry index.
                         break;
                     }
@@ -1287,7 +1299,10 @@ bool LLTextureCache::updateEntry(S32& idx, Entry& entry, S32 new_image_size, S32
         bool update_header = false ;
         if(entry.mImageSize < 0) //is a brand-new entry
         {
-            mHeaderIDMap[entry.mID] = idx;
+            {
+                LLMutexLock lock(&mHeaderIDMapMutex);
+                mHeaderIDMap[entry.mID] = idx;
+            }
             mTexturesSizeMap[entry.mID] = new_body_size ;
             mTexturesSizeTotal += new_body_size ;
 
@@ -1325,8 +1340,8 @@ bool LLTextureCache::updateEntry(S32& idx, Entry& entry, S32 new_image_size, S32
 
 U32 LLTextureCache::openAndReadEntries(std::vector<Entry>& entries)
 {
+    LLMutexLock lock(&mHeaderIDMapMutex);
     U32 num_entries = mHeaderEntriesInfo.mEntries;
-
     mHeaderIDMap.clear();
     mTexturesSizeMap.clear();
     mFreeList.clear();
@@ -1620,7 +1635,10 @@ void LLTextureCache::purgeAllTextures(bool purge_directories)
             LLFile::rmdir(mTexturesDirName);
         }
     }
-    mHeaderIDMap.clear();
+    {
+        LLMutexLock lock(&mHeaderIDMapMutex);
+        mHeaderIDMap.clear();
+    }
     mTexturesSizeMap.clear();
     mTexturesSizeTotal = 0;
     mFreeList.clear();
@@ -1667,6 +1685,7 @@ void LLTextureCache::purgeTexturesLazy(F32 time_limit_sec)
         {
             if (iter1->second > 0)
             {
+                LLMutexLock lock(&mHeaderIDMapMutex);
                 id_map_t::iterator iter2 = mHeaderIDMap.find(iter1->first);
                 if (iter2 != mHeaderIDMap.end())
                 {
@@ -1708,8 +1727,13 @@ void LLTextureCache::purgeTexturesLazy(F32 time_limit_sec)
             Entry entry = mPurgeEntryList.back().second;
             mPurgeEntryList.pop_back();
             // make sure record is still valid
-            id_map_t::iterator iter_header = mHeaderIDMap.find(entry.mID);
-            if (iter_header != mHeaderIDMap.end() && iter_header->second == idx)
+            bool remove_entry = false;
+            {
+                LLMutexLock lock(&mHeaderIDMapMutex);
+                id_map_t::iterator iter_header = mHeaderIDMap.find(entry.mID);
+                remove_entry = (iter_header != mHeaderIDMap.end() && iter_header->second == idx);
+            }
+            if (remove_entry)
             {
                 std::string tex_filename = getTextureFileName(entry.mID);
                 removeEntry(idx, entry, tex_filename);
@@ -1752,6 +1776,7 @@ void LLTextureCache::purgeTextures(bool validate)
     {
         if (iter1->second > 0)
         {
+            LLMutexLock lock(&mHeaderIDMapMutex);
             id_map_t::iterator iter2 = mHeaderIDMap.find(iter1->first);
             if (iter2 != mHeaderIDMap.end())
             {
@@ -2006,7 +2031,7 @@ LLPointer<LLImageRaw> LLTextureCache::readFromFastCache(const LLUUID& id, S32& d
 {
     U32 offset;
     {
-        LLMutexLock lock(&mHeaderMutex);
+        LLMutexLock lock(&mHeaderIDMapMutex);
         id_map_t::const_iterator iter = mHeaderIDMap.find(id);
         if(iter == mHeaderIDMap.end())
         {
@@ -2020,6 +2045,7 @@ LLPointer<LLImageRaw> LLTextureCache::readFromFastCache(const LLUUID& id, S32& d
     U8* data;
     S32 head[4];
     {
+        LL_PROFILE_ZONE_NAMED("Read fast cache");
         LLMutexLock lock(&mFastCacheMutex);
 
         openFastCache();
@@ -2231,7 +2257,10 @@ void LLTextureCache::removeCachedTexture(const LLUUID& id)
         mTexturesSizeTotal -= mTexturesSizeMap[id] ;
         mTexturesSizeMap.erase(id);
     }
-    mHeaderIDMap.erase(id);
+    {
+        LLMutexLock lock(&mHeaderIDMapMutex);
+        mHeaderIDMap.erase(id);
+    }
     // We are inside header's mutex so mHeaderAPRFilePoolp is safe to use,
     // but getLocalAPRFilePool() is not safe, it might be in use by worker
     LLAPRFile::remove(getTextureFileName(id), mHeaderAPRFilePoolp);
@@ -2262,7 +2291,10 @@ void LLTextureCache::removeEntry(S32 idx, Entry& entry, std::string& filename)
 
         entry.mImageSize = -1;
         entry.mBodySize = 0;
-        mHeaderIDMap.erase(entry.mID);
+        {
+            LLMutexLock lock(&mHeaderIDMapMutex);
+            mHeaderIDMap.erase(entry.mID);
+        }
         mTexturesSizeMap.erase(entry.mID);
         mFreeList.insert(idx);
     }

--- a/indra/newview/lltexturecache.h
+++ b/indra/newview/lltexturecache.h
@@ -194,6 +194,7 @@ private:
     // Internal
     LLMutex mWorkersMutex;
     LLMutex mHeaderMutex;
+    LLMutex mHeaderIDMapMutex;
     LLMutex mListMutex;
     LLMutex mFastCacheMutex;
     LLAPRFile* mHeaderAPRFile;


### PR DESCRIPTION
1. Inventory was parsing a large message for over a second, moved that to a thread worker.
2. Fast cache was locked from accessing id map by texture thread on a general cache mutex. Added map specific mutex. 