### PR TITLE
Preserve reflection probe alpha for the sky, and add new "Reflection Quality" setting.

### DIFF
--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -1394,6 +1394,7 @@ void LLShaderMgr::initAttribsAndUniforms()
     mReservedUniforms.push_back("modelview_delta");
     mReservedUniforms.push_back("inv_modelview_delta");
     mReservedUniforms.push_back("cube_snapshot");
+    mReservedUniforms.push_back("default_probe_render");
 
     mReservedUniforms.push_back("tc_scale");
     mReservedUniforms.push_back("rcp_screen_res");

--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -1395,6 +1395,7 @@ void LLShaderMgr::initAttribsAndUniforms()
     mReservedUniforms.push_back("inv_modelview_delta");
     mReservedUniforms.push_back("cube_snapshot");
     mReservedUniforms.push_back("default_probe_render");
+    mReservedUniforms.push_back("reflection_probe_quality");
 
     mReservedUniforms.push_back("tc_scale");
     mReservedUniforms.push_back("rcp_screen_res");

--- a/indra/llrender/llshadermgr.h
+++ b/indra/llrender/llshadermgr.h
@@ -197,6 +197,7 @@ public:
         MODELVIEW_DELTA_MATRIX,             //  "modelview_delta"
         INVERSE_MODELVIEW_DELTA_MATRIX,     //  "inv_modelview_delta"
         CUBE_SNAPSHOT,                      //  "cube_snapshot"
+        DEFAULT_PROBE_RENDER,               //  "default_probe_render"
 
         FXAA_TC_SCALE,                      //  "tc_scale"
         FXAA_RCP_SCREEN_RES,                //  "rcp_screen_res"

--- a/indra/llrender/llshadermgr.h
+++ b/indra/llrender/llshadermgr.h
@@ -198,6 +198,7 @@ public:
         INVERSE_MODELVIEW_DELTA_MATRIX,     //  "inv_modelview_delta"
         CUBE_SNAPSHOT,                      //  "cube_snapshot"
         DEFAULT_PROBE_RENDER,               //  "default_probe_render"
+        REFLECTION_PROBE_QUALITY,           //  "reflection_probe_quality"
 
         FXAA_TC_SCALE,                      //  "tc_scale"
         FXAA_RCP_SCREEN_RES,                //  "rcp_screen_res"

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9302,6 +9302,17 @@
     <key>Value</key>
     <integer>1</integer>
   </map>
+    <key>RenderReflectionProbeQuality</key>
+    <map>
+        <key>Comment</key>
+        <string>Quality of reflection probe rendering. (0 - Low quality RGB only, 1 - Medium quality with alpha preservation for sky blending)</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>S32</string>
+        <key>Value</key>
+        <integer>1</integer>
+    </map>
     <key>RenderReflectionProbeDynamicAllocation</key>
     <map>
         <key>Comment</key>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9389,7 +9389,7 @@
     <key>Type</key>
     <string>F32</string>
     <key>Value</key>
-    <real>2.0</real>
+    <real>0.5</real>
   </map>
   <key>RenderReflectionProbeLevel</key>
   <map>

--- a/indra/newview/app_settings/shaders/class1/interface/gaussianF.glsl
+++ b/indra/newview/app_settings/shaders/class1/interface/gaussianF.glsl
@@ -39,15 +39,15 @@ float linearDepth(float d, float znear, float zfar);
 
 void main()
 {
-    vec3 col = vec3(0,0,0);
+    vec4 col = vec4(0,0,0,0);
 
     float w[9] = float[9]( 0.0002, 0.0060, 0.0606, 0.2417, 0.3829, 0.2417, 0.0606, 0.0060, 0.0002 );
 
     for (int i = 0; i < 9; ++i)
     {
         vec2 tc = vary_texcoord0 + (i-4)*direction*resScale;
-        col += texture(diffuseRect, tc).rgb * w[i];
+        col += texture(diffuseRect, tc) * w[i];
     }
 
-    frag_color = max(vec4(col, 0.0), vec4(0));
+    frag_color = max(col, vec4(0));
 }

--- a/indra/newview/app_settings/shaders/class1/interface/reflectionmipF.glsl
+++ b/indra/newview/app_settings/shaders/class1/interface/reflectionmipF.glsl
@@ -31,6 +31,6 @@ in vec2 vary_texcoord0;
 
 void main()
 {
-    vec3 col = texture(diffuseRect, vary_texcoord0.xy).rgb;
-    frag_color = vec4(col, 0.0);
+    vec4 col = texture(diffuseRect, vary_texcoord0.xy);
+    frag_color = col;
 }

