### PR TITLE
[#5210] Improve detection of marketplace urls for the preloaded marketplace floater

### DIFF
--- a/indra/newview/llfloatermarketplace.cpp
+++ b/indra/newview/llfloatermarketplace.cpp
@@ -101,6 +101,22 @@ void LLFloaterMarketplace::openMarketplaceURL(const std::string& url)
 // static
 bool LLFloaterMarketplace::isMarketplaceURL(const std::string& url)
 {
+    auto trimURL = [](std::string_view url) -> std::string_view
+    {
+        if (url.starts_with("https://"))
+            url.remove_prefix(8);
+        else if (url.starts_with("http://"))
+            url.remove_prefix(7);
+
+        while (!url.empty() && url.back() == '/')
+            url.remove_suffix(1);
+
+        return url;
+    };
+
     static LLCachedControl<std::string> marketplace_url(gSavedSettings, "MarketplaceURL", "https://marketplace.secondlife.com/");
-    return url.starts_with(marketplace_url());
+    std::string_view marketplace_url_trimmed = trimURL(marketplace_url());
+    std::string_view url_trimmed = trimURL(url);
+
+    return !marketplace_url_trimmed.empty() && url_trimmed.starts_with(marketplace_url_trimmed);
 }


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/5210
Follow up to Dan-Lindens test on Mac: https://github.com/secondlife/viewer/issues/5210#issuecomment-3937301752

I got a few people to test the original change on their Macs and everything was behaving as expected.
So I suspect the reason why a marketplace url did not open with the preloaded-marketplace floater when Dan-Linden tested, was one of a few reason-
1. The url started with http:// and not https:// (This PR addresses this)
2. The url was simply https://marketplace.secondlife.com without the trailing / (This PR addresses this)
3. Their MarketplaceURL setting is modified (This PR does not address this and they need to default it)

As to why they weren't already logged in to the marketplace, that is out of scope and not a result of the marketplace changes I've made, and would be a result of the cookies not getting loaded or were invalid for some reason.

This PR simply just trims off the https:// or http:// from urls and removes any trailing /'s. That way when it compares against MarketplaceURL which also gets trimmed, it can more accurately determine if it was a marketplace url that is trying to be opened so it can use the preloaded marketplace floater.