### PR TITLE
#5376 fix snapshot size not being updated when clicking 'Save to disk'

### DIFF
--- a/indra/newview/llfloatersnapshot.cpp
+++ b/indra/newview/llfloatersnapshot.cpp
@@ -1043,7 +1043,7 @@ bool LLFloaterSnapshot::postBuild()
     getChild<LLComboBox>("profile_size_combo")->selectNthItem(0);
     getChild<LLComboBox>("postcard_size_combo")->selectNthItem(0);
     getChild<LLComboBox>("texture_size_combo")->selectNthItem(0);
-    getChild<LLComboBox>("local_size_combo")->selectNthItem(8);
+    getChild<LLComboBox>("local_size_combo")->selectNthItem(0);
     getChild<LLComboBox>("local_format_combo")->selectNthItem(0);
 
     impl->mPreviewHandle = previewp->getHandle();


### PR DESCRIPTION
Wrong selection prevented from updating snapshot size after clicking 'Save to disk'.