--- a/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
@@ -498,7 +498,7 @@ float sphereWeight(vec3 pos, vec3 dir, vec3 origin, float r, vec4 i, out float d
 // c - center of probe
 // r2 - radius of probe squared
 // i - index of probe
-vec3 tapRefMap(vec3 pos, vec3 dir, out float w, out float dw, float lod, vec3 c, int i)
+vec4 tapRefMap(vec3 pos, vec3 dir, out float w, out float dw, float lod, vec3 c, int i)
 {
     // parallax adjustment
     vec3 v;
@@ -528,9 +528,10 @@ vec3 tapRefMap(vec3 pos, vec3 dir, out float w, out float dw, float lod, vec3 c,
 
     v = env_mat * v;
 
-    vec4 ret = textureLod(reflectionProbes, vec4(v.xyz, refIndex[i].x), lod) * refParams[i].y;
+    vec4 probeSample = textureLod(reflectionProbes, vec4(v.xyz, refIndex[i].x), lod);
+    probeSample.rgb *= refParams[i].y;
 
-    return ret.rgb;
+    return vec4(probeSample.rgb, probeSample.a);
 }
 
 // Tap an irradiance map
@@ -575,6 +576,11 @@ vec3 tapIrradianceMap(vec3 pos, vec3 dir, out float w, out float dw, vec3 c, int
 
 vec3 sampleProbes(vec3 pos, vec3 dir, float lod)
 {
+    // Sample void probe ONCE using original direction
+    vec3 voidDir = env_mat * dir;
+    vec4 voidSample = textureLod(reflectionProbes, vec4(voidDir, 0), lod);
+    vec3 voidColor = voidSample.rgb * refParams[0].y;
+
     float wsum[2];
     wsum[0] = 0;
     wsum[1] = 0;
@@ -599,12 +605,15 @@ vec3 sampleProbes(vec3 pos, vec3 dir, float lod)
 
         float w = 0;
         float dw = 0;
-        vec3 refcol;
+        vec4 refcol;
 
         {
             refcol = tapRefMap(pos, dir, w, dw, lod, refSphere[i].xyz, i);
 
-            col[p] += refcol.rgb*w;
+            // Blend with void probe based on alpha: alpha=0 (geometry) uses probe, alpha=1 (sky) uses void
+            vec3 blended = mix(refcol.rgb, voidColor, refcol.a);
+
+            col[p] += blended*w;
             wsum[p] += w;
             dwsum[p] += dw;
         }

--- a/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
@@ -576,10 +576,12 @@ vec3 tapIrradianceMap(vec3 pos, vec3 dir, out float w, out float dw, vec3 c, int
 
 vec3 sampleProbes(vec3 pos, vec3 dir, float lod)
 {
-    // Sample void probe ONCE using original direction
+#ifdef REFLECTION_PROBE_MED_QUALITY
+    // Sample void probe ONCE using original direction (medium quality mode and above)
     vec3 voidDir = env_mat * dir;
     vec4 voidSample = textureLod(reflectionProbes, vec4(voidDir, 0), lod);
     vec3 voidColor = voidSample.rgb * refParams[0].y;
+#endif
 
     float wsum[2];
     wsum[0] = 0;
@@ -610,8 +612,15 @@ vec3 sampleProbes(vec3 pos, vec3 dir, float lod)
         {
             refcol = tapRefMap(pos, dir, w, dw, lod, refSphere[i].xyz, i);
 
-            // Blend with void probe based on alpha: alpha=0 (geometry) uses probe, alpha=1 (sky) uses void
-            vec3 blended = mix(refcol.rgb, voidColor, refcol.a);
+#ifdef REFLECTION_PROBE_MED_QUALITY
+            // Medium quality and above: Blend with void probe based on alpha: alpha=0 (geometry) uses probe, alpha=1 (sky) uses void
+            // Square the alpha to make the blend softer at edges (helps with supersampled subpixel blending)
+            float blend_factor = refcol.a * refcol.a;
+            vec3 blended = mix(refcol.rgb, voidColor, blend_factor);
+#else
+            // Low quality: No alpha blending, just use probe color
+            vec3 blended = refcol.rgb;
+#endif
 
             col[p] += blended*w;
             wsum[p] += w;

--- a/indra/newview/app_settings/shaders/class3/deferred/softenLightF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/softenLightF.glsl
@@ -80,8 +80,6 @@ vec3 srgb_to_linear(vec3 c);
 
 uniform vec4 waterPlane;
 
-uniform int cube_snapshot;
-
 uniform float sky_hdr_scale;
 
 void calcHalfVectors(vec3 lv, vec3 n, vec3 v, out vec3 h, out vec3 l, out float nh, out float nl, out float nv, out float vh, out float lightDist);
@@ -283,21 +281,18 @@ void main()
     frag_color.rgb = clampHDRRange(color.rgb * final_scale); //output linear since local lights will be added to this shader's results
 
     // Alpha handling for reflection probe cubemaps
-    if (cube_snapshot != 0)
+#ifdef CUBE_SNAPSHOT
+    if (GET_GBUFFER_FLAG(gb.gbufferFlag, GBUFFER_FLAG_SKIP_ATMOS))
     {
-        if (GET_GBUFFER_FLAG(gb.gbufferFlag, GBUFFER_FLAG_SKIP_ATMOS))
-        {
-            // Sky/clouds: write 1.0 alpha (will use void probe)
-            frag_color.a = 1.0;
-        }
-        else
-        {
-            // Everything else: write 0.0 alpha (will use local probe)
-            frag_color.a = 0.0;
-        }
+        // Sky/clouds: write 1.0 alpha (will use void probe)
+        frag_color.a = 1.0;
     }
     else
     {
+        // Everything else: write 0.0 alpha (will use local probe)
         frag_color.a = 0.0;
     }
+#else
+    frag_color.a = 0.0;
+#endif
 }

--- a/indra/newview/app_settings/shaders/class3/deferred/softenLightF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/softenLightF.glsl
@@ -281,5 +281,23 @@ void main()
         final_scale = 1.1;
 
     frag_color.rgb = clampHDRRange(color.rgb * final_scale); //output linear since local lights will be added to this shader's results
-    frag_color.a = 0.0;
+
+    // Alpha handling for reflection probe cubemaps
+    if (cube_snapshot != 0)
+    {
+        if (GET_GBUFFER_FLAG(gb.gbufferFlag, GBUFFER_FLAG_SKIP_ATMOS))
+        {
+            // Sky/clouds: write 1.0 alpha (will use void probe)
+            frag_color.a = 1.0;
+        }
+        else
+        {
+            // Everything else: write 0.0 alpha (will use local probe)
+            frag_color.a = 0.0;
+        }
+    }
+    else
+    {
+        frag_color.a = 0.0;
+    }
 }

--- a/indra/newview/app_settings/shaders/class3/environment/waterF.glsl
+++ b/indra/newview/app_settings/shaders/class3/environment/waterF.glsl
@@ -27,7 +27,7 @@
 #ifdef SSR
 #define WATER_MINIMAL_PLUS 1
 #else
-#define WATER_MINIMAL 1
+#define WATER_MINIMAL_PLUS 1
 #endif
 
 out vec4 frag_color;

--- a/indra/newview/featuretable.txt
+++ b/indra/newview/featuretable.txt
@@ -105,6 +105,7 @@ RenderMaxPartCount			1	0
 RenderTransparentWater      1   0
 RenderReflectionsEnabled    1   0
 RenderReflectionProbeDetail	1	0
+RenderReflectionProbeQuality	1	0
 RenderTerrainDetail			1	0
 RenderTerrainLODFactor		1	1
 RenderTerrainPBRDetail      1   -4
@@ -148,6 +149,7 @@ RenderLocalLightCount		1	256
 RenderTransparentWater      1   0
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	0
+RenderReflectionProbeQuality	1	0
 RenderTerrainDetail			1	1
 RenderTerrainLODFactor		1	1.0
 RenderTerrainPBRDetail      1   -1
@@ -202,6 +204,7 @@ RenderFSAAType  			1	1
 RenderFSAASamples			1	1
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	0
+RenderReflectionProbeQuality	1	1
 RenderScreenSpaceReflections 1  0
 RenderReflectionProbeLevel  1   1
 RenderMirrors				1	0
@@ -244,6 +247,7 @@ RenderFSAAType  			1	1
 RenderFSAASamples			1	1
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
+RenderReflectionProbeQuality	1	1
 RenderScreenSpaceReflections 1  0
 RenderReflectionProbeLevel  1   1
 RenderMirrors				1	0
@@ -286,6 +290,7 @@ RenderFSAAType  			1	2
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
+RenderReflectionProbeQuality	1	1
 RenderScreenSpaceReflections 1  0
 RenderReflectionProbeLevel  1   2
 RenderMirrors				1	0
@@ -328,6 +333,7 @@ RenderFSAAType  			1	2
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
+RenderReflectionProbeQuality	1	1
 RenderScreenSpaceReflections 1  0
 RenderReflectionProbeLevel  1   3
 RenderMirrors				1	0
@@ -370,6 +376,7 @@ RenderFSAAType  			1	2
 RenderFSAASamples			1	3
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
+RenderReflectionProbeQuality	1	1
 RenderScreenSpaceReflections 1  1
 RenderReflectionProbeLevel  1   3
 RenderMirrors				1	0

--- a/indra/newview/featuretable_mac.txt
+++ b/indra/newview/featuretable_mac.txt
@@ -72,6 +72,7 @@ RenderGLMultiThreadedMedia         1   1
 RenderAppleUseMultGL        1   1
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	2
+RenderReflectionProbeQuality 1  1
 RenderScreenSpaceReflections 1  1
 RenderReflectionProbeLevel  1   3
 RenderMirrors				1	1
@@ -116,6 +117,7 @@ RenderFSAAType			    1	0
 RenderFSAASamples			1	0
 RenderReflectionsEnabled    1   0
 RenderReflectionProbeDetail	1	0
+RenderReflectionProbeQuality 1  0
 RenderScreenSpaceReflections 1  0
 RenderReflectionProbeLevel  1   0
 RenderMirrors				1	0
@@ -159,6 +161,7 @@ RenderFSAAType			    1	0
 RenderFSAASamples			1	0
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	0
+RenderReflectionProbeQuality 1  0
 RenderScreenSpaceReflections 1  0
 RenderReflectionProbeLevel  1   0
 RenderMirrors				1	0
@@ -202,6 +205,7 @@ RenderFSAAType			    1	1
 RenderFSAASamples			1	0
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	0
+RenderReflectionProbeQuality 1  1
 RenderScreenSpaceReflections 1  0
 RenderReflectionProbeLevel  1   0
 RenderMirrors				1	0
@@ -244,6 +248,7 @@ RenderFSAAType			    1	1
 RenderFSAASamples			1	1
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	0
+RenderReflectionProbeQuality 1  1
 RenderScreenSpaceReflections 1  0
 RenderReflectionProbeLevel  1   0
 RenderMirrors				1	0
@@ -286,6 +291,7 @@ RenderFSAAType			    1	1
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
+RenderReflectionProbeQuality 1  1
 RenderScreenSpaceReflections 1  0
 RenderReflectionProbeLevel  1   1
 RenderMirrors				1	0
@@ -328,6 +334,7 @@ RenderFSAAType			    1	2
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
+RenderReflectionProbeQuality 1  1
 RenderScreenSpaceReflections 1  0
 RenderReflectionProbeLevel  1   2
 RenderMirrors				1	0
@@ -370,6 +377,7 @@ RenderFSAAType			    1	2
 RenderFSAASamples			1	3
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
+RenderReflectionProbeQuality 1  1
 RenderScreenSpaceReflections 1  1
 RenderReflectionProbeLevel  1   3
 RenderMirrors				1	0

--- a/indra/newview/lldrawpoolwlsky.cpp
+++ b/indra/newview/lldrawpoolwlsky.cpp
@@ -181,6 +181,7 @@ void LLDrawPoolWLSky::renderSkyHazeDeferred(const LLVector3& camPosLocal, F32 ca
         LLGLSPipelineDepthTestSkyBox sky(true, true);
 
         sky_shader->uniform1i(LLShaderMgr::CUBE_SNAPSHOT, gCubeSnapshot ? 1 : 0);
+        sky_shader->uniform1i(LLShaderMgr::DEFAULT_PROBE_RENDER, LLPipeline::sDefaultProbeRender ? 1 : 0);
 
         LLSettingsSky::ptr_t psky = LLEnvironment::instance().getCurrentSky();
 
@@ -340,6 +341,7 @@ void LLDrawPoolWLSky::renderSkyCloudsDeferred(const LLVector3& camPosLocal, F32 
         cloudshader->uniform1f(LLShaderMgr::BLEND_FACTOR, blend_factor);
         cloudshader->uniform1f(LLShaderMgr::CLOUD_VARIANCE, cloud_variance);
         cloudshader->uniform1f(LLShaderMgr::SUN_MOON_GLOW_FACTOR, psky->getSunMoonGlowFactor());
+        cloudshader->uniform1i(LLShaderMgr::DEFAULT_PROBE_RENDER, LLPipeline::sDefaultProbeRender ? 1 : 0);
 
         /// Render the skydome
         renderDome(camPosLocal, camHeightLocal, cloudshader);

--- a/indra/newview/llfloaterpreferencesgraphicsadvanced.cpp
+++ b/indra/newview/llfloaterpreferencesgraphicsadvanced.cpp
@@ -48,6 +48,7 @@ LLFloaterPreferenceGraphicsAdvanced::LLFloaterPreferenceGraphicsAdvanced(const L
     mCommitCallbackRegistrar.add("Pref.RenderOptionUpdate",            boost::bind(&LLFloaterPreferenceGraphicsAdvanced::onRenderOptionEnable, this));
     mCommitCallbackRegistrar.add("Pref.UpdateIndirectMaxNonImpostors", boost::bind(&LLFloaterPreferenceGraphicsAdvanced::updateMaxNonImpostors,this));
     mCommitCallbackRegistrar.add("Pref.UpdateIndirectMaxComplexity",   boost::bind(&LLFloaterPreferenceGraphicsAdvanced::updateMaxComplexity,this));
+    mCommitCallbackRegistrar.add("Pref.UpdateReflectionsQuality",      boost::bind(&LLFloaterPreferenceGraphicsAdvanced::onReflectionsQualityChanged, this));
 
     mCommitCallbackRegistrar.add("Pref.Cancel", boost::bind(&LLFloaterPreferenceGraphicsAdvanced::onBtnCancel, this, _2));
     mCommitCallbackRegistrar.add("Pref.OK",     boost::bind(&LLFloaterPreferenceGraphicsAdvanced::onBtnOK, this, _2));
@@ -171,6 +172,24 @@ void LLFloaterPreferenceGraphicsAdvanced::refresh()
     bool enable_complexity = gSavedSettings.getS32("RenderAvatarComplexityMode") != LLVOAvatar::AV_RENDER_ONLY_SHOW_FRIENDS;
     getChild<LLSliderCtrl>("IndirectMaxComplexity")->setEnabled(enable_complexity);
     getChild<LLSliderCtrl>("IndirectMaxNonImpostors")->setEnabled(enable_complexity);
+
+    // Set Reflections Quality dropdown based on current settings
+    S32 probe_quality = gSavedSettings.getS32("RenderReflectionProbeQuality");
+    bool ssr_enabled = gSavedSettings.getBOOL("RenderScreenSpaceReflections");
+    LLComboBox* reflections_combo = getChild<LLComboBox>("ReflectionsQuality");
+
+    if (probe_quality == 0)
+    {
+        reflections_combo->setValue(0); // Low
+    }
+    else if (probe_quality == 1 && !ssr_enabled)
+    {
+        reflections_combo->setValue(1); // Medium
+    }
+    else
+    {
+        reflections_combo->setValue(2); // High
+    }
 }
 
 void LLFloaterPreferenceGraphicsAdvanced::refreshEnabledGraphics()
@@ -404,4 +423,33 @@ void LLFloaterPreferenceGraphicsAdvanced::onBtnCancel(const LLSD& userdata)
     {
         instance->onBtnCancel(userdata);
     }
+}
+
+void LLFloaterPreferenceGraphicsAdvanced::onReflectionsQualityChanged()
+{
+    LLComboBox* combo = getChild<LLComboBox>("ReflectionsQuality");
+    S32 quality = combo->getValue().asInteger();
+
+    // Map quality levels to settings:
+    // 0 (Low) = probe quality 0, SSR off
+    // 1 (Medium) = probe quality 1, SSR off
+    // 2 (High) = probe quality 1, SSR on
+
+    if (quality == 0)
+    {
+        gSavedSettings.setS32("RenderReflectionProbeQuality", 0);
+        gSavedSettings.setBOOL("RenderScreenSpaceReflections", false);
+    }
+    else if (quality == 1)
+    {
+        gSavedSettings.setS32("RenderReflectionProbeQuality", 1);
+        gSavedSettings.setBOOL("RenderScreenSpaceReflections", false);
+    }
+    else // quality == 2
+    {
+        gSavedSettings.setS32("RenderReflectionProbeQuality", 1);
+        gSavedSettings.setBOOL("RenderScreenSpaceReflections", true);
+    }
+
+    onRenderOptionEnable();
 }

--- a/indra/newview/llfloaterpreferencesgraphicsadvanced.h
+++ b/indra/newview/llfloaterpreferencesgraphicsadvanced.h
@@ -55,6 +55,7 @@ public:
     // callback for when client modifies a render option
     void onRenderOptionEnable();
     void onAdvancedAtmosphericsEnable();
+    void onReflectionsQualityChanged();
     LOG_CLASS(LLFloaterPreferenceGraphicsAdvanced);
 
 protected:

--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -274,7 +274,7 @@ void LLReflectionMapManager::update()
 
     if (!mRenderTarget.isComplete())
     {
-        U32 color_fmt = render_hdr ? GL_R11F_G11F_B10F : GL_RGB8;
+        U32 color_fmt = render_hdr ? GL_RGBA16F : GL_RGBA8;
         U32 targetRes = mProbeResolution * 4; // super sample
         mRenderTarget.allocate(targetRes, targetRes, color_fmt, true);
     }
@@ -287,7 +287,7 @@ void LLReflectionMapManager::update()
         mMipChain.resize(count);
         for (U32 i = 0; i < count; ++i)
         {
-            mMipChain[i].allocate(res, res, render_hdr ? GL_R11F_G11F_B10F : GL_RGB8);
+            mMipChain[i].allocate(res, res, render_hdr ? GL_RGBA16F : GL_RGBA8);
             res /= 2;
         }
     }
@@ -783,7 +783,9 @@ void LLReflectionMapManager::updateProbeFace(LLReflectionMap* probe, U32 face)
         gPipeline.andRenderTypeMask(LLPipeline::RENDER_TYPE_SKY, LLPipeline::RENDER_TYPE_WL_SKY,
             LLPipeline::RENDER_TYPE_WATER, LLPipeline::RENDER_TYPE_VOIDWATER, LLPipeline::RENDER_TYPE_CLOUDS, LLPipeline::RENDER_TYPE_TERRAIN, LLPipeline::END_RENDER_TYPES);
 
+        LLPipeline::sDefaultProbeRender = true;
         probe->update(mRenderTarget.getWidth(), face);
+        LLPipeline::sDefaultProbeRender = false;
 
         gPipeline.popRenderTypeMask();
     }
@@ -1456,10 +1458,11 @@ void LLReflectionMapManager::initReflectionMaps()
 
                 // store mReflectionProbeCount+2 cube maps, final two cube maps are used for render target and radiance map generation
                 // source)
-                mTexture->allocate(mProbeResolution, 3, mReflectionProbeCount + 2, true, render_hdr);
+                // Use 4 components to include alpha channel for sky transparency control
+                mTexture->allocate(mProbeResolution, 4, mReflectionProbeCount + 2, true, render_hdr);
 
                 mIrradianceMaps = new LLCubeMapArray();
-                mIrradianceMaps->allocate(LL_IRRADIANCE_MAP_RESOLUTION, 3, mReflectionProbeCount, false, render_hdr);
+                mIrradianceMaps->allocate(LL_IRRADIANCE_MAP_RESOLUTION, 4, mReflectionProbeCount, false, render_hdr);
             }
         }
 

--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -271,10 +271,21 @@ void LLReflectionMapManager::update()
     initReflectionMaps();
 
     static LLCachedControl<bool> render_hdr(gSavedSettings, "RenderHDREnabled", true);
+    static LLCachedControl<S32> probe_quality(gSavedSettings, "RenderReflectionProbeQuality", 1);
 
     if (!mRenderTarget.isComplete())
     {
-        U32 color_fmt = render_hdr ? GL_RGBA16F : GL_RGBA8;
+        U32 color_fmt;
+        if (probe_quality > 0)
+        {
+            // High quality: RGBA with alpha preservation for sky blending
+            color_fmt = render_hdr ? GL_RGBA16F : GL_RGBA8;
+        }
+        else
+        {
+            // Low quality: RGB only (legacy path)
+            color_fmt = render_hdr ? GL_R11F_G11F_B10F : GL_RGB8;
+        }
         U32 targetRes = mProbeResolution * 4; // super sample
         mRenderTarget.allocate(targetRes, targetRes, color_fmt, true);
     }
@@ -287,7 +298,18 @@ void LLReflectionMapManager::update()
         mMipChain.resize(count);
         for (U32 i = 0; i < count; ++i)
         {
-            mMipChain[i].allocate(res, res, render_hdr ? GL_RGBA16F : GL_RGBA8);
+            U32 mip_fmt;
+            if (probe_quality > 0)
+            {
+                // High quality: RGBA with alpha preservation
+                mip_fmt = render_hdr ? GL_RGBA16F : GL_RGBA8;
+            }
+            else
+            {
+                // Low quality: RGB only (legacy path)
+                mip_fmt = render_hdr ? GL_R11F_G11F_B10F : GL_RGB8;
+            }
+            mMipChain[i].allocate(res, res, mip_fmt);
             res /= 2;
         }
     }
@@ -1455,14 +1477,15 @@ void LLReflectionMapManager::initReflectionMaps()
                 mTexture = new LLCubeMapArray();
 
                 static LLCachedControl<bool> render_hdr(gSavedSettings, "RenderHDREnabled", true);
+                static LLCachedControl<S32> probe_quality(gSavedSettings, "RenderReflectionProbeQuality", 1);
 
                 // store mReflectionProbeCount+2 cube maps, final two cube maps are used for render target and radiance map generation
                 // source)
-                // Use 4 components to include alpha channel for sky transparency control
-                mTexture->allocate(mProbeResolution, 4, mReflectionProbeCount + 2, true, render_hdr);
+                U32 components = (probe_quality > 0) ? 4 : 3;  // Use 4 components (RGBA) for high quality with alpha preservation, 3 (RGB) for low quality
+                mTexture->allocate(mProbeResolution, components, mReflectionProbeCount + 2, true, render_hdr);
 
                 mIrradianceMaps = new LLCubeMapArray();
-                mIrradianceMaps->allocate(LL_IRRADIANCE_MAP_RESOLUTION, 4, mReflectionProbeCount, false, render_hdr);
+                mIrradianceMaps->allocate(LL_IRRADIANCE_MAP_RESOLUTION, components, mReflectionProbeCount, false, render_hdr);
             }
         }
 

