### PR TITLE
#5405 Stalls on LLFileSystem::getExists

### DIFF
--- a/indra/llaudio/llaudioengine.cpp
+++ b/indra/llaudio/llaudioengine.cpp
@@ -225,6 +225,7 @@ void LLAudioEngine::updateChannels()
 
 void LLAudioEngine::idle()
 {
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_MEDIA;
     // "Update" all of our audio sources, clean up dead ones.
     // Primarily does position updating, cleanup of unused audio sources.
     // Also does regeneration of the current priority of each audio source.

--- a/indra/llfilesystem/llfilesystem.cpp
+++ b/indra/llfilesystem/llfilesystem.cpp
@@ -77,11 +77,10 @@ bool LLFileSystem::getExists(const LLUUID& file_id, const LLAssetType::EType fil
     LL_PROFILE_ZONE_SCOPED;
     const std::string filename = LLDiskCache::metaDataToFilepath(file_id, file_type);
 
-    llifstream file(filename, std::ios::binary);
-    if (file.is_open())
+    boost::system::error_code ec;
+    if (boost::filesystem::exists(filename, ec) && boost::filesystem::is_regular_file(filename, ec))
     {
-        file.seekg(0, std::ios::end);
-        return file.tellg() > 0;
+        return boost::filesystem::file_size(filename, ec) > 0;
     }
     return false;
 }
@@ -120,15 +119,12 @@ S32 LLFileSystem::getFileSize(const LLUUID& file_id, const LLAssetType::EType fi
 {
     const std::string filename = LLDiskCache::metaDataToFilepath(file_id, file_type);
 
-    S32 file_size = 0;
-    llifstream file(filename, std::ios::binary);
-    if (file.is_open())
+    boost::system::error_code ec;
+    if (boost::filesystem::exists(filename, ec) && boost::filesystem::is_regular_file(filename, ec))
     {
-        file.seekg(0, std::ios::end);
-        file_size = (S32)file.tellg();
+        return static_cast<S32>(boost::filesystem::file_size(filename, ec));
     }
-
-    return file_size;
+    return 0;
 }
 
 bool LLFileSystem::read(U8* buffer, S32 bytes)

--- a/indra/newview/llviewerwearable.cpp
+++ b/indra/newview/llviewerwearable.cpp
@@ -96,6 +96,7 @@ LLViewerWearable::~LLViewerWearable()
 // virtual
 LLWearable::EImportResult LLViewerWearable::importStream( std::istream& input_stream, LLAvatarAppearance* avatarp )
 {
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_AVATAR;
     // suppress texlayerset updates while wearables are being imported. Layersets will be updated
     // when the wearables are "worn", not loaded. Note state will be restored when this object is destroyed.
     LLOverrideBakedTextureUpdate stop_bakes(false);


### PR DESCRIPTION
Getting info from a file descriptor is far faster than trying to read and seek a file.