### PR TITLE
#5443 fix crash in LLPreviewNotecard::canClose

### DIFF
--- a/indra/newview/llpreviewnotecard.cpp
+++ b/indra/newview/llpreviewnotecard.cpp
@@ -79,6 +79,7 @@ LLPreviewNotecard::LLPreviewNotecard(const LLSD& key) //const LLUUID& item_id,
 LLPreviewNotecard::~LLPreviewNotecard()
 {
     delete mLiveFile;
+    mEditor = nullptr;
 }
 
 bool LLPreviewNotecard::postBuild()
@@ -166,7 +167,7 @@ bool LLPreviewNotecard::handleKeyHere(KEY key, MASK mask)
 // virtual
 bool LLPreviewNotecard::canClose()
 {
-    if(mForceClose || mEditor->isPristine())
+    if(mForceClose || !mEditor || mEditor->isPristine())
     {
         return true;
     }


### PR DESCRIPTION
Add null check to avoid a crash