### PR TITLE
FIX - pre-jump and land animations being shortcircuited by race conditions with AGENT_CONTROL_FINISH_ANIM when chaining jumps

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -489,6 +489,17 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>RecentJumpThresholdSecs</key>
+    <map>
+      <key>Comment</key>
+      <string>Seconds after a jump input during which finish-anim is suppressed to avoid interrupting rapid successive jumps.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>1.0</real>
+    </map>
     <key>AvatarAxisDeadZone0</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -425,6 +425,8 @@ LLAgent::LLAgent() :
 
     mIsDoNotDisturb(false),
 
+    mLastJumpRequestTime(0.0),
+
     mControlFlags(0x00000000),
 
     mAutoPilot(false),
@@ -677,6 +679,10 @@ void LLAgent::moveAt(S32 direction, bool reset)
 
     if (direction > 0)
     {
+        if (!getFlying())
+        {
+            mLastJumpRequestTime = LLTimer::getTotalSeconds();
+        }
         setControlFlags(AGENT_CONTROL_AT_POS | AGENT_CONTROL_FAST_AT);
     }
     else if (direction < 0)
@@ -2663,7 +2669,19 @@ void LLAgent::onAnimStop(const LLUUID& id)
     }
     else if (id == ANIM_AGENT_PRE_JUMP || id == ANIM_AGENT_LAND || id == ANIM_AGENT_MEDIUM_LAND)
     {
-        setControlFlags(AGENT_CONTROL_FINISH_ANIM);
+        // If the jump key is currently held, avoid forcing a finish-anim that can
+        // short-circuit the next pre-jump in cases of rapid successive jumps.
+        // Bug amplified since v7 viewers or so, likely caused by https://github.com/FirestormViewer/phoenix-firestorm/commit/da87e8bd370ea079576f8b412a4ddb80c0715bd1
+        // TODO: the real fix would be to discern which anim the viewer finished, but this requires simulator fixes.
+        const bool up_pos = (mControlFlags & AGENT_CONTROL_UP_POS) != 0;
+        const F64 now = LLTimer::getTotalSeconds();
+        const F64 elapsed = now - mLastJumpRequestTime;
+        const bool recent_jump = (mLastJumpRequestTime > 0.0) && (elapsed < 1.0);
+
+        if (!up_pos && !recent_jump)
+        {
+            setControlFlags(AGENT_CONTROL_FINISH_ANIM);
+        }
     }
 }
 

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -115,6 +115,7 @@ const F32 AUTOPILOT_MAX_TIME_NO_PROGRESS_FLY = 2.5f;        // seconds. Flying i
 
 const F32 MAX_VELOCITY_AUTO_LAND_SQUARED = 4.f * 4.f;
 const F64 CHAT_AGE_FAST_RATE = 3.0;
+const F64 RECENT_JUMP_THRESHOLD_SECS = 1.0; // seconds
 
 // fidget constants
 const F32 MIN_FIDGET_TIME = 8.f; // seconds
@@ -425,9 +426,8 @@ LLAgent::LLAgent() :
 
     mIsDoNotDisturb(false),
 
-    mLastJumpRequestTime(0.0),
-
     mControlFlags(0x00000000),
+    mLastJumpRequestTime(0.0),
 
     mAutoPilot(false),
     mAutoPilotFlyOnStop(false),
@@ -679,10 +679,6 @@ void LLAgent::moveAt(S32 direction, bool reset)
 
     if (direction > 0)
     {
-        if (!getFlying())
-        {
-            mLastJumpRequestTime = LLTimer::getTotalSeconds();
-        }
         setControlFlags(AGENT_CONTROL_AT_POS | AGENT_CONTROL_FAST_AT);
     }
     else if (direction < 0)
@@ -786,6 +782,10 @@ void LLAgent::moveUp(S32 direction)
 
     if (direction > 0)
     {
+        if (!getFlying())
+        {
+            mLastJumpRequestTime = LLTimer::getTotalSeconds();
+        }
         setControlFlags(AGENT_CONTROL_UP_POS | AGENT_CONTROL_FAST_UP);
     }
     else if (direction < 0)
@@ -2676,7 +2676,7 @@ void LLAgent::onAnimStop(const LLUUID& id)
         const bool up_pos = (mControlFlags & AGENT_CONTROL_UP_POS) != 0;
         const F64 now = LLTimer::getTotalSeconds();
         const F64 elapsed = now - mLastJumpRequestTime;