--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -861,6 +861,7 @@ void settings_setup_listeners()
     setting_setup_signal_listener(gSavedSettings, "RenderResolutionDivisor", handleRenderResolutionDivisorChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderReflectionProbeLevel", handleReflectionProbeDetailChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderReflectionProbeDetail", handleReflectionProbeDetailChanged);
+    setting_setup_signal_listener(gSavedSettings, "RenderReflectionProbeQuality", handleReflectionProbeDetailChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderReflectionProbeCount", handleReflectionProbeCountChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderReflectionsEnabled", handleReflectionProbeDetailChanged);
 #if LL_DARWIN

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -162,6 +162,7 @@ LLGLSLShader            gHazeProgram;
 LLGLSLShader            gHazeWaterProgram;
 LLGLSLShader            gDeferredBlurLightProgram;
 LLGLSLShader            gDeferredSoftenProgram;
+LLGLSLShader            gDeferredSoftenCubeProgram;
 LLGLSLShader            gDeferredShadowProgram;
 LLGLSLShader            gDeferredSkinnedShadowProgram;
 LLGLSLShader            gDeferredShadowCubeProgram;
@@ -424,6 +425,7 @@ void LLViewerShaderMgr::finalizeShaderList()
     mShaderList.push_back(&gHazeProgram);
     mShaderList.push_back(&gHazeWaterProgram);
     mShaderList.push_back(&gDeferredSoftenProgram);
