### PR TITLE
#5084 Fix mac's watchdog not catching test case

### DIFF
--- a/indra/llwindow/llwindowmacosx-objc.h
+++ b/indra/llwindow/llwindowmacosx-objc.h
@@ -78,6 +78,8 @@ void initMainLoop();
 void cleanupViewer();
 void handleUrl(const char* url);
 void dispatchUrl(std::string url);
+void startWatchdog(std::string_view state);
+void stopWatchdog();
 
 /* Defined in llwindowmacosx-objc.mm: */
 int createNSApp(int argc, const char **argv);

--- a/indra/newview/llappdelegate-objc.mm
+++ b/indra/newview/llappdelegate-objc.mm
@@ -395,11 +395,13 @@ struct AttachmentInfo
 
 - (void)sendEvent:(NSEvent *)event
 {
+    startWatchdog("sendEvent"); // events are outside pumpMainLoop
     [super sendEvent:event];
     if ([event type] == NSEventTypeKeyUp && ([event modifierFlags] & NSEventModifierFlagCommand))
     {
         [[self keyWindow] sendEvent:event];
     }
+    stopWatchdog(); // leaving scope
 }
 
 @end

--- a/indra/newview/llappviewermacosx.cpp
+++ b/indra/newview/llappviewermacosx.cpp
@@ -135,6 +135,16 @@ void cleanupViewer()
     gViewerAppPtr = NULL;
 }
 
+void startWatchdog(std::string_view state)
+{
+    gViewerAppPtr->resumeMainloopTimeout(state);
+}
+
+void stopWatchdog()
+{
+    gViewerAppPtr->pauseMainloopTimeout();
+}
+
 void clearDumpLogsDir()
 {
     if (!LLAppViewer::instance()->isSecondInstance())


### PR DESCRIPTION
This happens because on mac watchdog quits at the end of frame. And events get handled outside the frame. The might be other cases that need similar handling.