### PR TITLE
FIX - PBR materials with alpha mode BLEND and alpha value of 0 are not highlighted

### DIFF
--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -5983,7 +5983,7 @@ void LLVolumeGeometryManager::rebuildGeom(LLSpatialGroup* group)
                                     bool should_render = true;
                                     if (gltf_mat->mAlphaMode == LLGLTFMaterial::ALPHA_MODE_BLEND)
                                     {
-                                        if (gltf_mat->mBaseColor.mV[3] == 0.0f)
+                                        if (gltf_mat->mBaseColor.mV[3] == 0.0f && !LLDrawPoolAlpha::sShowDebugAlpha)
                                         {
                                             should_render = false;
                                         }


### PR DESCRIPTION
I did not find a canny specifically referencing this problem.

## Bug
When highlighting transparency (CTRL+ALT+T), any object with a PBR material with alpha mode BLEND and an alpha of 0 will fail to be highlighted. 

## Reproduction
You can repro this bug by building a prim, inserting a blank PBR material, setting its alpha to BLEND mode and 0, then turning on highlight transparency. See how it doesn't highlight.

## Fix
Don't skip rendering PBR with Alpha blend of 0 when DebugAlpha mode is enabled.


Side note: While fixing this, I noticed if you have a PBR material with alpha mode BLEND or MASK and the alpha is 1.0, that object is still highlighted. If this isn't intentional, I'll follow up with another fix.