+    mShaderList.push_back(&gDeferredSoftenCubeProgram);
     mShaderList.push_back(&gDeferredAlphaProgram);
     mShaderList.push_back(&gHUDAlphaProgram);
     mShaderList.push_back(&gDeferredAlphaImpostorProgram);
@@ -836,6 +838,12 @@ std::string LLViewerShaderMgr::loadBasicShaders()
     {
         attribs["REFMAP_LEVEL"] = std::to_string(probe_level);
         attribs["REF_SAMPLE_COUNT"] = "32";
+
+        S32 probe_quality = gSavedSettings.getS32("RenderReflectionProbeQuality");
+        if (probe_quality > 0)
+        {
+            attribs["REFLECTION_PROBE_MED_QUALITY"] = "1";
+        }
     }
 
     if (mirrors)
@@ -1097,6 +1105,7 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         gDeferredSunProgram.unload();
         gDeferredBlurLightProgram.unload();
         gDeferredSoftenProgram.unload();
+        gDeferredSoftenCubeProgram.unload();
         gDeferredShadowProgram.unload();
         gDeferredSkinnedShadowProgram.unload();
         gDeferredShadowCubeProgram.unload();
@@ -2133,6 +2142,35 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         }
 
         success = gDeferredSoftenProgram.createShader();