-        const bool recent_jump = (mLastJumpRequestTime > 0.0) && (elapsed < 1.0);
+        const bool recent_jump = (mLastJumpRequestTime > 0.0) && (elapsed < RECENT_JUMP_THRESHOLD_SECS);
 
         if (!up_pos && !recent_jump)
         {

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -115,7 +115,6 @@ const F32 AUTOPILOT_MAX_TIME_NO_PROGRESS_FLY = 2.5f;        // seconds. Flying i
 
 const F32 MAX_VELOCITY_AUTO_LAND_SQUARED = 4.f * 4.f;
 const F64 CHAT_AGE_FAST_RATE = 3.0;
-const F64 RECENT_JUMP_THRESHOLD_SECS = 1.0; // seconds
 
 // fidget constants
 const F32 MIN_FIDGET_TIME = 8.f; // seconds
@@ -427,7 +426,7 @@ LLAgent::LLAgent() :
     mIsDoNotDisturb(false),
 
     mControlFlags(0x00000000),
-    mLastJumpRequestTime(0.0),
+    mLastJumpInputTime(0.0),
 
     mAutoPilot(false),
     mAutoPilotFlyOnStop(false),
@@ -2669,14 +2668,16 @@ void LLAgent::onAnimStop(const LLUUID& id)
     }
     else if (id == ANIM_AGENT_PRE_JUMP || id == ANIM_AGENT_LAND || id == ANIM_AGENT_MEDIUM_LAND)
     {
-        // If the jump key is currently held, avoid forcing a finish-anim that can
-        // short-circuit the next pre-jump in cases of rapid successive jumps.
-        // Bug amplified since v7 viewers or so, likely caused by https://github.com/FirestormViewer/phoenix-firestorm/commit/da87e8bd370ea079576f8b412a4ddb80c0715bd1
-        // TODO: the real fix would be to discern which anim the viewer finished, but this requires simulator fixes.
+        // FIRE-34049/FIRE-34273/https://github.com/secondlife/viewer/issues/4218
+        // Avoid forcing AGENT_CONTROL_FINISH_ANIM, which can short-circuit the next pre-jump
+        // during rapid successive jumps.
+        // TODO: a more robust fix would require knowing which specific animation finished,
+        // information that is not currently provided by the simulator.
         const bool up_pos = (mControlFlags & AGENT_CONTROL_UP_POS) != 0;
         const F64 now = LLTimer::getTotalSeconds();
-        const F64 elapsed = now - mLastJumpRequestTime;
-        const bool recent_jump = (mLastJumpRequestTime > 0.0) && (elapsed < RECENT_JUMP_THRESHOLD_SECS);
+        const F64 elapsed = now - mLastJumpInputTime;
+        static LLCachedControl<F32> recent_jump_threshold_secs(gSavedSettings, "RecentJumpThresholdSecs");
+        const bool recent_jump = (mLastJumpInputTime > 0.0) && (elapsed < recent_jump_threshold_secs);
 
         if (!up_pos && !recent_jump)
         {

--- a/indra/newview/llagent.h
+++ b/indra/newview/llagent.h
@@ -487,6 +487,7 @@ private:
     S32             mControlsTakenCount[TOTAL_CONTROLS];
     S32             mControlsTakenPassedOnCount[TOTAL_CONTROLS];
     U32             mControlFlags;                  // Replacement for the mFooKey's
+    F64             mLastJumpRequestTime;
 
     //--------------------------------------------------------------------
     // Animations

--- a/indra/newview/llagent.h
+++ b/indra/newview/llagent.h
@@ -487,7 +487,7 @@ private:
     S32             mControlsTakenCount[TOTAL_CONTROLS];
     S32             mControlsTakenPassedOnCount[TOTAL_CONTROLS];
     U32             mControlFlags;                  // Replacement for the mFooKey's
-    F64             mLastJumpRequestTime;           // Time of last jump request in seconds from LLTimer::getTotalSeconds()
+    F64             mLastJumpInputTime;             // Time of last jump input (key-down) in seconds from LLTimer::getTotalSeconds()
 
     //--------------------------------------------------------------------
     // Animations

--- a/indra/newview/llagent.h
+++ b/indra/newview/llagent.h
@@ -487,7 +487,7 @@ private:
     S32             mControlsTakenCount[TOTAL_CONTROLS];
     S32             mControlsTakenPassedOnCount[TOTAL_CONTROLS];
     U32             mControlFlags;                  // Replacement for the mFooKey's
-    F64             mLastJumpRequestTime;
+    F64             mLastJumpRequestTime;           // Time of last jump request in seconds from LLTimer::getTotalSeconds()
 
     //--------------------------------------------------------------------
     // Animations


### PR DESCRIPTION
fixes [FIRE-34049](https://jira.firestormviewer.org/browse/FIRE-34049)
fixes [FIRE-34273](https://jira.firestormviewer.org/browse/FIRE-34273)
fixes [this canny](https://feedback.secondlife.com/bug-reports/p/disable-waiting-for-pre-jump-and-landing-setting-not-working)
related to https://github.com/secondlife/viewer/issues/4218 LL viewer issue
.. and likely more tickets I have not unearthed.

## Bug Repro
This bug is easy and difficult to reproduce at the same time. It's not only about the accidental quick jump. Depending on your animation length, your AO, your ping, your lag, etc. you will send AGENT_CONTROL_FINISH_ANIM flags while mid-landing animation or mid-prejumps. This effectively cancels some animation states early when the simulator has moved you to the next state (from landing to prejump, etc.). Even if you don't trigger a quick jump, you can see that by holding jump in place, on current release of most v7 viewers, the pre-jump and landing animations get cutoff at times.. or most of the time for some.

## Expected Behavior
Animation states should play in full length, preventing early cancels and potential quickjumps when chaining jumps

## Fix implementation notes
Please note that this fix doesn't impact the other technique known as "super jump" where jumping from an elevation change causes an abnormal amount of vertical velocity.
The settings to disable pre-jump animations still works as before.
Ideally, someone at the Lab would work on the simulator code to change how control flags work so the viewer can indicate which animation state it is done with.. In the meantime, viewers can mitigate this ambiguity by holding back on sending AGENT_CONTROL_FINISH_ANIM when actively jumping. The sim should maintain authority of the jump timings for controls to remain consistent.
The fix is done by not sending the flag while in a jumping sequence. I've tested myself with a decent North American ping (70ms) and I can notice huge improvements with all AOs I own, even without an AO. Jumping and landing looks proper and is much more consistent, we regain a lot of visual fidelity with this fix. A friend from EU also tried this patch with success. I've yet to find any side-effect to this. Considering how important it is to parts of the community, I would at least suggest a settings toggle for this fixes, if some side-effects are found when implemented.
As per my comment on canny, I believe the issue has been amplified by PBR viewer increasing lag/input delay at the time of release as well as [this](https://github.com/FirestormViewer/phoenix-firestorm/commit/da87e8bd370ea079576f8b412a4ddb80c0715bd1) change to control flags handling.