+        llassert(success);
+    }
+
+    if (success)
+    {
+        // Cube snapshot variant with CUBE_SNAPSHOT define
+        gDeferredSoftenCubeProgram.mName = "Deferred Soften Cube Shader";
+        gDeferredSoftenCubeProgram.mFeatures = gDeferredSoftenProgram.mFeatures;
+        gDeferredSoftenCubeProgram.mShaderFiles = gDeferredSoftenProgram.mShaderFiles;
+        gDeferredSoftenCubeProgram.mShaderLevel = gDeferredSoftenProgram.mShaderLevel;
+        gDeferredSoftenCubeProgram.mShaderGroup = gDeferredSoftenProgram.mShaderGroup;
+        gDeferredSoftenCubeProgram.mDefines = gDeferredSoftenProgram.mDefines;
+        gDeferredSoftenCubeProgram.clearPermutations();
+        add_common_permutations(&gDeferredSoftenCubeProgram);
+
+        if (use_sun_shadow)
+        {
+            gDeferredSoftenCubeProgram.addPermutation("HAS_SUN_SHADOW", "1");
+        }
+
+        if (gSavedSettings.getBOOL("RenderDeferredSSAO"))
+        {
+            gDeferredSoftenCubeProgram.mShaderLevel = llmax(gDeferredSoftenCubeProgram.mShaderLevel, 2);
+            gDeferredSoftenCubeProgram.addPermutation("HAS_SSAO", "1");
+        }
+
+        gDeferredSoftenCubeProgram.addPermutation("CUBE_SNAPSHOT", "1");
+
+        success = gDeferredSoftenCubeProgram.createShader();
         llassert(success);
     }
 

--- a/indra/newview/llviewershadermgr.h
+++ b/indra/newview/llviewershadermgr.h
@@ -236,6 +236,7 @@ extern LLGLSLShader         gHazeWaterProgram;
 extern LLGLSLShader         gDeferredBlurLightProgram;
 extern LLGLSLShader         gDeferredAvatarProgram;
 extern LLGLSLShader         gDeferredSoftenProgram;
+extern LLGLSLShader         gDeferredSoftenCubeProgram;
 extern LLGLSLShader         gDeferredShadowProgram;
 extern LLGLSLShader         gDeferredShadowCubeProgram;
 extern LLGLSLShader         gDeferredShadowAlphaMaskProgram;

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -8597,7 +8597,8 @@ void LLPipeline::renderDeferredLighting()
 
         if (RenderDeferredAtmospheric)
         {  // apply sunlight contribution
-            LLGLSLShader &soften_shader = gDeferredSoftenProgram;
+            // Use cube snapshot variant shader when rendering to reflection probes
+            LLGLSLShader &soften_shader = gCubeSnapshot ? gDeferredSoftenCubeProgram : gDeferredSoftenProgram;
 
             LL_PROFILE_ZONE_NAMED_CATEGORY_PIPELINE("renderDeferredLighting - atmospherics");
             LL_PROFILE_GPU_ZONE("atmospherics");
@@ -8618,9 +8619,11 @@ void LLPipeline::renderDeferredLighting()
 
             soften_shader.uniform4fv(LLShaderMgr::WATER_WATERPLANE, 1, LLDrawPoolAlpha::sWaterPlane.mV);
 
-            // Pass cube_snapshot and default_probe_render flags to preserve alpha when rendering to reflection probes
-            soften_shader.uniform1i(LLShaderMgr::CUBE_SNAPSHOT, gCubeSnapshot ? 1 : 0);
-            soften_shader.uniform1i(LLShaderMgr::DEFAULT_PROBE_RENDER, LLPipeline::sDefaultProbeRender ? 1 : 0);
+            // Pass default_probe_render flag when rendering to reflection probes
+            if (gCubeSnapshot)
+            {
+                soften_shader.uniform1i(LLShaderMgr::DEFAULT_PROBE_RENDER, LLPipeline::sDefaultProbeRender ? 1 : 0);
+            }
 
             {
                 LLGLDepthTest depth(GL_FALSE);

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -330,6 +330,7 @@ bool    LLPipeline::sUseFarClip = true;
 bool    LLPipeline::sShadowRender = false;
 bool    LLPipeline::sRenderGlow = false;
 bool    LLPipeline::sReflectionRender = false;
+bool    LLPipeline::sDefaultProbeRender = false;
 bool    LLPipeline::sDistortionRender = false;
 bool    LLPipeline::sImpostorRender = false;
 bool    LLPipeline::sImpostorRenderAlphaDepthPass = false;
@@ -8616,6 +8617,10 @@ void LLPipeline::renderDeferredLighting()
             soften_shader.uniform3fv(LLShaderMgr::LIGHTNORM, 1, environment.getClampedLightNorm().mV);
 
             soften_shader.uniform4fv(LLShaderMgr::WATER_WATERPLANE, 1, LLDrawPoolAlpha::sWaterPlane.mV);
+
+            // Pass cube_snapshot and default_probe_render flags to preserve alpha when rendering to reflection probes
+            soften_shader.uniform1i(LLShaderMgr::CUBE_SNAPSHOT, gCubeSnapshot ? 1 : 0);
+            soften_shader.uniform1i(LLShaderMgr::DEFAULT_PROBE_RENDER, LLPipeline::sDefaultProbeRender ? 1 : 0);
 
             {
                 LLGLDepthTest depth(GL_FALSE);

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -671,6 +671,7 @@ public:
     static bool             sDynamicLOD;
     static bool             sPickAvatar;
     static bool             sReflectionRender;
+    static bool             sDefaultProbeRender;
     static bool             sDistortionRender;
     static bool             sImpostorRender;
     static bool             sImpostorRenderAlphaDepthPass;

--- a/indra/newview/skins/default/xui/en/floater_preferences_graphics_advanced.xml
+++ b/indra/newview/skins/default/xui/en/floater_preferences_graphics_advanced.xml
@@ -768,19 +768,42 @@
        value="2"/>
   </combo_box>
 
-  <check_box
-    control_name="RenderScreenSpaceReflections"
+  <text
+    type="string"
+    length="1"
+    follows="left|top"
     height="16"
-    initial_value="true"
-    label="Screen Space Reflections"
     layout="topleft"
     left="420"
-    name="ScreenSpaceReflections"
+    name="ReflectionsQualityText"
+    text_readonly_color="LabelDisabledColor"
     top_delta="24"
-    width="240">
-    <check_box.commit_callback
-      function="Pref.RenderOptionUpdate" />
-  </check_box>
+    width="128">
+    Reflections Quality:
+  </text>
+
+  <combo_box
+   height="18"
+   layout="topleft"
+   left_delta="130"
+   top_delta="0"
+   name="ReflectionsQuality"
+   width="150">
+    <combo_box.item
+      label="Low"
+      name="0"
+      value="0"/>
+    <combo_box.item
+      label="Medium"
+      name="1"
+      value="1"/>
+    <combo_box.item
+      label="High"
+      name="2"
+      value="2"/>
+    <combo_box.commit_callback
+      function="Pref.UpdateReflectionsQuality" />
+  </combo_box>
   
   <text
     type="string"


### PR DESCRIPTION
Pipes through alpha from softenLightF, and adds a new reflection quality setting.  Low = probes as you have them today, Medium = probes with the sky probe passed through where you'd expect a sky, High = Medium + SSR.