### PR TITLE
Velocity Buffer Support

### DIFF
--- a/indra/llrender/llglslshader.h
+++ b/indra/llrender/llglslshader.h
@@ -60,6 +60,7 @@ public:
     bool hasHeroProbes = false;
     bool isPBRTerrain = false;
     bool hasTonemap = false;
+    bool hasMotionBlur = false;
 };
 
 // ============= Structure for caching shader uniforms ===============

--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -174,6 +174,14 @@ bool LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
         }
     }
 
+    if (features->hasMotionBlur)
+    {
+        if (!shader->attachVertexObject("deferred/velocityFuncV.glsl"))
+        {
+            return false;
+        }
+    }
+
     if (!shader->attachVertexObject("deferred/textureUtilV.glsl"))
     {
         return false;
@@ -1431,6 +1439,7 @@ void LLShaderMgr::initAttribsAndUniforms()
     mReservedUniforms.push_back("lightFunc");
     mReservedUniforms.push_back("lightMap");
     mReservedUniforms.push_back("bloomMap");
+    mReservedUniforms.push_back("velocityMap");
     mReservedUniforms.push_back("projectionMap");
     mReservedUniforms.push_back("norm_mat");
 
@@ -1543,6 +1552,14 @@ void LLShaderMgr::initAttribsAndUniforms()
     mReservedUniforms.push_back("areaTex");
     mReservedUniforms.push_back("searchTex");
     mReservedUniforms.push_back("blendTex");
+
+    mReservedUniforms.push_back("current_modelview_matrix");
+    mReservedUniforms.push_back("last_modelview_matrix");
+    mReservedUniforms.push_back("last_modelview_matrix_inverse");
+    mReservedUniforms.push_back("current_object_matrix");
+    mReservedUniforms.push_back("last_object_matrix");
+    mReservedUniforms.push_back("lastMatrixPalette");
+    mReservedUniforms.push_back("motion_blur_strength");
 
     llassert(mReservedUniforms.size() == END_RESERVED_UNIFORMS);
 

--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -1552,6 +1552,10 @@ void LLShaderMgr::initAttribsAndUniforms()
     mReservedUniforms.push_back("areaTex");
     mReservedUniforms.push_back("searchTex");
     mReservedUniforms.push_back("blendTex");
+    mReservedUniforms.push_back("subsampleIndices");
+    mReservedUniforms.push_back("currentColorTex");
+    mReservedUniforms.push_back("previousColorTex");
+    mReservedUniforms.push_back("velocityTex");
 
     mReservedUniforms.push_back("current_modelview_matrix");
     mReservedUniforms.push_back("last_modelview_matrix");

--- a/indra/llrender/llshadermgr.h
+++ b/indra/llrender/llshadermgr.h
@@ -347,6 +347,10 @@ public:
         SMAA_AREA_TEX,                      //  "areaTex"
         SMAA_SEARCH_TEX,                    //  "searchTex"
         SMAA_BLEND_TEX,                     //  "blendTex"
+        SMAA_SUBSAMPLE_INDICES,             //  "subsampleIndices"
+        SMAA_CURRENT_COLOR_TEX,             //  "currentColorTex"
+        SMAA_PREVIOUS_COLOR_TEX,            //  "previousColorTex"
+        SMAA_VELOCITY_TEX,                  //  "velocityTex"
 
         CURRENT_MODELVIEW_MATRIX,           //  "current_modelview_matrix"
         LAST_MODELVIEW_MATRIX,              //  "last_modelview_matrix"

--- a/indra/llrender/llshadermgr.h
+++ b/indra/llrender/llshadermgr.h
@@ -231,6 +231,7 @@ public:
         DEFERRED_LIGHTFUNC,                 //  "lightFunc"
         DEFERRED_LIGHT,                     //  "lightMap"
         DEFERRED_BLOOM,                     //  "bloomMap"
+        DEFERRED_VELOCITY,                  //  "velocityMap"
         DEFERRED_PROJECTION,                //  "projectionMap"
         DEFERRED_NORM_MATRIX,               //  "norm_mat"
         SPECULAR_COLOR,                     //  "specular_color"
@@ -346,6 +347,14 @@ public:
         SMAA_AREA_TEX,                      //  "areaTex"
         SMAA_SEARCH_TEX,                    //  "searchTex"
         SMAA_BLEND_TEX,                     //  "blendTex"
+
+        CURRENT_MODELVIEW_MATRIX,           //  "current_modelview_matrix"
+        LAST_MODELVIEW_MATRIX,              //  "last_modelview_matrix"
+        LAST_MODELVIEW_MATRIX_INVERSE,      //  "last_modelview_matrix_inverse"
+        CURRENT_OBJECT_MATRIX,              //  "current_object_matrix"
+        LAST_OBJECT_MATRIX,                 //  "last_object_matrix"
+        AVATAR_LAST_MATRIX,                 //  "lastMatrixPalette"
+        MOTION_BLUR_STRENGTH,               //  "motion_blur_strength"
 
         END_RESERVED_UNIFORMS
     } eGLSLReservedUniforms;

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -7476,7 +7476,7 @@
   <key>RenderBufferVisualization</key>
   <map>
     <key>Comment</key>
-    <string>Outputs a selected buffer to the screen.  -1 = final render buffer.  0 = Albedo, 1 = Specular/ORM, 2 = Normal, 3 = Emissive, 4 = Eye luminance, 5 = FXAA Luminance/SMAA Edge Tex, 6 = SMAA Blend Weights</string>
+    <string>Outputs a selected buffer to the screen.  -1 = final render buffer.  0 = Albedo, 1 = Specular/ORM, 2 = Normal, 3 = Emissive, 4 = Eye luminance, 5 = FXAA Luminance/SMAA Edge Tex, 6 = SMAA Blend Weights, 7 = Velocity</string>
     <key>Persist</key>
     <integer>0</integer>
     <key>Type</key>
@@ -7683,6 +7683,28 @@
     <string>Boolean</string>
     <key>Value</key>
     <integer>0</integer>
+  </map>
+  <key>RenderMotionBlur</key>
+  <map>
+    <key>Comment</key>
+    <string>Enable per-object motion blur velocity buffer generation.</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>Boolean</string>
+    <key>Value</key>
+    <integer>0</integer>
+  </map>
+  <key>RenderMotionBlurStrength</key>
+  <map>
+    <key>Comment</key>
+    <string>Maximum motion blur length in pixels (higher = stronger blur)</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>S32</string>
+    <key>Value</key>
+    <integer>32</integer>
   </map>
   <key>RenderScreenSpaceReflections</key>
   <map>

--- a/indra/newview/app_settings/shaders/class1/deferred/SMAA.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/SMAA.glsl
@@ -550,7 +550,7 @@ uniform vec4 SMAA_RT_METRICS;
 #endif
 
 #ifndef SMAA_DECODE_VELOCITY
-#define SMAA_DECODE_VELOCITY(sample) sample.rg
+#define SMAA_DECODE_VELOCITY(sample) (sample.rg * 0.5)
 #endif
 
 //-----------------------------------------------------------------------------

--- a/indra/newview/app_settings/shaders/class1/deferred/SMAABlendWeightsF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/SMAABlendWeightsF.glsl
@@ -34,6 +34,7 @@ in vec4 vary_offset[3];
 uniform sampler2D edgesTex;
 uniform sampler2D areaTex;
 uniform sampler2D searchTex;
+uniform vec4 subsampleIndices;
 
 vec4 SMAABlendingWeightCalculationPS(vec2 texcoord,
                                        vec2 pixcoord,
@@ -51,7 +52,7 @@ void main()
                                                  edgesTex,
                                                  areaTex,
                                                  searchTex,
-                                                 vec4(0.0)
+                                                 subsampleIndices
                                                  );
 }
 

--- a/indra/newview/app_settings/shaders/class1/deferred/SMAAResolveF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/SMAAResolveF.glsl
@@ -1,0 +1,59 @@
+/**
+ * @file SMAAResolveF.glsl
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2024, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+/*[EXTRA_CODE_HERE]*/
+
+out vec4 frag_color;
+
+in vec2 vary_texcoord0;
+
+uniform sampler2D currentColorTex;
+uniform sampler2D previousColorTex;
+#if SMAA_REPROJECTION
+uniform sampler2D velocityTex;
+#endif
+
+#define float4 vec4
+#define float2 vec2
+#define SMAATexture2D(tex) sampler2D tex
+
+float4 SMAAResolvePS(float2 texcoord,
+                     SMAATexture2D(currentColorTex),
+                     SMAATexture2D(previousColorTex)
+                     #if SMAA_REPROJECTION
+                     , SMAATexture2D(velocityTex)
+                     #endif
+                     );
+
+void main()
+{
+    frag_color = SMAAResolvePS(vary_texcoord0,
+                               currentColorTex,
+                               previousColorTex
+                               #if SMAA_REPROJECTION
+                               , velocityTex
+                               #endif
+                               );
+}

--- a/indra/newview/app_settings/shaders/class1/deferred/SMAAResolveV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/SMAAResolveV.glsl
@@ -1,0 +1,34 @@
+/**
+ * @file SMAAResolveV.glsl
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2024, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+in vec3 position;
+
+out vec2 vary_texcoord0;
+
+void main()
+{
+    gl_Position = vec4(position.xyz, 1.0);
+    vary_texcoord0 = (gl_Position.xy * 0.5 + 0.5);
+}

--- a/indra/newview/app_settings/shaders/class1/deferred/avatarAlphaMaskShadowF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/avatarAlphaMaskShadowF.glsl
@@ -32,36 +32,13 @@ in float target_pos_x;
 in float pos_w;
 in vec2 vary_texcoord0;
 
+void bayerDitherDiscard(float alpha, float threshold);
+
 void main()
 {
     float alpha = texture(diffuseMap, vary_texcoord0.xy).a;
 
-    if (alpha < 0.05) // treat as totally transparent
-    {
-        discard;
-    }
-
-    if (alpha < minimum_alpha)
-    {
-        // 4x4 Bayer dither pattern
-        vec2 screen_pos = gl_FragCoord.xy;
-        ivec2 ipos = ivec2(mod(screen_pos, 4.0));
-
-        // 4x4 Bayer matrix values normalized to [0, 1]
-        const float dither_pattern[16] = float[16](
-            0.0/16.0,  8.0/16.0,  2.0/16.0, 10.0/16.0,
-           12.0/16.0,  4.0/16.0, 14.0/16.0,  6.0/16.0,
-            3.0/16.0, 11.0/16.0,  1.0/16.0,  9.0/16.0,
-           15.0/16.0,  7.0/16.0, 13.0/16.0,  5.0/16.0
-        );
-
-        float threshold = dither_pattern[ipos.y * 4 + ipos.x];
-
-        if (alpha < threshold)
-        {
-            discard;
-        }
-    }
+    bayerDitherDiscard(alpha, minimum_alpha);
 
     frag_color = vec4(1,1,1,1);
 }

--- a/indra/newview/app_settings/shaders/class1/deferred/avatarAlphaShadowF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/avatarAlphaShadowF.glsl
@@ -34,36 +34,13 @@ in float target_pos_x;
 in vec2 vary_texcoord0;
 uniform vec4 color;
 
+void bayerDitherDiscard(float alpha, float threshold);
+
 void main()
 {
     float alpha = texture(diffuseMap, vary_texcoord0.xy).a * color.a;
 
-    if (alpha < 0.05) // treat as totally transparent
-    {
-        discard;
-    }
-
-    if (alpha < minimum_alpha) // treat as semi-transparent
-    {
-        // 4x4 Bayer dither pattern
-        vec2 screen_pos = gl_FragCoord.xy;
-        ivec2 ipos = ivec2(mod(screen_pos, 4.0));
-
-        // 4x4 Bayer matrix values normalized to [0, 1]
-        const float dither_pattern[16] = float[16](
-            0.0/16.0,  8.0/16.0,  2.0/16.0, 10.0/16.0,
-           12.0/16.0,  4.0/16.0, 14.0/16.0,  6.0/16.0,
-            3.0/16.0, 11.0/16.0,  1.0/16.0,  9.0/16.0,
-           15.0/16.0,  7.0/16.0, 13.0/16.0,  5.0/16.0
-        );
-
-        float threshold = dither_pattern[ipos.y * 4 + ipos.x];
-
-        if (alpha < threshold)
-        {
-            discard;
-        }
-    }
+    bayerDitherDiscard(alpha, minimum_alpha);
 
     frag_color = vec4(1,1,1,1);
 }

--- a/indra/newview/app_settings/shaders/class1/deferred/avatarVelocityF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/avatarVelocityF.glsl
@@ -1,5 +1,5 @@
 /**
- * @file postDeferredNoDoFF.glsl
+ * @file avatarVelocityF.glsl
  *
  * $LicenseInfo:firstyear=2007&license=viewerlgpl$
  * Second Life Viewer Source Code
@@ -27,15 +27,22 @@
 
 out vec4 frag_color;
 
-uniform sampler2D diffuseRect;
-uniform float mipLevel;
+uniform sampler2D diffuseMap;
 
-in vec2 vary_fragcoord;
+in vec4 vary_cur_clip;
+in vec4 vary_last_clip;
+in vec2 vary_texcoord0;
 
 void main()
 {
-    vec4 diff = textureLod(diffuseRect, vary_fragcoord.xy, mipLevel);
+    float alpha = texture(diffuseMap, vary_texcoord0.xy).a;
+    if (alpha < 0.2)
+    {
+        discard;
+    }
 
-    frag_color = (diff * 0.5 + 0.5);
+    vec2 cur_ndc  = vary_cur_clip.xy / vary_cur_clip.w;
+    vec2 last_ndc = vary_last_clip.xy / vary_last_clip.w;
+
+    frag_color = vec4(cur_ndc - last_ndc, 0.0, 1.0);
 }
-

--- a/indra/newview/app_settings/shaders/class1/deferred/avatarVelocityV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/avatarVelocityV.glsl
@@ -1,0 +1,68 @@
+/**
+ * @file avatarVelocityV.glsl
+ *
+ * $LicenseInfo:firstyear=2007&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2007, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+uniform mat4 projection_matrix;
+uniform vec4 lastMatrixPalette[45];
+
+in vec3 position;
+in vec4 weight;
+in vec2 texcoord0;
+
+out vec2 vary_texcoord0;
+
+mat4 getSkinnedTransform();
+
+void writeVaryVelocity(vec4 pos, vec4 last_pos);
+
+mat4 getLastSkinnedTransform()
+{
+    mat4 ret;
+    int i = int(floor(weight.x));
+    float x = fract(weight.x);
+
+    ret[0] = mix(lastMatrixPalette[i+0],  lastMatrixPalette[i+1],  x);
+    ret[1] = mix(lastMatrixPalette[i+15], lastMatrixPalette[i+16], x);
+    ret[2] = mix(lastMatrixPalette[i+30], lastMatrixPalette[i+31], x);
+    ret[3] = vec4(0,0,0,1);
+
+    return ret;
+}
+
+void main()
+{
+    vec4 pos = vec4(position.xyz, 1.0);
+
+    mat4 current_skin = getSkinnedTransform();
+    vec4 current_clip = projection_matrix * (current_skin * pos);
+
+    mat4 last_skin = getLastSkinnedTransform();
+    vec4 last_clip = projection_matrix * (last_skin * pos);
+
+    gl_Position = current_clip;
+
+    writeVaryVelocity(current_clip, last_clip);
+
+    vary_texcoord0 = texcoord0;
+}

--- a/indra/newview/app_settings/shaders/class1/deferred/globalF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/globalF.glsl
@@ -59,3 +59,32 @@ vec4 decodeNormal(vec4 norm)
     n.z = 1-f/2;
     return n;
 }
+
+// 4x4 Bayer dither matrix normalized to [0, 1]
+const float BAYER_PATTERN[16] = float[16](
+     0.0/16.0,  8.0/16.0,  2.0/16.0, 10.0/16.0,
+    12.0/16.0,  4.0/16.0, 14.0/16.0,  6.0/16.0,
+     3.0/16.0, 11.0/16.0,  1.0/16.0,  9.0/16.0,
+    15.0/16.0,  7.0/16.0, 13.0/16.0,  5.0/16.0
+);
+
+// Discard fragment based on dithered alpha threshold.
+// Fragments with alpha < 0.05 are always discarded.
+// Fragments with alpha >= threshold are always kept.
+// Fragments in between are dithered using a 4x4 Bayer pattern.
+void bayerDitherDiscard(float alpha, float threshold)
+{
+    if (alpha < 0.05)
+    {
+        discard;
+    }
+
+    if (alpha < threshold)
+    {
+        ivec2 ipos = ivec2(mod(gl_FragCoord.xy, 4.0));
+        if (alpha < BAYER_PATTERN[ipos.y * 4 + ipos.x])
+        {
+            discard;
+        }
+    }
+}

--- a/indra/newview/app_settings/shaders/class1/deferred/motionBlurF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/motionBlurF.glsl
@@ -1,0 +1,79 @@
+/**
+ * @file motionBlurF.glsl
+ *
+ * $LicenseInfo:firstyear=2007&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2007, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+/*[EXTRA_CODE_HERE]*/
+
+out vec4 frag_color;
+
+uniform sampler2D diffuseRect;
+uniform sampler2D velocityMap;
+uniform vec2 screen_res;
+uniform int motion_blur_strength;
+
+in vec2 vary_fragcoord;
+
+void main()
+{
+    vec2 uv = vary_fragcoord;
+    vec2 vel = texture(velocityMap, uv).rg;
+
+    // NDC velocity to pixel velocity
+    vec2 pixel_vel = vel * screen_res * 0.5;
+    float speed = length(pixel_vel);
+
+    // Early out for negligible motion
+    if (speed < 0.5)
+    {
+        frag_color = texture(diffuseRect, uv);
+        return;
+    }
+
+    // Clamp to max blur length
+    float max_blur = float(motion_blur_strength);
+    if (speed > max_blur)
+    {
+        pixel_vel *= max_blur / speed;
+    }
+
+    // Step size in UV space per iteration
+    vec2 step_uv = (pixel_vel / screen_res) * (2.0 / 32.0);
+
+    // Start sampling ahead of center
+    vec2 sample_uv = uv + step_uv * 16.0;
+
+    // 32-sample triangle-weighted blur
+    vec3 color = vec3(0.0);
+    float total = 0.0;
+
+    for (int i = 0; i < 32; ++i)
+    {
+        float w = 32.0 - abs(float(i) - 16.0);
+        total += w;
+        color += texture(diffuseRect, sample_uv).rgb * w;
+        sample_uv -= step_uv;
+    }
+
+    frag_color = vec4(color / total, 1.0);
+}

--- a/indra/newview/app_settings/shaders/class1/deferred/pbrShadowAlphaBlendF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/pbrShadowAlphaBlendF.glsl
@@ -33,38 +33,14 @@ in vec4 vertex_color;
 in vec2 vary_texcoord0;
 uniform float minimum_alpha;
 
+void bayerDitherDiscard(float alpha, float threshold);
+
 void main()
 {
-    float alpha = texture(diffuseMap,vary_texcoord0.xy).a;
-
+    float alpha = texture(diffuseMap, vary_texcoord0.xy).a;
     alpha *= vertex_color.a;
 
-    if (alpha < 0.05) // treat as totally transparent
-    {
-        discard;
-    }
-
-    if (alpha < 0.88) // treat as semi-transparent
-    {
-        // 4x4 Bayer dither pattern
-        vec2 screen_pos = gl_FragCoord.xy;
-        ivec2 ipos = ivec2(mod(screen_pos, 4.0));
-
-        // 4x4 Bayer matrix values normalized to [0, 1]
-        const float dither_pattern[16] = float[16](
-            0.0/16.0,  8.0/16.0,  2.0/16.0, 10.0/16.0,
-           12.0/16.0,  4.0/16.0, 14.0/16.0,  6.0/16.0,
-            3.0/16.0, 11.0/16.0,  1.0/16.0,  9.0/16.0,
-           15.0/16.0,  7.0/16.0, 13.0/16.0,  5.0/16.0
-        );
-
-        float threshold = dither_pattern[ipos.y * 4 + ipos.x];
-
-        if (alpha < threshold)
-        {
-            discard;
-        }
-    }
+    bayerDitherDiscard(alpha, 0.88);
 
     frag_color = vec4(1,1,1,1);
 }

--- a/indra/newview/app_settings/shaders/class1/deferred/shadowAlphaMaskF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/shadowAlphaMaskF.glsl
@@ -33,6 +33,8 @@ in vec4 vertex_color;
 in vec2 vary_texcoord0;
 uniform float minimum_alpha;
 
+void bayerDitherDiscard(float alpha, float threshold);
+
 void main()
 {
     float alpha = diffuseLookup(vary_texcoord0.xy).a;
@@ -46,32 +48,7 @@ void main()
     alpha *= vertex_color.a;
 #endif
 
-    if (alpha < 0.05) // treat as totally transparent
-    {
-        discard;
-    }
-
-    if (alpha < 0.88) // treat as semi-transparent
-    {
-        // 4x4 Bayer dither pattern
-        vec2 screen_pos = gl_FragCoord.xy;
-        ivec2 ipos = ivec2(mod(screen_pos, 4.0));
-
-        // 4x4 Bayer matrix values normalized to [0, 1]
-        const float dither_pattern[16] = float[16](
-            0.0/16.0,  8.0/16.0,  2.0/16.0, 10.0/16.0,
-           12.0/16.0,  4.0/16.0, 14.0/16.0,  6.0/16.0,
-            3.0/16.0, 11.0/16.0,  1.0/16.0,  9.0/16.0,
-           15.0/16.0,  7.0/16.0, 13.0/16.0,  5.0/16.0
-        );
-
-        float threshold = dither_pattern[ipos.y * 4 + ipos.x];
-
-        if (alpha < threshold)
-        {
-            discard;
-        }
-    }
+    bayerDitherDiscard(alpha, 0.88);
 
     frag_color = vec4(1,1,1,1);
 }

--- a/indra/newview/app_settings/shaders/class1/deferred/skinnedVelocityAlphaV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/skinnedVelocityAlphaV.glsl
@@ -1,5 +1,6 @@
 /**
- * @file objectSkinV.glsl
+ * @file skinnedVelocityAlphaV.glsl
+ *
  * $LicenseInfo:firstyear=2007&license=viewerlgpl$
  * Second Life Viewer Source Code
  * Copyright (C) 2007, Linden Research, Inc.
@@ -22,54 +23,24 @@
  * $/LicenseInfo$
  */
 
-in vec4 weight4;
+uniform mat4 modelview_projection_matrix;
+uniform mat4 projection_matrix;
+uniform mat4 last_modelview_matrix;
+uniform mat4 texture_matrix0;
 
-uniform mat3x4 matrixPalette[MAX_JOINTS_PER_MESH_OBJECT];
+in vec3 position;
+in vec4 weight4;
+in vec4 diffuse_color;
+in vec2 texcoord0;
+
+out vec2 vary_texcoord0;
+out vec4 vertex_color;
+
 uniform mat3x4 lastMatrixPalette[MAX_JOINTS_PER_MESH_OBJECT];
 
-mat4 getObjectSkinnedTransform()
-{
-    int i;
+mat4 getObjectSkinnedTransform();
 
-    vec4 w = fract(weight4);
-    vec4 index = floor(weight4);
-
-    index = min(index, vec4(MAX_JOINTS_PER_MESH_OBJECT-1));
-    index = max(index, vec4( 0.0));
-
-    w *= 1.0/(w.x+w.y+w.z+w.w);
-
-    int i1 = int(index.x);
-    int i2 = int(index.y);
-    int i3 = int(index.z);
-    int i4 = int(index.w);
-
-    mat3 mat = mat3(matrixPalette[i1])*w.x;
-         mat += mat3(matrixPalette[i2])*w.y;
-         mat += mat3(matrixPalette[i3])*w.z;
-         mat += mat3(matrixPalette[i4])*w.w;
-
-    vec3 trans = vec3(matrixPalette[i1][0].w,matrixPalette[i1][1].w,matrixPalette[i1][2].w)*w.x;
-         trans += vec3(matrixPalette[i2][0].w,matrixPalette[i2][1].w,matrixPalette[i2][2].w)*w.y;
-         trans += vec3(matrixPalette[i3][0].w,matrixPalette[i3][1].w,matrixPalette[i3][2].w)*w.z;
-         trans += vec3(matrixPalette[i4][0].w,matrixPalette[i4][1].w,matrixPalette[i4][2].w)*w.w;
-
-    mat4 ret;
-
-    ret[0] = vec4(mat[0], 0);
-    ret[1] = vec4(mat[1], 0);
-    ret[2] = vec4(mat[2], 0);
-    ret[3] = vec4(trans, 1.0);
-
-    return ret;
-
-#ifdef IS_AMD_CARD
-   // If it's AMD make sure the GLSL compiler sees the arrays referenced once by static index. Otherwise it seems to optimise the storage awawy which leads to unfun crashes and artifacts.
-   mat3x4 dummy1 = matrixPalette[0];
-   mat3x4 dummy2 = matrixPalette[MAX_JOINTS_PER_MESH_OBJECT-1];
-#endif
-
-}
+void writeVaryVelocity(vec4 pos, vec4 last_pos);
 
 mat4 getLastObjectSkinnedTransform()
 {
@@ -105,3 +76,19 @@ mat4 getLastObjectSkinnedTransform()
     return ret;
 }
 
+void main()
+{
+    vec4 pos = vec4(position.xyz, 1.0);
+
+    vec4 current_clip = modelview_projection_matrix * pos;
+
+    mat4 last_mat = getLastObjectSkinnedTransform();
+    vec4 last_clip = projection_matrix * (last_modelview_matrix * (last_mat * pos));
+
+    gl_Position = current_clip;
+
+    writeVaryVelocity(current_clip, last_clip);
+
+    vary_texcoord0 = (texture_matrix0 * vec4(texcoord0, 0, 1)).xy;
+    vertex_color = diffuse_color;
+}

--- a/indra/newview/app_settings/shaders/class1/deferred/skinnedVelocityV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/skinnedVelocityV.glsl
@@ -1,5 +1,6 @@
 /**
- * @file objectSkinV.glsl
+ * @file skinnedVelocityV.glsl
+ *
  * $LicenseInfo:firstyear=2007&license=viewerlgpl$
  * Second Life Viewer Source Code
  * Copyright (C) 2007, Linden Research, Inc.
@@ -22,54 +23,18 @@
  * $/LicenseInfo$
  */
 
+uniform mat4 modelview_projection_matrix;
+uniform mat4 projection_matrix;
+uniform mat4 last_modelview_matrix;
+
+in vec3 position;
 in vec4 weight4;
 
-uniform mat3x4 matrixPalette[MAX_JOINTS_PER_MESH_OBJECT];
 uniform mat3x4 lastMatrixPalette[MAX_JOINTS_PER_MESH_OBJECT];
 
-mat4 getObjectSkinnedTransform()
-{
-    int i;
+mat4 getObjectSkinnedTransform();
 
-    vec4 w = fract(weight4);
-    vec4 index = floor(weight4);
-
-    index = min(index, vec4(MAX_JOINTS_PER_MESH_OBJECT-1));
-    index = max(index, vec4( 0.0));
-
-    w *= 1.0/(w.x+w.y+w.z+w.w);
-
-    int i1 = int(index.x);
-    int i2 = int(index.y);
-    int i3 = int(index.z);
-    int i4 = int(index.w);
-
-    mat3 mat = mat3(matrixPalette[i1])*w.x;
-         mat += mat3(matrixPalette[i2])*w.y;
-         mat += mat3(matrixPalette[i3])*w.z;
-         mat += mat3(matrixPalette[i4])*w.w;
-
-    vec3 trans = vec3(matrixPalette[i1][0].w,matrixPalette[i1][1].w,matrixPalette[i1][2].w)*w.x;
-         trans += vec3(matrixPalette[i2][0].w,matrixPalette[i2][1].w,matrixPalette[i2][2].w)*w.y;
-         trans += vec3(matrixPalette[i3][0].w,matrixPalette[i3][1].w,matrixPalette[i3][2].w)*w.z;
-         trans += vec3(matrixPalette[i4][0].w,matrixPalette[i4][1].w,matrixPalette[i4][2].w)*w.w;
-
-    mat4 ret;
-
-    ret[0] = vec4(mat[0], 0);
-    ret[1] = vec4(mat[1], 0);
-    ret[2] = vec4(mat[2], 0);
-    ret[3] = vec4(trans, 1.0);
-
-    return ret;
-
-#ifdef IS_AMD_CARD
-   // If it's AMD make sure the GLSL compiler sees the arrays referenced once by static index. Otherwise it seems to optimise the storage awawy which leads to unfun crashes and artifacts.
-   mat3x4 dummy1 = matrixPalette[0];
-   mat3x4 dummy2 = matrixPalette[MAX_JOINTS_PER_MESH_OBJECT-1];
-#endif
-
-}
+void writeVaryVelocity(vec4 pos, vec4 last_pos);
 
 mat4 getLastObjectSkinnedTransform()
 {
@@ -105,3 +70,16 @@ mat4 getLastObjectSkinnedTransform()
     return ret;
 }
 
+void main()
+{
+    vec4 pos = vec4(position.xyz, 1.0);
+
+    vec4 current_clip = modelview_projection_matrix * pos;
+
+    mat4 last_mat = getLastObjectSkinnedTransform();
+    vec4 last_clip = projection_matrix * (last_modelview_matrix * (last_mat * pos));
+
+    gl_Position = current_clip;
+
+    writeVaryVelocity(current_clip, last_clip);
+}

--- a/indra/newview/app_settings/shaders/class1/deferred/velocityAlphaF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/velocityAlphaF.glsl
@@ -28,6 +28,7 @@
 out vec4 frag_color;
 
 vec4 diffuseLookup(vec2 texcoord);
+void bayerDitherDiscard(float alpha, float threshold);
 
 in vec4 vary_cur_clip;
 in vec4 vary_last_clip;
@@ -39,10 +40,7 @@ void main()
     float alpha = diffuseLookup(vary_texcoord0.xy).a;
     alpha *= vertex_color.a;
 
-    if (alpha < 0.75)
-    {
-        discard;
-    }
+    bayerDitherDiscard(alpha, 0.88);
 
     vec2 cur_ndc  = vary_cur_clip.xy / vary_cur_clip.w;
     vec2 last_ndc = vary_last_clip.xy / vary_last_clip.w;

--- a/indra/newview/app_settings/shaders/class1/deferred/velocityAlphaF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/velocityAlphaF.glsl
@@ -1,5 +1,5 @@
 /**
- * @file postDeferredNoDoFF.glsl
+ * @file velocityAlphaF.glsl
  *
  * $LicenseInfo:firstyear=2007&license=viewerlgpl$
  * Second Life Viewer Source Code
@@ -27,15 +27,25 @@
 
 out vec4 frag_color;
 
-uniform sampler2D diffuseRect;
-uniform float mipLevel;
+vec4 diffuseLookup(vec2 texcoord);
 
-in vec2 vary_fragcoord;
+in vec4 vary_cur_clip;
+in vec4 vary_last_clip;
+in vec2 vary_texcoord0;
+in vec4 vertex_color;
 
 void main()
 {
-    vec4 diff = textureLod(diffuseRect, vary_fragcoord.xy, mipLevel);
+    float alpha = diffuseLookup(vary_texcoord0.xy).a;
+    alpha *= vertex_color.a;
 
-    frag_color = (diff * 0.5 + 0.5);
+    if (alpha < 0.75)
+    {
+        discard;
+    }
+
+    vec2 cur_ndc  = vary_cur_clip.xy / vary_cur_clip.w;
+    vec2 last_ndc = vary_last_clip.xy / vary_last_clip.w;
+
+    frag_color = vec4(cur_ndc - last_ndc, 0.0, 1.0);
 }
-

--- a/indra/newview/app_settings/shaders/class1/deferred/velocityAlphaV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/velocityAlphaV.glsl
@@ -1,0 +1,70 @@
+/**
+ * @file velocityAlphaV.glsl
+ *
+ * $LicenseInfo:firstyear=2007&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2007, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+uniform mat4 modelview_projection_matrix;
+uniform mat4 modelview_matrix;
+uniform mat4 projection_matrix;
+uniform mat4 last_modelview_matrix;
+uniform mat4 last_object_matrix;
+uniform mat4 texture_matrix0;
+
+in vec3 position;
+in vec4 diffuse_color;
+in vec2 texcoord0;
+
+out vec2 vary_texcoord0;
+out vec4 vertex_color;
+
+void passTextureIndex();
+void writeVaryVelocity(vec4 pos, vec4 last_pos);
+
+#ifdef HAS_SKIN
+mat4 getObjectSkinnedTransform();
+mat4 getLastObjectSkinnedTransform();
+#endif
+
+void main()
+{
+    vary_texcoord0 = (texture_matrix0 * vec4(texcoord0, 0, 1)).xy;
+    vertex_color = diffuse_color;
+
+    passTextureIndex();
+
+#ifdef HAS_SKIN
+    mat4 cur_mat = getObjectSkinnedTransform();
+    vec4 pos = projection_matrix * modelview_matrix * cur_mat * vec4(position.xyz, 1.0);
+    gl_Position = pos;
+
+    mat4 last_mat = getLastObjectSkinnedTransform();
+    vec4 last_pos = projection_matrix * last_modelview_matrix * last_mat * vec4(position.xyz, 1.0);
+#else
+    vec4 pos = modelview_projection_matrix * vec4(position.xyz, 1.0);
+    gl_Position = pos;
+
+    vec4 last_pos = projection_matrix * last_modelview_matrix * last_object_matrix * vec4(position.xyz, 1.0);
+#endif
+
+    writeVaryVelocity(pos, last_pos);
+}

--- a/indra/newview/app_settings/shaders/class1/deferred/velocityF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/velocityF.glsl
@@ -1,5 +1,5 @@
 /**
- * @file postDeferredNoDoFF.glsl
+ * @file velocityF.glsl
  *
  * $LicenseInfo:firstyear=2007&license=viewerlgpl$
  * Second Life Viewer Source Code
@@ -27,15 +27,13 @@
 
 out vec4 frag_color;
 
-uniform sampler2D diffuseRect;
-uniform float mipLevel;
-
-in vec2 vary_fragcoord;
+in vec4 vary_cur_clip;
+in vec4 vary_last_clip;
 
 void main()
 {
-    vec4 diff = textureLod(diffuseRect, vary_fragcoord.xy, mipLevel);
+    vec2 cur_ndc  = vary_cur_clip.xy / vary_cur_clip.w;
+    vec2 last_ndc = vary_last_clip.xy / vary_last_clip.w;
 
-    frag_color = (diff * 0.5 + 0.5);
+    frag_color = vec4(cur_ndc - last_ndc, 0.0, 1.0);
 }
-

--- a/indra/newview/app_settings/shaders/class1/deferred/velocityFuncV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/velocityFuncV.glsl
@@ -1,5 +1,5 @@
 /**
- * @file postDeferredNoDoFF.glsl
+ * @file velocityFuncV.glsl
  *
  * $LicenseInfo:firstyear=2007&license=viewerlgpl$
  * Second Life Viewer Source Code
@@ -23,19 +23,11 @@
  * $/LicenseInfo$
  */
 
-/*[EXTRA_CODE_HERE]*/
+out vec4 vary_cur_clip;
+out vec4 vary_last_clip;
 
-out vec4 frag_color;
-
-uniform sampler2D diffuseRect;
-uniform float mipLevel;
-
-in vec2 vary_fragcoord;
-
-void main()
+void writeVaryVelocity(vec4 pos, vec4 last_pos)
 {
-    vec4 diff = textureLod(diffuseRect, vary_fragcoord.xy, mipLevel);
-
-    frag_color = (diff * 0.5 + 0.5);
+    vary_cur_clip = pos;
+    vary_last_clip = last_pos;
 }
-

--- a/indra/newview/app_settings/shaders/class1/deferred/velocityV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/velocityV.glsl
@@ -1,5 +1,5 @@
 /**
- * @file postDeferredNoDoFF.glsl
+ * @file velocityV.glsl
  *
  * $LicenseInfo:firstyear=2007&license=viewerlgpl$
  * Second Life Viewer Source Code
@@ -23,19 +23,36 @@
  * $/LicenseInfo$
  */
 
-/*[EXTRA_CODE_HERE]*/
+uniform mat4 modelview_projection_matrix;
+uniform mat4 modelview_matrix;
+uniform mat4 projection_matrix;
+uniform mat4 last_modelview_matrix;
+uniform mat4 last_object_matrix;
 
-out vec4 frag_color;
+in vec3 position;
 
-uniform sampler2D diffuseRect;
-uniform float mipLevel;
+void writeVaryVelocity(vec4 pos, vec4 last_pos);
 
-in vec2 vary_fragcoord;
+#ifdef HAS_SKIN
+mat4 getObjectSkinnedTransform();
+mat4 getLastObjectSkinnedTransform();
+#endif
 
 void main()
 {
-    vec4 diff = textureLod(diffuseRect, vary_fragcoord.xy, mipLevel);
+#ifdef HAS_SKIN
+    mat4 cur_mat = getObjectSkinnedTransform();
+    vec4 pos = projection_matrix * modelview_matrix * cur_mat * vec4(position.xyz, 1.0);
+    gl_Position = pos;
 
-    frag_color = (diff * 0.5 + 0.5);
+    mat4 last_mat = getLastObjectSkinnedTransform();
+    vec4 last_pos = projection_matrix * last_modelview_matrix * last_mat * vec4(position.xyz, 1.0);
+#else
+    vec4 pos = modelview_projection_matrix * vec4(position.xyz, 1.0);
+    gl_Position = pos;
+
+    vec4 last_pos = projection_matrix * last_modelview_matrix * last_object_matrix * vec4(position.xyz, 1.0);
+#endif
+
+    writeVaryVelocity(pos, last_pos);
 }
-

--- a/indra/newview/lldrawable.h
+++ b/indra/newview/lldrawable.h
@@ -288,6 +288,8 @@ public:
 
     F32             mDistanceWRTCamera;
 
+    LLMatrix4       mLastVelocityMatrix;
+
     static F32 sCurPixelAngle; //current pixels per radian
 
 private:

--- a/indra/newview/lldrawpool.cpp
+++ b/indra/newview/lldrawpool.cpp
@@ -790,6 +790,8 @@ void LLRenderPass::pushVelocityBatches(U32 type)
             continue;
         }
 
+        LLGLDisable cull_face(params.mGLTFMaterial && params.mGLTFMaterial->mDoubleSided ? GL_CULL_FACE : 0);
+
         applyModelMatrix(params);
 
         // Upload the previous matrix from the drawable
@@ -856,6 +858,8 @@ void LLRenderPass::pushVelocityBatchesTextured(U32 type)
         {
             continue;
         }
+
+        LLGLDisable cull_face(params.mGLTFMaterial && params.mGLTFMaterial->mDoubleSided ? GL_CULL_FACE : 0);
 
         applyModelMatrix(params);
 

--- a/indra/newview/lldrawpool.cpp
+++ b/indra/newview/lldrawpool.cpp
@@ -241,6 +241,30 @@ void LLDrawPool::renderShadow(S32 pass)
 
 }
 
+//virtual
+void LLDrawPool::beginMotionBlurPass(S32 pass)
+{
+
+}
+
+//virtual
+void LLDrawPool::endMotionBlurPass(S32 pass)
+{
+
+}
+
+//virtual
+S32 LLDrawPool::getNumMotionBlurPasses()
+{
+    return 0;
+}
+
+//virtual
+void LLDrawPool::renderMotionBlur(S32 pass)
+{
+
+}
+
 //=============================
 // Face Pool Implementation
 //=============================
@@ -748,6 +772,174 @@ bool LLRenderPass::uploadMatrixPalette(LLVOAvatar* avatar, LLMeshSkinInfo* skinI
     }
 
     return !skipLastSkin;
+}
+
+void LLRenderPass::pushVelocityBatches(U32 type)
+{
+    static const LLMatrix4 identity;
+    auto* begin = gPipeline.beginRenderMap(type);
+    auto* end = gPipeline.endRenderMap(type);
+
+    for (LLCullResult::drawinfo_iterator i = begin; i != end; )
+    {
+        LLDrawInfo& params = **i;
+        LLCullResult::increment_iterator(i, end);
+
+        if (!params.mVertexBuffer.notNull())
+        {
+            continue;
+        }
+
+        applyModelMatrix(params);
+
+        // Upload the previous matrix from the drawable
+        const LLMatrix4* last_mat = params.mLastModelMatrix ? params.mLastModelMatrix : &identity;
+        LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::LAST_OBJECT_MATRIX, 1, GL_FALSE, (GLfloat*)last_mat->mMatrix);
+
+        params.mVertexBuffer->setBuffer();
+        params.mVertexBuffer->drawRange(LLRender::TRIANGLES, params.mStart, params.mEnd, params.mCount, params.mOffset);
+
+        // Store current matrix on the drawable for next frame
+        const LLMatrix4* current_mat = params.mModelMatrix ? params.mModelMatrix : &identity;
+        if (params.mLastModelMatrix)
+        {
+            *params.mLastModelMatrix = *current_mat;
+        }
+    }
+}
+
+void LLRenderPass::pushRiggedVelocityBatches(U32 type)
+{
+    const LLVOAvatar* lastAvatar = nullptr;
+    U64 lastMeshId = 0;
+    bool skipLastSkin = false;
+
+    auto* begin = gPipeline.beginRenderMap(type);
+    auto* end = gPipeline.endRenderMap(type);
+
+    for (LLCullResult::drawinfo_iterator i = begin; i != end; )
+    {
+        LLDrawInfo& params = **i;
+        LLCullResult::increment_iterator(i, end);
+
+        if (!params.mVertexBuffer.notNull() || !params.mAvatar)
+        {
+            continue;
+        }
+
+        if (!uploadMatrixPalette(params.mAvatar, params.mSkinInfo, lastAvatar, lastMeshId, skipLastSkin))
+        {
+            continue;
+        }
+
+        uploadLastMatrixPalette(params.mAvatar, params.mSkinInfo);
+
+        applyModelMatrix(params);
+
+        params.mVertexBuffer->setBuffer();
+        params.mVertexBuffer->drawRange(LLRender::TRIANGLES, params.mStart, params.mEnd, params.mCount, params.mOffset);
+    }
+}
+
+void LLRenderPass::pushVelocityBatchesTextured(U32 type)
+{
+    static const LLMatrix4 identity;
+    auto* begin = gPipeline.beginRenderMap(type);
+    auto* end = gPipeline.endRenderMap(type);
+
+    for (LLCullResult::drawinfo_iterator i = begin; i != end; )
+    {
+        LLDrawInfo& params = **i;
+        LLCullResult::increment_iterator(i, end);
+
+        if (!params.mVertexBuffer.notNull())
+        {
+            continue;
+        }
+
+        applyModelMatrix(params);
+
+        if (params.mTexture.notNull())
+        {
+            gGL.getTexUnit(0)->bindFast(params.mTexture);
+        }
+
+        // Upload the previous matrix from the drawable
+        const LLMatrix4* last_mat = params.mLastModelMatrix ? params.mLastModelMatrix : &identity;
+        LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::LAST_OBJECT_MATRIX, 1, GL_FALSE, (GLfloat*)last_mat->mMatrix);
+
+        params.mVertexBuffer->setBuffer();
+        params.mVertexBuffer->drawRange(LLRender::TRIANGLES, params.mStart, params.mEnd, params.mCount, params.mOffset);
+
+        // Store current matrix on the drawable for next frame
+        const LLMatrix4* current_mat = params.mModelMatrix ? params.mModelMatrix : &identity;
+        if (params.mLastModelMatrix)
+        {
+            *params.mLastModelMatrix = *current_mat;
+        }
+    }
+}
+
+void LLRenderPass::pushRiggedVelocityBatchesTextured(U32 type)
+{
+    const LLVOAvatar* lastAvatar = nullptr;
+    U64 lastMeshId = 0;
+    bool skipLastSkin = false;
+
+    auto* begin = gPipeline.beginRenderMap(type);
+    auto* end = gPipeline.endRenderMap(type);
+
+    for (LLCullResult::drawinfo_iterator i = begin; i != end; )
+    {
+        LLDrawInfo& params = **i;
+        LLCullResult::increment_iterator(i, end);
+
+        if (!params.mVertexBuffer.notNull() || !params.mAvatar)
+        {
+            continue;
+        }
+
+        if (!uploadMatrixPalette(params.mAvatar, params.mSkinInfo, lastAvatar, lastMeshId, skipLastSkin))
+        {
+            continue;
+        }
+
+        uploadLastMatrixPalette(params.mAvatar, params.mSkinInfo);
+
+        applyModelMatrix(params);
+
+        if (params.mTexture.notNull())
+        {
+            gGL.getTexUnit(0)->bindFast(params.mTexture);
+        }
+
+        params.mVertexBuffer->setBuffer();
+        params.mVertexBuffer->drawRange(LLRender::TRIANGLES, params.mStart, params.mEnd, params.mCount, params.mOffset);
+    }
+}
+
+//static
+bool LLRenderPass::uploadLastMatrixPalette(LLVOAvatar* avatar, LLMeshSkinInfo* skinInfo)
+{
+    if (!avatar || !skinInfo)
+    {
+        return false;
+    }
+
+    const LLVOAvatar::MatrixPaletteCache& mpc = avatar->updateSkinInfoMatrixPalette(skinInfo);
+    U32 count = static_cast<U32>(mpc.mMatrixPalette.size());
+
+    if (count == 0 || mpc.mLastGLMp.empty())
+    {
+        return false;
+    }
+
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix3x4fv(LLViewerShaderMgr::AVATAR_LAST_MATRIX,
+        count,
+        false,
+        (GLfloat*)&(mpc.mLastGLMp[0]));
+
+    return true;
 }
 
 void setup_texture_matrix(LLDrawInfo& params)

--- a/indra/newview/lldrawpool.h
+++ b/indra/newview/lldrawpool.h
@@ -110,6 +110,11 @@ public:
     virtual S32 getNumShadowPasses();
     virtual void renderShadow(S32 pass = 0);
 
+    virtual void beginMotionBlurPass(S32 pass);
+    virtual void endMotionBlurPass(S32 pass);
+    virtual S32 getNumMotionBlurPasses();
+    virtual void renderMotionBlur(S32 pass = 0);
+
     virtual void render(S32 pass = 0) {};
     virtual void prerender() {};
     virtual U32 getVertexDataMask() { return 0; } // DEPRECATED -- draw pool doesn't actually determine vertex data mask any more
@@ -345,10 +350,10 @@ public:
 
     LLRenderPass(const U32 type);
     virtual ~LLRenderPass();
-    /*virtual*/ LLViewerTexture* getDebugTexture() { return NULL; }
-    LLViewerTexture* getTexture() { return NULL; }
-    bool isDead() { return false; }
-    void resetDrawOrders() { }
+    LLViewerTexture* getDebugTexture() override { return NULL; }
+    LLViewerTexture* getTexture() override { return NULL; }
+    bool isDead() override { return false; }
+    void resetDrawOrders() override { }
 
     static void applyModelMatrix(const LLDrawInfo& params);
     // For rendering that doesn't use LLDrawInfo for some reason
@@ -392,6 +397,14 @@ public:
     static bool uploadMatrixPalette(LLVOAvatar* avatar, LLMeshSkinInfo* skinInfo, const LLVOAvatar*& lastAvatar, U64& lastMeshId, const LLGLSLShader*& lastAvatarShader, bool& skipLastSkin);
     virtual void renderGroup(LLSpatialGroup* group, U32 type, bool texture = true);
     virtual void renderRiggedGroup(LLSpatialGroup* group, U32 type, bool texture = true);
+
+    // Velocity buffer helpers — iterate render map, upload per-object last/current matrices, draw
+    void pushVelocityBatches(U32 type);
+    void pushRiggedVelocityBatches(U32 type);
+    void pushVelocityBatchesTextured(U32 type);
+    void pushRiggedVelocityBatchesTextured(U32 type);
+
+    static bool uploadLastMatrixPalette(LLVOAvatar* avatar, LLMeshSkinInfo* skinInfo);
 };
 
 class LLFacePool : public LLDrawPool
@@ -408,18 +421,18 @@ public:
     LLFacePool(const U32 type);
     virtual ~LLFacePool();
 
-    bool isDead() { return mReferences.empty(); }
+    bool isDead() override { return mReferences.empty(); }
 
-    virtual LLViewerTexture *getTexture();
+    LLViewerTexture *getTexture() override;
     virtual void dirtyTextures(const std::set<LLViewerFetchedTexture*>& textures);
 
     virtual void enqueue(LLFace *face);
     virtual bool addFace(LLFace *face);
     virtual bool removeFace(LLFace *face);
 
-    virtual bool verify() const;        // Verify that all data in the draw pool is correct!
+    bool verify() const override;        // Verify that all data in the draw pool is correct!
 
-    virtual void resetDrawOrders();
+    void resetDrawOrders() override;
     void resetAll();
 
     void destroy();
@@ -431,10 +444,10 @@ public:
 
     void printDebugInfo() const;
 
-    bool isFacePool() { return true; }
+    bool isFacePool() override { return true; }
 
     // call drawIndexed on every draw face
-    void pushFaceGeometry();
+    void pushFaceGeometry() override;
 
     friend class LLFace;
     friend class LLPipeline;

--- a/indra/newview/lldrawpoolalpha.cpp
+++ b/indra/newview/lldrawpoolalpha.cpp
@@ -915,6 +915,7 @@ void LLDrawPoolAlpha::endMotionBlurPass(S32 pass)
 void LLDrawPoolAlpha::renderMotionBlur(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED;
+    LLGLEnable cull(GL_CULL_FACE);
     pushVelocityBatchesTextured(LLRenderPass::PASS_ALPHA);
 
     gVelocityAlphaProgram.bind(true);

--- a/indra/newview/lldrawpoolalpha.cpp
+++ b/indra/newview/lldrawpoolalpha.cpp
@@ -888,3 +888,38 @@ void LLDrawPoolAlpha::renderAlpha(U32 mask, bool depth_only, bool rigged)
         gPipeline.enableLightsDynamic();
     }
 }
+
+S32 LLDrawPoolAlpha::getNumMotionBlurPasses()
+{
+    // Only render velocity from one instance to avoid double-stamping mLastModelMatrix
+    if (getType() == LLDrawPool::POOL_ALPHA_PRE_WATER)
+        return 0;
+    return 1;
+}
+
+void LLDrawPoolAlpha::beginMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityAlphaProgram.bind();
+    gVelocityAlphaProgram.uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    gVelocityAlphaProgram.uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    gVelocityAlphaProgram.uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+}
+
+void LLDrawPoolAlpha::endMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityAlphaProgram.unbind();
+}
+
+void LLDrawPoolAlpha::renderMotionBlur(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    pushVelocityBatchesTextured(LLRenderPass::PASS_ALPHA);
+
+    gVelocityAlphaProgram.bind(true);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+    pushRiggedVelocityBatchesTextured(LLRenderPass::PASS_ALPHA_RIGGED);
+}

--- a/indra/newview/lldrawpoolalpha.h
+++ b/indra/newview/lldrawpoolalpha.h
@@ -49,17 +49,22 @@ public:
                             LLVertexBuffer::MAP_COLOR |
                             LLVertexBuffer::MAP_TEXCOORD0
     };
-    virtual U32 getVertexDataMask() { return VERTEX_DATA_MASK; }
+    U32 getVertexDataMask() override { return VERTEX_DATA_MASK; }
 
     LLDrawPoolAlpha(U32 type);
-    /*virtual*/ ~LLDrawPoolAlpha();
+    ~LLDrawPoolAlpha() override;
 
-    /*virtual*/ S32 getNumPostDeferredPasses();
-    /*virtual*/ void renderPostDeferred(S32 pass);
-    /*virtual*/ S32  getNumPasses() { return 1; }
+    S32 getNumPostDeferredPasses() override;
+    void renderPostDeferred(S32 pass) override;
+    S32 getNumPasses() override { return 1; }
+
+    S32 getNumMotionBlurPasses() override;
+    void beginMotionBlurPass(S32 pass) override;
+    void endMotionBlurPass(S32 pass) override;
+    void renderMotionBlur(S32 pass) override;
 
     void forwardRender(bool write_depth = false);
-    /*virtual*/ void prerender();
+    void prerender() override;
 
     void renderDebugAlpha();
 

--- a/indra/newview/lldrawpoolavatar.cpp
+++ b/indra/newview/lldrawpoolavatar.cpp
@@ -447,6 +447,7 @@ void LLDrawPoolAvatar::endMotionBlurPass(S32 pass)
 void LLDrawPoolAvatar::renderMotionBlur(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_AVATAR;
+    LLGLEnable cull(GL_CULL_FACE);
 
     if (mDrawFace.empty())
     {

--- a/indra/newview/lldrawpoolavatar.cpp
+++ b/indra/newview/lldrawpoolavatar.cpp
@@ -408,6 +408,73 @@ void LLDrawPoolAvatar::renderShadow(S32 pass)
     }
 }
 
+S32 LLDrawPoolAvatar::getNumMotionBlurPasses()
+{
+    return 1;
+}
+
+void LLDrawPoolAvatar::beginMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_AVATAR;
+
+    sVertexProgram = &gAvatarVelocityProgram;
+
+    if (sShaderLevel > 0)
+    {
+        sRenderingSkinned = true;
+        sVertexProgram->bind();
+    }
+
+    sVertexProgram->uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    sVertexProgram->uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    sVertexProgram->uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+
+    gGL.diffuseColor4f(1, 1, 1, 1);
+}
+
+void LLDrawPoolAvatar::endMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_AVATAR;
+
+    if (sShaderLevel > 0)
+    {
+        sVertexProgram->unbind();
+    }
+    sVertexProgram = NULL;
+    sRenderingSkinned = false;
+}
+
+void LLDrawPoolAvatar::renderMotionBlur(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_AVATAR;
+
+    if (mDrawFace.empty())
+    {
+        return;
+    }
+
+    const LLFace* facep = mDrawFace[0];
+    if (!facep->getDrawable())
+    {
+        return;
+    }
+    LLVOAvatar* avatarp = (LLVOAvatar*)facep->getDrawable()->getVObj().get();
+
+    if (avatarp->isDead() || avatarp->isUIAvatar() || avatarp->mDrawable.isNull())
+    {
+        return;
+    }
+
+    LLVOAvatar::AvatarOverallAppearance oa = avatarp->getOverallAppearance();
+    bool impostor = !LLPipeline::sImpostorRender && avatarp->isImpostor();
+    if (avatarp->isTooSlow() || impostor || (oa == LLVOAvatar::AOA_INVISIBLE))
+    {
+        return;
+    }
+
+    avatarp->renderSkinned();
+}
+
 S32 LLDrawPoolAvatar::getNumPasses()
 {
     return 3;

--- a/indra/newview/lldrawpoolavatar.h
+++ b/indra/newview/lldrawpoolavatar.h
@@ -54,7 +54,7 @@ public:
     };
 
     ~LLDrawPoolAvatar();
-    /*virtual*/ bool isDead();
+    bool isDead() override;
 
 typedef enum
     {
@@ -64,34 +64,39 @@ typedef enum
         NUM_SHADOW_PASSES
     } eShadowPass;
 
-    virtual U32 getVertexDataMask() { return VERTEX_DATA_MASK; }
+    U32 getVertexDataMask() override { return VERTEX_DATA_MASK; }
 
-    virtual S32 getShaderLevel() const;
+    S32 getShaderLevel() const override;
 
     LLDrawPoolAvatar(U32 type);
 
     static LLMatrix4& getModelView();
 
-    /*virtual*/ S32  getNumPasses();
-    /*virtual*/ void beginRenderPass(S32 pass);
-    /*virtual*/ void endRenderPass(S32 pass);
-    /*virtual*/ void prerender();
-    /*virtual*/ void render(S32 pass = 0);
+    S32  getNumPasses() override;
+    void beginRenderPass(S32 pass) override;
+    void endRenderPass(S32 pass) override;
+    void prerender() override;
+    void render(S32 pass = 0) override;
 
-    /*virtual*/ S32 getNumDeferredPasses();
-    /*virtual*/ void beginDeferredPass(S32 pass);
-    /*virtual*/ void endDeferredPass(S32 pass);
-    /*virtual*/ void renderDeferred(S32 pass);
+    S32 getNumDeferredPasses() override;
+    void beginDeferredPass(S32 pass) override;
+    void endDeferredPass(S32 pass) override;
+    void renderDeferred(S32 pass) override;
 
-    /*virtual*/ S32 getNumPostDeferredPasses();
-    /*virtual*/ void beginPostDeferredPass(S32 pass);
-    /*virtual*/ void endPostDeferredPass(S32 pass);
-    /*virtual*/ void renderPostDeferred(S32 pass);
+    S32 getNumPostDeferredPasses() override;
+    void beginPostDeferredPass(S32 pass) override;
+    void endPostDeferredPass(S32 pass) override;
+    void renderPostDeferred(S32 pass) override;
 
-    /*virtual*/ S32 getNumShadowPasses();
-    /*virtual*/ void beginShadowPass(S32 pass);
-    /*virtual*/ void endShadowPass(S32 pass);
-    /*virtual*/ void renderShadow(S32 pass);
+    S32 getNumShadowPasses() override;
+    void beginShadowPass(S32 pass) override;
+    void endShadowPass(S32 pass) override;
+    void renderShadow(S32 pass) override;
+
+    S32 getNumMotionBlurPasses() override;
+    void beginMotionBlurPass(S32 pass) override;
+    void endMotionBlurPass(S32 pass) override;
+    void renderMotionBlur(S32 pass) override;
 
     void beginRigid();
     void beginImpostor();
@@ -109,8 +114,8 @@ typedef enum
     void endDeferredImpostor();
     void endDeferredSkinned();
 
-    /*virtual*/ LLViewerTexture *getDebugTexture();
-    /*virtual*/ LLColor3 getDebugColor() const; // For AGP debug display
+    LLViewerTexture *getDebugTexture() override;
+    LLColor3 getDebugColor() const; // For AGP debug display
 
     void renderAvatars(LLVOAvatar *single_avatar, S32 pass = -1); // renders only one avatar if single_avatar is not null.
 

--- a/indra/newview/lldrawpoolbump.cpp
+++ b/indra/newview/lldrawpoolbump.cpp
@@ -592,6 +592,38 @@ void LLDrawPoolBump::renderDeferred(S32 pass)
 }
 
 
+S32 LLDrawPoolBump::getNumMotionBlurPasses()
+{
+    return 1;
+}
+
+void LLDrawPoolBump::beginMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityProgram.bind();
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    gVelocityProgram.uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+}
+
+void LLDrawPoolBump::endMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityProgram.unbind();
+}
+
+void LLDrawPoolBump::renderMotionBlur(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    pushVelocityBatches(LLRenderPass::PASS_BUMP);
+
+    gVelocityProgram.bind(true);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_BUMP_RIGGED);
+}
+
 void LLDrawPoolBump::renderPostDeferred(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DRAWPOOL;

--- a/indra/newview/lldrawpoolbump.cpp
+++ b/indra/newview/lldrawpoolbump.cpp
@@ -615,6 +615,7 @@ void LLDrawPoolBump::endMotionBlurPass(S32 pass)
 void LLDrawPoolBump::renderMotionBlur(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED;
+    LLGLEnable cull(GL_CULL_FACE);
     pushVelocityBatches(LLRenderPass::PASS_BUMP);
 
     gVelocityProgram.bind(true);

--- a/indra/newview/lldrawpoolbump.h
+++ b/indra/newview/lldrawpoolbump.h
@@ -48,11 +48,11 @@ public:
     static U32 sVertexMask;
     bool mShiny;
 
-    virtual U32 getVertexDataMask() override { return sVertexMask; }
+    U32 getVertexDataMask() override { return sVertexMask; }
 
     LLDrawPoolBump();
 
-    /*virtual*/ void prerender() override;
+    void prerender() override;
 
     void pushBumpBatches(U32 type);
     void renderGroup(LLSpatialGroup* group, U32 type, bool texture) override;
@@ -70,11 +70,16 @@ public:
     static void bindCubeMap(LLGLSLShader* shader, S32 shader_level, S32& diffuse_channel, S32& cube_channel);
     static void unbindCubeMap(LLGLSLShader* shader, S32 shader_level, S32& diffuse_channel, S32& cube_channel);
 
-    virtual S32 getNumDeferredPasses() override;
-    /*virtual*/ void renderDeferred(S32 pass) override;
+    S32 getNumDeferredPasses() override;
+    void renderDeferred(S32 pass) override;
 
-    virtual S32 getNumPostDeferredPasses() override { return 1; }
-    /*virtual*/ void renderPostDeferred(S32 pass) override;
+    S32 getNumMotionBlurPasses() override;
+    void beginMotionBlurPass(S32 pass) override;
+    void endMotionBlurPass(S32 pass) override;
+    void renderMotionBlur(S32 pass) override;
+
+    S32 getNumPostDeferredPasses() override { return 1; }
+    void renderPostDeferred(S32 pass) override;
 
     static bool bindBumpMap(LLDrawInfo& params, S32 channel = -2);
     static bool bindBumpMap(LLFace* face, S32 channel = -2);

--- a/indra/newview/lldrawpoolmaterials.cpp
+++ b/indra/newview/lldrawpoolmaterials.cpp
@@ -312,6 +312,7 @@ void LLDrawPoolMaterials::endMotionBlurPass(S32 pass)
 void LLDrawPoolMaterials::renderMotionBlur(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED;
+    LLGLEnable cull(GL_CULL_FACE);
 
     // Static passes
     pushVelocityBatches(LLRenderPass::PASS_MATERIAL);

--- a/indra/newview/lldrawpoolmaterials.cpp
+++ b/indra/newview/lldrawpoolmaterials.cpp
@@ -29,6 +29,7 @@
 
 #include "lldrawpoolmaterials.h"
 #include "llviewershadermgr.h"
+#include "llrender.h"
 #include "pipeline.h"
 #include "llglcommonfunc.h"
 #include "llvoavatar.h"
@@ -286,4 +287,61 @@ void LLDrawPoolMaterials::renderDeferred(S32 pass)
             gGL.matrixMode(LLRender::MM_MODELVIEW);
         }
     }
+}
+
+S32 LLDrawPoolMaterials::getNumMotionBlurPasses()
+{
+    return 1;
+}
+
+void LLDrawPoolMaterials::beginMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityProgram.bind();
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    gVelocityProgram.uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+}
+
+void LLDrawPoolMaterials::endMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityProgram.unbind();
+}
+
+void LLDrawPoolMaterials::renderMotionBlur(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+
+    // Static passes
+    pushVelocityBatches(LLRenderPass::PASS_MATERIAL);
+    pushVelocityBatches(LLRenderPass::PASS_MATERIAL_ALPHA_MASK);
+    pushVelocityBatches(LLRenderPass::PASS_MATERIAL_ALPHA_EMISSIVE);
+    pushVelocityBatches(LLRenderPass::PASS_SPECMAP);
+    pushVelocityBatches(LLRenderPass::PASS_SPECMAP_MASK);
+    pushVelocityBatches(LLRenderPass::PASS_SPECMAP_EMISSIVE);
+    pushVelocityBatches(LLRenderPass::PASS_NORMMAP);
+    pushVelocityBatches(LLRenderPass::PASS_NORMMAP_MASK);
+    pushVelocityBatches(LLRenderPass::PASS_NORMMAP_EMISSIVE);
+    pushVelocityBatches(LLRenderPass::PASS_NORMSPEC);
+    pushVelocityBatches(LLRenderPass::PASS_NORMSPEC_MASK);
+    pushVelocityBatches(LLRenderPass::PASS_NORMSPEC_EMISSIVE);
+
+    // Rigged passes
+    gVelocityProgram.bind(true);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_MATERIAL_RIGGED);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_MATERIAL_ALPHA_MASK_RIGGED);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_MATERIAL_ALPHA_EMISSIVE_RIGGED);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_SPECMAP_RIGGED);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_SPECMAP_MASK_RIGGED);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_SPECMAP_EMISSIVE_RIGGED);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_NORMMAP_RIGGED);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_NORMMAP_MASK_RIGGED);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_NORMMAP_EMISSIVE_RIGGED);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_NORMSPEC_RIGGED);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_NORMSPEC_MASK_RIGGED);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_NORMSPEC_EMISSIVE_RIGGED);
 }

--- a/indra/newview/lldrawpoolmaterials.h
+++ b/indra/newview/lldrawpoolmaterials.h
@@ -65,6 +65,11 @@ public:
     void beginDeferredPass(S32 pass) override;
     void endDeferredPass(S32 pass) override;
     void renderDeferred(S32 pass) override;
+
+    S32 getNumMotionBlurPasses() override;
+    void beginMotionBlurPass(S32 pass) override;
+    void endMotionBlurPass(S32 pass) override;
+    void renderMotionBlur(S32 pass) override;
 };
 
 #endif //LL_LLDRAWPOOLMATERIALS_H

--- a/indra/newview/lldrawpoolpbropaque.cpp
+++ b/indra/newview/lldrawpoolpbropaque.cpp
@@ -29,6 +29,7 @@
 #include "lldrawpool.h"
 #include "lldrawpoolpbropaque.h"
 #include "llviewershadermgr.h"
+#include "llrender.h"
 #include "pipeline.h"
 #include "gltfscenemanager.h"
 
@@ -91,5 +92,54 @@ void LLDrawPoolGLTFPBR::renderPostDeferred(S32 pass)
 
         gGL.setColorMask(true, false);
     }
+}
+
+S32 LLDrawPoolGLTFPBR::getNumMotionBlurPasses()
+{
+    return 1;
+}
+
+void LLDrawPoolGLTFPBR::beginMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    LLGLSLShader& shader = (mRenderType == LLPipeline::RENDER_TYPE_PASS_GLTF_PBR_ALPHA_MASK)
+        ? gVelocityAlphaProgram : gVelocityProgram;
+    shader.bind();
+    shader.uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    shader.uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    shader.uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+}
+
+void LLDrawPoolGLTFPBR::endMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    if (mRenderType == LLPipeline::RENDER_TYPE_PASS_GLTF_PBR_ALPHA_MASK)
+        gVelocityAlphaProgram.unbind();
+    else
+        gVelocityProgram.unbind();
+}
+
+void LLDrawPoolGLTFPBR::renderMotionBlur(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+
+    bool alpha_mask = (mRenderType == LLPipeline::RENDER_TYPE_PASS_GLTF_PBR_ALPHA_MASK);
+
+    // Static pass for this pool type only
+    if (alpha_mask)
+        pushVelocityBatchesTextured(mRenderType);
+    else
+        pushVelocityBatches(mRenderType);
+
+    // Rigged pass for this pool type only
+    LLGLSLShader& shader = alpha_mask ? gVelocityAlphaProgram : gVelocityProgram;
+    shader.bind(true);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+    if (alpha_mask)
+        pushRiggedVelocityBatchesTextured(mRenderType + 1);
+    else
+        pushRiggedVelocityBatches(mRenderType + 1);
 }
 

--- a/indra/newview/lldrawpoolpbropaque.cpp
+++ b/indra/newview/lldrawpoolpbropaque.cpp
@@ -122,6 +122,7 @@ void LLDrawPoolGLTFPBR::endMotionBlurPass(S32 pass)
 void LLDrawPoolGLTFPBR::renderMotionBlur(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED;
+    LLGLEnable cull(GL_CULL_FACE);
 
     bool alpha_mask = (mRenderType == LLPipeline::RENDER_TYPE_PASS_GLTF_PBR_ALPHA_MASK);
 

--- a/indra/newview/lldrawpoolpbropaque.h
+++ b/indra/newview/lldrawpoolpbropaque.h
@@ -41,6 +41,11 @@ public:
 
     S32 getNumPostDeferredPasses() override;
     void renderPostDeferred(S32 pass) override;
+
+    S32 getNumMotionBlurPasses() override;
+    void beginMotionBlurPass(S32 pass) override;
+    void endMotionBlurPass(S32 pass) override;
+    void renderMotionBlur(S32 pass) override;
 };
 
 #endif // LL_LLDRAWPOOLPBROPAQUE_H

--- a/indra/newview/lldrawpoolsimple.cpp
+++ b/indra/newview/lldrawpoolsimple.cpp
@@ -181,6 +181,169 @@ void LLDrawPoolFullbright::renderPostDeferred(S32 pass)
     }
 }
 
+// ============================================
+// Motion Blur Velocity Passes
+// ============================================
+
+// LLDrawPoolSimple
+S32 LLDrawPoolSimple::getNumMotionBlurPasses()
+{
+    return 1;
+}
+
+void LLDrawPoolSimple::beginMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityProgram.bind();
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    gVelocityProgram.uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+}
+
+void LLDrawPoolSimple::endMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityProgram.unbind();
+}
+
+void LLDrawPoolSimple::renderMotionBlur(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    pushVelocityBatches(LLRenderPass::PASS_SIMPLE);
+
+    gVelocityProgram.bind(true);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_SIMPLE_RIGGED);
+}
+
+// LLDrawPoolGrass
+S32 LLDrawPoolGrass::getNumMotionBlurPasses()
+{
+    return 1;
+}
+
+void LLDrawPoolGrass::beginMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityProgram.bind();
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    gVelocityProgram.uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+}
+
+void LLDrawPoolGrass::endMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityProgram.unbind();
+}
+
+void LLDrawPoolGrass::renderMotionBlur(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    pushVelocityBatches(LLRenderPass::PASS_GRASS);
+}
+
+// LLDrawPoolAlphaMask
+S32 LLDrawPoolAlphaMask::getNumMotionBlurPasses()
+{
+    return 1;
+}
+
+void LLDrawPoolAlphaMask::beginMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityAlphaProgram.bind();
+    gVelocityAlphaProgram.uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    gVelocityAlphaProgram.uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    gVelocityAlphaProgram.uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+}
+
+void LLDrawPoolAlphaMask::endMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityAlphaProgram.unbind();
+}
+
+void LLDrawPoolAlphaMask::renderMotionBlur(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    pushVelocityBatchesTextured(LLRenderPass::PASS_ALPHA_MASK);
+
+    gVelocityAlphaProgram.bind(true);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+    pushRiggedVelocityBatchesTextured(LLRenderPass::PASS_ALPHA_MASK_RIGGED);
+}
+
+// LLDrawPoolFullbrightAlphaMask
+S32 LLDrawPoolFullbrightAlphaMask::getNumMotionBlurPasses()
+{
+    return 1;
+}
+
+void LLDrawPoolFullbrightAlphaMask::beginMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityAlphaProgram.bind();
+    gVelocityAlphaProgram.uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    gVelocityAlphaProgram.uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    gVelocityAlphaProgram.uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+}
+
+void LLDrawPoolFullbrightAlphaMask::endMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityAlphaProgram.unbind();
+}
+
+void LLDrawPoolFullbrightAlphaMask::renderMotionBlur(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    pushVelocityBatchesTextured(LLRenderPass::PASS_FULLBRIGHT_ALPHA_MASK);
+
+    gVelocityAlphaProgram.bind(true);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+    pushRiggedVelocityBatchesTextured(LLRenderPass::PASS_FULLBRIGHT_ALPHA_MASK_RIGGED);
+}
+
+// LLDrawPoolFullbright
+S32 LLDrawPoolFullbright::getNumMotionBlurPasses()
+{
+    return 1;
+}
+
+void LLDrawPoolFullbright::beginMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityProgram.bind();
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    gVelocityProgram.uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+}
+
+void LLDrawPoolFullbright::endMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    gVelocityProgram.unbind();
+}
+
+void LLDrawPoolFullbright::renderMotionBlur(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+    pushVelocityBatches(LLRenderPass::PASS_FULLBRIGHT);
+
+    gVelocityProgram.bind(true);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    LLGLSLShader::sCurBoundShaderPtr->uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+    pushRiggedVelocityBatches(LLRenderPass::PASS_FULLBRIGHT_RIGGED);
+}
+
 void LLDrawPoolFullbrightAlphaMask::renderPostDeferred(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DRAWPOOL; //LL_RECORD_BLOCK_TIME(FTM_RENDER_FULLBRIGHT);

--- a/indra/newview/lldrawpoolsimple.cpp
+++ b/indra/newview/lldrawpoolsimple.cpp
@@ -209,6 +209,7 @@ void LLDrawPoolSimple::endMotionBlurPass(S32 pass)
 void LLDrawPoolSimple::renderMotionBlur(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED;
+    LLGLEnable cull(GL_CULL_FACE);
     pushVelocityBatches(LLRenderPass::PASS_SIMPLE);
 
     gVelocityProgram.bind(true);
@@ -242,6 +243,7 @@ void LLDrawPoolGrass::endMotionBlurPass(S32 pass)
 void LLDrawPoolGrass::renderMotionBlur(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED;
+    LLGLEnable cull(GL_CULL_FACE);
     pushVelocityBatches(LLRenderPass::PASS_GRASS);
 }
 
@@ -269,6 +271,7 @@ void LLDrawPoolAlphaMask::endMotionBlurPass(S32 pass)
 void LLDrawPoolAlphaMask::renderMotionBlur(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED;
+    LLGLEnable cull(GL_CULL_FACE);
     pushVelocityBatchesTextured(LLRenderPass::PASS_ALPHA_MASK);
 
     gVelocityAlphaProgram.bind(true);
@@ -302,6 +305,7 @@ void LLDrawPoolFullbrightAlphaMask::endMotionBlurPass(S32 pass)
 void LLDrawPoolFullbrightAlphaMask::renderMotionBlur(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED;
+    LLGLEnable cull(GL_CULL_FACE);
     pushVelocityBatchesTextured(LLRenderPass::PASS_FULLBRIGHT_ALPHA_MASK);
 
     gVelocityAlphaProgram.bind(true);
@@ -335,6 +339,7 @@ void LLDrawPoolFullbright::endMotionBlurPass(S32 pass)
 void LLDrawPoolFullbright::renderMotionBlur(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED;
+    LLGLEnable cull(GL_CULL_FACE);
     pushVelocityBatches(LLRenderPass::PASS_FULLBRIGHT);
 
     gVelocityProgram.bind(true);

--- a/indra/newview/lldrawpoolsimple.h
+++ b/indra/newview/lldrawpoolsimple.h
@@ -47,6 +47,11 @@ public:
 
     S32 getNumDeferredPasses() override;
     void renderDeferred(S32 pass) override;
+
+    S32 getNumMotionBlurPasses() override;
+    void beginMotionBlurPass(S32 pass) override;
+    void endMotionBlurPass(S32 pass) override;
+    void renderMotionBlur(S32 pass) override;
 };
 
 class LLDrawPoolGrass final : public LLRenderPass
@@ -65,6 +70,11 @@ public:
 
     S32 getNumDeferredPasses() override { return 1; }
     void renderDeferred(S32 pass) override;
+
+    S32 getNumMotionBlurPasses() override;
+    void beginMotionBlurPass(S32 pass) override;
+    void endMotionBlurPass(S32 pass) override;
+    void renderMotionBlur(S32 pass) override;
 };
 
 class LLDrawPoolAlphaMask final : public LLRenderPass
@@ -83,6 +93,11 @@ public:
 
     S32 getNumDeferredPasses() override { return 1; }
     void renderDeferred(S32 pass) override;
+
+    S32 getNumMotionBlurPasses() override;
+    void beginMotionBlurPass(S32 pass) override;
+    void endMotionBlurPass(S32 pass) override;
+    void renderMotionBlur(S32 pass) override;
 };
 
 class LLDrawPoolFullbrightAlphaMask final : public LLRenderPass
@@ -100,6 +115,11 @@ public:
 
     S32 getNumPostDeferredPasses() override { return 1; }
     void renderPostDeferred(S32 pass) override;
+
+    S32 getNumMotionBlurPasses() override;
+    void beginMotionBlurPass(S32 pass) override;
+    void endMotionBlurPass(S32 pass) override;
+    void renderMotionBlur(S32 pass) override;
 };
 
 
@@ -118,6 +138,11 @@ public:
 
     S32 getNumPostDeferredPasses() override { return 1; }
     void renderPostDeferred(S32 pass) override;
+
+    S32 getNumMotionBlurPasses() override;
+    void beginMotionBlurPass(S32 pass) override;
+    void endMotionBlurPass(S32 pass) override;
+    void renderMotionBlur(S32 pass) override;
 };
 
 class LLDrawPoolGlow final : public LLRenderPass

--- a/indra/newview/lldrawpoolterrain.cpp
+++ b/indra/newview/lldrawpoolterrain.cpp
@@ -201,6 +201,59 @@ void LLDrawPoolTerrain::drawLoop()
     }
 }
 
+//============================================
+// motion blur implementation
+//============================================
+S32 LLDrawPoolTerrain::getNumMotionBlurPasses()
+{
+    return 1;
+}
+
+void LLDrawPoolTerrain::beginMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_DRAWPOOL;
+
+    gVelocityProgram.bind();
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    gVelocityProgram.uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+}
+
+void LLDrawPoolTerrain::endMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_DRAWPOOL;
+
+    gVelocityProgram.unbind();
+}
+
+void LLDrawPoolTerrain::renderMotionBlur(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_DRAWPOOL;
+
+    if (mDrawFace.empty())
+    {
+        return;
+    }
+
+    for (std::vector<LLFace*>::iterator iter = mDrawFace.begin();
+         iter != mDrawFace.end(); iter++)
+    {
+        LLFace *facep = *iter;
+        LLDrawable* drawable = facep->getDrawable();
+        if (!drawable) continue;
+
+        LLMatrix4* model_matrix = &(drawable->getRegion()->mRenderMatrix);
+
+        llassert(gGL.getMatrixMode() == LLRender::MM_MODELVIEW);
+        LLRenderPass::applyModelMatrix(model_matrix);
+
+        LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::CURRENT_OBJECT_MATRIX, 1, GL_FALSE, (GLfloat*)model_matrix->mMatrix);
+        LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::LAST_OBJECT_MATRIX, 1, GL_FALSE, (GLfloat*)model_matrix->mMatrix);
+
+        facep->renderIndexed();
+    }
+}
+
 void LLDrawPoolTerrain::renderFullShader()
 {
     const bool use_local_materials = gLocalTerrainMaterials.makeMaterialsReady(true, false);

--- a/indra/newview/lldrawpoolterrain.cpp
+++ b/indra/newview/lldrawpoolterrain.cpp
@@ -229,6 +229,7 @@ void LLDrawPoolTerrain::endMotionBlurPass(S32 pass)
 void LLDrawPoolTerrain::renderMotionBlur(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DRAWPOOL;
+    LLGLEnable cull(GL_CULL_FACE);
 
     if (mDrawFace.empty())
     {

--- a/indra/newview/lldrawpoolterrain.h
+++ b/indra/newview/lldrawpoolterrain.h
@@ -42,25 +42,30 @@ public:
                     LLVertexBuffer::MAP_TEXCOORD1
     };
 
-    virtual U32 getVertexDataMask();
+    U32 getVertexDataMask() override;
     LLDrawPoolTerrain(LLViewerTexture *texturep);
     virtual ~LLDrawPoolTerrain();
 
-    /*virtual*/ S32 getNumDeferredPasses() { return 1; }
-    /*virtual*/ void beginDeferredPass(S32 pass);
-    /*virtual*/ void endDeferredPass(S32 pass);
-    /*virtual*/ void renderDeferred(S32 pass);
+    S32 getNumDeferredPasses() override { return 1; }
+    void beginDeferredPass(S32 pass) override;
+    void endDeferredPass(S32 pass) override;
+    void renderDeferred(S32 pass) override;
 
-    /*virtual*/ S32 getNumShadowPasses() { return 1; }
-    /*virtual*/ void beginShadowPass(S32 pass);
-    /*virtual*/ void endShadowPass(S32 pass);
-    /*virtual*/ void renderShadow(S32 pass);
+    S32 getNumShadowPasses() override { return 1; }
+    void beginShadowPass(S32 pass) override;
+    void endShadowPass(S32 pass) override;
+    void renderShadow(S32 pass) override;
 
-    /*virtual*/ void prerender();
-    /*virtual*/ void dirtyTextures(const std::set<LLViewerFetchedTexture*>& textures);
-    /*virtual*/ LLViewerTexture *getTexture();
-    /*virtual*/ LLViewerTexture *getDebugTexture();
-    /*virtual*/ LLColor3 getDebugColor() const; // For AGP debug display
+    S32 getNumMotionBlurPasses() override;
+    void beginMotionBlurPass(S32 pass) override;
+    void endMotionBlurPass(S32 pass) override;
+    void renderMotionBlur(S32 pass) override;
+
+    void prerender() override;
+    void dirtyTextures(const std::set<LLViewerFetchedTexture*>& textures) override;
+    LLViewerTexture *getTexture() override;
+    LLViewerTexture *getDebugTexture() override;
+    LLColor3 getDebugColor() const; // For AGP debug display
 
     LLPointer<LLViewerTexture> mAlphaRampImagep;
     LLPointer<LLViewerTexture> m2DAlphaRampImagep;

--- a/indra/newview/lldrawpooltree.cpp
+++ b/indra/newview/lldrawpooltree.cpp
@@ -161,6 +161,7 @@ void LLDrawPoolTree::endMotionBlurPass(S32 pass)
 void LLDrawPoolTree::renderMotionBlur(S32 pass)
 {
     LL_PROFILE_ZONE_SCOPED;
+    LLGLEnable cull(GL_CULL_FACE);
 
     if (mDrawFace.empty())
     {

--- a/indra/newview/lldrawpooltree.cpp
+++ b/indra/newview/lldrawpooltree.cpp
@@ -133,6 +133,62 @@ void LLDrawPoolTree::endShadowPass(S32 pass)
     gDeferredTreeShadowProgram.unbind();
 }
 
+//============================================
+// motion blur implementation
+//============================================
+S32 LLDrawPoolTree::getNumMotionBlurPasses()
+{
+    return 1;
+}
+
+void LLDrawPoolTree::beginMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+
+    gVelocityProgram.bind();
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::LAST_MODELVIEW_MATRIX, 1, GL_FALSE, gGLLastModelView);
+    gVelocityProgram.uniformMatrix4fv(LLShaderMgr::CURRENT_MODELVIEW_MATRIX, 1, GL_FALSE, gGLModelView);
+    gVelocityProgram.uniform4f(LLShaderMgr::VIEWPORT, (F32)gGLViewport[0], (F32)gGLViewport[1], (F32)gGLViewport[2], (F32)gGLViewport[3]);
+}
+
+void LLDrawPoolTree::endMotionBlurPass(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+
+    gVelocityProgram.unbind();
+}
+
+void LLDrawPoolTree::renderMotionBlur(S32 pass)
+{
+    LL_PROFILE_ZONE_SCOPED;
+
+    if (mDrawFace.empty())
+    {
+        return;
+    }
+
+    for (std::vector<LLFace*>::iterator iter = mDrawFace.begin();
+        iter != mDrawFace.end(); iter++)
+    {
+        LLFace* face = *iter;
+        LLVertexBuffer* buff = face->getVertexBuffer();
+
+        if (buff)
+        {
+            LLMatrix4* model_matrix = &(face->getDrawable()->getRegion()->mRenderMatrix);
+
+            llassert(gGL.getMatrixMode() == LLRender::MM_MODELVIEW);
+            LLRenderPass::applyModelMatrix(model_matrix);
+
+            LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::CURRENT_OBJECT_MATRIX, 1, GL_FALSE, (GLfloat*)model_matrix->mMatrix);
+            LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLShaderMgr::LAST_OBJECT_MATRIX, 1, GL_FALSE, (GLfloat*)model_matrix->mMatrix);
+
+            buff->setBuffer();
+            buff->drawRange(LLRender::TRIANGLES, 0, buff->getNumVerts() - 1, buff->getNumIndices(), 0);
+        }
+    }
+}
+
 bool LLDrawPoolTree::verify() const
 {
     return true;

--- a/indra/newview/lldrawpooltree.h
+++ b/indra/newview/lldrawpooltree.h
@@ -41,23 +41,28 @@ public:
                             LLVertexBuffer::MAP_TEXCOORD0
     };
 
-    virtual U32 getVertexDataMask() { return VERTEX_DATA_MASK; }
+    U32 getVertexDataMask() override { return VERTEX_DATA_MASK; }
 
     LLDrawPoolTree(LLViewerTexture *texturep);
 
-    /*virtual*/ S32 getNumDeferredPasses() { return 1; }
-    /*virtual*/ void beginDeferredPass(S32 pass);
-    /*virtual*/ void endDeferredPass(S32 pass);
-    /*virtual*/ void renderDeferred(S32 pass);
+    S32 getNumDeferredPasses() override { return 1; }
+    void beginDeferredPass(S32 pass) override;
+    void endDeferredPass(S32 pass) override;
+    void renderDeferred(S32 pass) override;
 
-    /*virtual*/ S32 getNumShadowPasses() { return 1; }
-    /*virtual*/ void beginShadowPass(S32 pass);
-    /*virtual*/ void endShadowPass(S32 pass);
-    /*virtual*/ void renderShadow(S32 pass);
+    S32 getNumShadowPasses() override { return 1; }
+    void beginShadowPass(S32 pass) override;
+    void endShadowPass(S32 pass) override;
+    void renderShadow(S32 pass) override;
 
-    /*virtual*/ bool verify() const;
-    /*virtual*/ LLViewerTexture *getTexture();
-    /*virtual*/ LLViewerTexture *getDebugTexture();
+    S32 getNumMotionBlurPasses() override;
+    void beginMotionBlurPass(S32 pass) override;
+    void endMotionBlurPass(S32 pass) override;
+    void renderMotionBlur(S32 pass) override;
+
+    bool verify() const override;
+    LLViewerTexture *getTexture() override;
+    LLViewerTexture *getDebugTexture() override;
     /*virtual*/ LLColor3 getDebugColor() const; // For AGP debug display
 
     static S32 sDiffTex;

--- a/indra/newview/llspatialpartition.h
+++ b/indra/newview/llspatialpartition.h
@@ -101,6 +101,7 @@ public:
     const LLMatrix4* mNormalMapMatrix = nullptr;
     const LLMatrix4* mTextureMatrix = nullptr;
     const LLMatrix4* mModelMatrix = nullptr;
+    LLMatrix4* mLastModelMatrix = nullptr;
 
     LLPointer<LLVOAvatar> mAvatar = nullptr;
     LLMeshSkinInfo* mSkinInfo = nullptr;

--- a/indra/newview/llviewercamera.cpp
+++ b/indra/newview/llviewercamera.cpp
@@ -50,10 +50,13 @@
 #include "llquaternion.h"
 #include "llwindow.h"           // getPixelAspectRatio()
 #include "lltracerecording.h"
+#include "pipeline.h"
 #include "llenvironment.h"
 
 // System includes
 #include <iomanip> // for setprecision
+
+extern bool gCubeSnapshot;
 
 LLTrace::CountStatHandle<> LLViewerCamera::sVelocityStat("camera_velocity");
 LLTrace::CountStatHandle<> LLViewerCamera::sAngularVelocityStat("camera_angular_velocity");
@@ -367,6 +370,20 @@ void LLViewerCamera::setPerspective(bool for_selection,
     calcProjection(z_far); // Update the projection matrix cache
 
     proj_mat *= glm::perspective(fov_y, aspect, z_near, z_far);
+
+    if (LLPipeline::RenderFSAAType == 3 && !for_selection && !gCubeSnapshot)
+    {
+        // SMAA T2x subpixel jitter (alternating ±0.25 pixels)
+        static const float jitters[2][2] = {
+            { 0.25f, -0.25f},   // Frame 0
+            {-0.25f,  0.25f},   // Frame 1
+        };
+        U32 idx = gPipeline.mSMAAFrameIndex & 1;
+        float jx = jitters[idx][0] * 2.0f / (float)width;
+        float jy = jitters[idx][1] * 2.0f / (float)height;
+        proj_mat[2][0] += jx;
+        proj_mat[2][1] += jy;
+    }
 
     gGL.loadMatrix(glm::value_ptr(proj_mat));
 

--- a/indra/newview/llviewercamera.cpp
+++ b/indra/newview/llviewercamera.cpp
@@ -371,7 +371,7 @@ void LLViewerCamera::setPerspective(bool for_selection,
 
     proj_mat *= glm::perspective(fov_y, aspect, z_near, z_far);
 
-    if (LLPipeline::RenderFSAAType == 3 && !for_selection && !gCubeSnapshot)
+    if (LLPipeline::sT2xJitterEnabled && !for_selection && !gCubeSnapshot)
     {
         // SMAA T2x subpixel jitter (alternating ±0.25 pixels)
         static const float jitters[2][2] = {

--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -223,6 +223,7 @@ void display_update_camera()
     }
     LLViewerCamera::getInstance()->setFar(final_far);
     LLVOAvatar::sRenderDistance = llclamp(final_far, 16.f, 256.f);
+    LLPipeline::sT2xJitterEnabled = (LLPipeline::RenderFSAAType == 3);
     gViewerWindow->setup3DRender();
 
     if (!gCubeSnapshot)
@@ -1487,6 +1488,10 @@ void render_ui(F32 zoom_factor, int subfield)
         set_current_modelview(glm::make_mat4(gGLLastModelView));
     }
 
+    // Disable T2x jitter before any projection setup in the UI path.
+    // The main scene projection was jittered; UI/HUD/nametags must not be.
+    LLPipeline::sT2xJitterEnabled = false;
+
     if(LLSceneMonitor::getInstance()->needsUpdate())
     {
         gGL.pushMatrix();
@@ -1498,6 +1503,10 @@ void render_ui(F32 zoom_factor, int subfield)
 
     // apply gamma correction and post effects
     gPipeline.renderFinalize();
+
+    // Reload the projection matrix without jitter for HUD/nametag rendering.
+    // sT2xJitterEnabled is already false, so this produces an unjittered matrix.
+    gViewerWindow->setup3DRender();
 
     {
         LLGLState::checkStates();

--- a/indra/newview/llviewerjoint.cpp
+++ b/indra/newview/llviewerjoint.cpp
@@ -88,7 +88,7 @@ U32 LLViewerJoint::render( F32 pixelArea, bool first_pass, bool is_dummy )
         {
             triangle_count += drawShape( pixelArea, first_pass, is_dummy );
         }
-        else if (LLPipeline::sShadowRender)
+        else if (LLPipeline::sShadowRender || LLPipeline::sVelocityRender)
         {
             triangle_count += drawShape(pixelArea, first_pass, is_dummy );
         }

--- a/indra/newview/llviewerjointmesh.cpp
+++ b/indra/newview/llviewerjointmesh.cpp
@@ -194,6 +194,8 @@ void LLViewerJointMesh::uploadJointMatrices()
             if (LLGLSLShader::sCurBoundShaderPtr == &gAvatarVelocityProgram)
             {
                 LLGLSLShader::sCurBoundShaderPtr->uniform4fv(LLViewerShaderMgr::AVATAR_LAST_MATRIX, 45, mLastMatrixPalette);
+                // Save current palette as "last" for next frame
+                memcpy(mLastMatrixPalette, mat, sizeof(GLfloat) * 45 * 4);
             }
         }
         stop_glerror();

--- a/indra/newview/llviewerjointmesh.cpp
+++ b/indra/newview/llviewerjointmesh.cpp
@@ -178,10 +178,23 @@ void LLViewerJointMesh::uploadJointMatrices()
                 memcpy(mat+offset*4, vector, sizeof(GLfloat)*4);
             }
         }
+        // Save previous frame palette before uploading current
+        if (mLastMatrixPaletteFrame < (S32)gFrameCount - 1)
+        {
+            memcpy(mLastMatrixPalette, mat, sizeof(GLfloat) * 45 * 4);
+        }
+        mLastMatrixPaletteFrame = gFrameCount;
+
         stop_glerror();
         if (LLGLSLShader::sCurBoundShaderPtr)
         {
             LLGLSLShader::sCurBoundShaderPtr->uniform4fv(LLViewerShaderMgr::AVATAR_MATRIX, 45, mat);
+
+            // Upload last frame palette for motion blur
+            if (LLGLSLShader::sCurBoundShaderPtr == &gAvatarVelocityProgram)
+            {
+                LLGLSLShader::sCurBoundShaderPtr->uniform4fv(LLViewerShaderMgr::AVATAR_LAST_MATRIX, 45, mLastMatrixPalette);
+            }
         }
         stop_glerror();
     }

--- a/indra/newview/llviewerjointmesh.h
+++ b/indra/newview/llviewerjointmesh.h
@@ -68,6 +68,10 @@ public:
 
     bool isAnimatable() const override { return false; }
 
+    // Previous frame matrix palette for motion blur
+    F32 mLastMatrixPalette[45 * 4];
+    S32 mLastMatrixPaletteFrame = -1;
+
 private:
 
     //copy mesh into given face's vertex buffer, applying current animation pose

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -209,6 +209,8 @@ LLGLSLShader            gFXAAProgram[4];
 LLGLSLShader            gSMAAEdgeDetectProgram[4];
 LLGLSLShader            gSMAABlendWeightsProgram[4];
 LLGLSLShader            gSMAANeighborhoodBlendProgram[4];
+LLGLSLShader            gSMAANeighborhoodBlendT2xProgram[4];
+LLGLSLShader            gSMAAResolveProgram[4];
 LLGLSLShader            gCASProgram;
 LLGLSLShader            gCASLegacyGammaProgram;
 LLGLSLShader            gDeferredPostNoDoFProgram;
@@ -1161,6 +1163,8 @@ bool LLViewerShaderMgr::loadShadersDeferred()
             gSMAAEdgeDetectProgram[i].unload();
             gSMAABlendWeightsProgram[i].unload();
             gSMAANeighborhoodBlendProgram[i].unload();
+            gSMAANeighborhoodBlendT2xProgram[i].unload();
+            gSMAAResolveProgram[i].unload();
         }
         gCASProgram.unload();
         gCASLegacyGammaProgram.unload();
@@ -2793,6 +2797,81 @@ bool LLViewerShaderMgr::loadShadersDeferred()
                 gSMAAEdgeDetectProgram[i].unload();
                 gSMAABlendWeightsProgram[i].unload();
                 gSMAANeighborhoodBlendProgram[i].unload();
+            }
+        }
+
+        // SMAA T2x variants: neighborhood blend with reprojection and temporal resolve
+        if (!failed)
+        {
+            int t2x_i = 0;
+            bool t2x_failed = false;
+            for (const auto& smaa_pair : quality_levels)
+            {
+                std::map<std::string, std::string> t2x_defines;
+                if (gGLManager.mGLVersion >= 4.f)
+                    t2x_defines.emplace("SMAA_GLSL_4", "1");
+                else if (gGLManager.mGLVersion >= 3.1f)
+                    t2x_defines.emplace("SMAA_GLSL_3", "1");
+                else
+                    t2x_defines.emplace("SMAA_GLSL_2", "1");
+                t2x_defines.emplace("SMAA_PREDICATION", "0");
+                t2x_defines.emplace("SMAA_REPROJECTION", "1");
+                t2x_defines.emplace("SMAA_REPROJECTION_WEIGHT_SCALE", "10.0");
+                t2x_defines.emplace(smaa_pair.first, "1");
+
+                if (success)
+                {
+                    gSMAANeighborhoodBlendT2xProgram[t2x_i].mName = llformat("SMAA T2x Neighborhood Blending (%s)", smaa_pair.second.c_str());
+                    gSMAANeighborhoodBlendT2xProgram[t2x_i].mFeatures.isDeferred = true;
+                    gSMAANeighborhoodBlendT2xProgram[t2x_i].clearPermutations();
+                    gSMAANeighborhoodBlendT2xProgram[t2x_i].addPermutations(t2x_defines);
+                    gSMAANeighborhoodBlendT2xProgram[t2x_i].mShaderFiles.clear();
+                    gSMAANeighborhoodBlendT2xProgram[t2x_i].mShaderFiles.push_back(make_pair("deferred/SMAANeighborhoodBlendF.glsl", GL_FRAGMENT_SHADER_ARB));
+                    gSMAANeighborhoodBlendT2xProgram[t2x_i].mShaderFiles.push_back(make_pair("deferred/SMAANeighborhoodBlendV.glsl", GL_VERTEX_SHADER_ARB));
+                    gSMAANeighborhoodBlendT2xProgram[t2x_i].mShaderFiles.push_back(make_pair("deferred/SMAA.glsl", GL_FRAGMENT_SHADER_ARB));
+                    gSMAANeighborhoodBlendT2xProgram[t2x_i].mShaderFiles.push_back(make_pair("deferred/SMAA.glsl", GL_VERTEX_SHADER_ARB));
+                    gSMAANeighborhoodBlendT2xProgram[t2x_i].mShaderLevel = mShaderLevel[SHADER_DEFERRED];
+                    success = gSMAANeighborhoodBlendT2xProgram[t2x_i].createShader();
+                    if (!success)
+                    {
+                        LL_WARNS() << "Failed to create shader '" << gSMAANeighborhoodBlendT2xProgram[t2x_i].mName << "', disabling!" << LL_ENDL;
+                        t2x_failed = true;
+                        success = true;
+                        break;
+                    }
+                }
+
+                if (success)
+                {
+                    gSMAAResolveProgram[t2x_i].mName = llformat("SMAA T2x Resolve (%s)", smaa_pair.second.c_str());
+                    gSMAAResolveProgram[t2x_i].mFeatures.isDeferred = true;
+                    gSMAAResolveProgram[t2x_i].clearPermutations();
+                    gSMAAResolveProgram[t2x_i].addPermutations(t2x_defines);
+                    gSMAAResolveProgram[t2x_i].mShaderFiles.clear();
+                    gSMAAResolveProgram[t2x_i].mShaderFiles.push_back(make_pair("deferred/SMAAResolveF.glsl", GL_FRAGMENT_SHADER_ARB));
+                    gSMAAResolveProgram[t2x_i].mShaderFiles.push_back(make_pair("deferred/SMAAResolveV.glsl", GL_VERTEX_SHADER_ARB));
+                    gSMAAResolveProgram[t2x_i].mShaderFiles.push_back(make_pair("deferred/SMAA.glsl", GL_FRAGMENT_SHADER_ARB));
+                    gSMAAResolveProgram[t2x_i].mShaderFiles.push_back(make_pair("deferred/SMAA.glsl", GL_VERTEX_SHADER_ARB));
+                    gSMAAResolveProgram[t2x_i].mShaderLevel = mShaderLevel[SHADER_DEFERRED];
+                    success = gSMAAResolveProgram[t2x_i].createShader();
+                    if (!success)
+                    {
+                        LL_WARNS() << "Failed to create shader '" << gSMAAResolveProgram[t2x_i].mName << "', disabling!" << LL_ENDL;
+                        t2x_failed = true;
+                        success = true;
+                        break;
+                    }
+                }
+                ++t2x_i;
+            }
+
+            if (t2x_failed)
+            {
+                for (auto j = 0; j < 4; ++j)
+                {
+                    gSMAANeighborhoodBlendT2xProgram[j].unload();
+                    gSMAAResolveProgram[j].unload();
+                }
             }
         }
     }

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -213,6 +213,7 @@ LLGLSLShader            gCASProgram;
 LLGLSLShader            gCASLegacyGammaProgram;
 LLGLSLShader            gDeferredPostNoDoFProgram;
 LLGLSLShader            gDeferredPostNoDoFNoiseProgram;
+LLGLSLShader            gDeferredMotionBlurProgram;
 LLGLSLShader            gDeferredWLSkyProgram;
 LLGLSLShader            gEnvironmentMapProgram;
 LLGLSLShader            gDeferredWLCloudProgram;
@@ -240,6 +241,12 @@ LLGLSLShader            gHUDPBRAlphaProgram;
 LLGLSLShader            gDeferredPBRAlphaProgram;
 LLGLSLShader            gDeferredSkinnedPBRAlphaProgram;
 LLGLSLShader            gDeferredPBRTerrainProgram[TERRAIN_PAINT_TYPE_COUNT];
+
+LLGLSLShader            gVelocityProgram;
+LLGLSLShader            gVelocitySkinnedProgram;
+LLGLSLShader            gVelocityAlphaProgram;
+LLGLSLShader            gVelocityAlphaSkinnedProgram;
+LLGLSLShader            gAvatarVelocityProgram;
 
 LLGLSLShader            gGLTFPBRMetallicRoughnessProgram;
 
@@ -792,6 +799,7 @@ std::string LLViewerShaderMgr::loadBasicShaders()
     shaders.push_back( make_pair( "avatar/avatarSkinV.glsl",                1 ) );
     shaders.push_back( make_pair( "avatar/objectSkinV.glsl",                1 ) );
     shaders.push_back( make_pair( "deferred/textureUtilV.glsl",             1 ) );
+    shaders.push_back( make_pair( "deferred/velocityFuncV.glsl",            1 ) );
     if (gGLManager.mGLSLVersionMajor >= 2 || gGLManager.mGLSLVersionMinor >= 30)
     {
         shaders.push_back( make_pair( "objects/indexedTextureV.glsl",           1 ) );
@@ -1191,6 +1199,13 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         {
             gDeferredPBRTerrainProgram[paint_type].unload();
         }
+
+        gVelocityProgram.unload();
+        gVelocitySkinnedProgram.unload();
+        gVelocityAlphaProgram.unload();
+        gVelocityAlphaSkinnedProgram.unload();
+        gAvatarVelocityProgram.unload();
+        gDeferredMotionBlurProgram.unload();
 
         return true;
     }
@@ -2887,6 +2902,18 @@ bool LLViewerShaderMgr::loadShadersDeferred()
 
     if (success)
     {
+        gDeferredMotionBlurProgram.mName = "Deferred Motion Blur Shader";
+        gDeferredMotionBlurProgram.mFeatures.isDeferred = true;
+        gDeferredMotionBlurProgram.mShaderFiles.clear();
+        gDeferredMotionBlurProgram.mShaderFiles.push_back(make_pair("deferred/postDeferredNoTCV.glsl", GL_VERTEX_SHADER));
+        gDeferredMotionBlurProgram.mShaderFiles.push_back(make_pair("deferred/motionBlurF.glsl", GL_FRAGMENT_SHADER));
+        gDeferredMotionBlurProgram.mShaderLevel = mShaderLevel[SHADER_DEFERRED];
+        success = gDeferredMotionBlurProgram.createShader();
+        llassert(success);
+    }
+
+    if (success)
+    {
         gEnvironmentMapProgram.mName = "Environment Map Program";
         gEnvironmentMapProgram.mShaderFiles.clear();
         gEnvironmentMapProgram.mFeatures.calculatesAtmospherics = true;
@@ -3047,6 +3074,44 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         add_common_permutations(&gDeferredBufferVisualProgram);
 
         success = gDeferredBufferVisualProgram.createShader();
+    }
+
+    if (success)
+    {
+        gVelocityProgram.mName = "Velocity Shader";
+        gVelocityProgram.mFeatures.hasMotionBlur = true;
+        gVelocityProgram.mShaderFiles.clear();
+        gVelocityProgram.mShaderFiles.push_back(make_pair("deferred/velocityV.glsl", GL_VERTEX_SHADER));
+        gVelocityProgram.mShaderFiles.push_back(make_pair("deferred/velocityF.glsl", GL_FRAGMENT_SHADER));
+        gVelocityProgram.mShaderLevel = mShaderLevel[SHADER_DEFERRED];
+        success = make_rigged_variant(gVelocityProgram, gVelocitySkinnedProgram);
+        success = success && gVelocityProgram.createShader();
+    }
+
+    if (success)
+    {
+        gVelocityAlphaProgram.mName = "Velocity Alpha Shader";
+        gVelocityAlphaProgram.mFeatures.hasMotionBlur = true;
+        gVelocityAlphaProgram.mFeatures.mIndexedTextureChannels = LLGLSLShader::sIndexedTextureChannels;
+        gVelocityAlphaProgram.mShaderFiles.clear();
+        gVelocityAlphaProgram.mShaderFiles.push_back(make_pair("deferred/velocityAlphaV.glsl", GL_VERTEX_SHADER));
+        gVelocityAlphaProgram.mShaderFiles.push_back(make_pair("deferred/velocityAlphaF.glsl", GL_FRAGMENT_SHADER));
+        gVelocityAlphaProgram.mShaderLevel = mShaderLevel[SHADER_DEFERRED];
+        add_common_permutations(&gVelocityAlphaProgram);
+        success = make_rigged_variant(gVelocityAlphaProgram, gVelocityAlphaSkinnedProgram);
+        success = success && gVelocityAlphaProgram.createShader();
+    }
+
+    if (success)
+    {
+        gAvatarVelocityProgram.mName = "Avatar Velocity Shader";
+        gAvatarVelocityProgram.mFeatures.hasSkinning = true;
+        gAvatarVelocityProgram.mFeatures.hasMotionBlur = true;
+        gAvatarVelocityProgram.mShaderFiles.clear();
+        gAvatarVelocityProgram.mShaderFiles.push_back(make_pair("deferred/avatarVelocityV.glsl", GL_VERTEX_SHADER));
+        gAvatarVelocityProgram.mShaderFiles.push_back(make_pair("deferred/avatarVelocityF.glsl", GL_FRAGMENT_SHADER));
+        gAvatarVelocityProgram.mShaderLevel = mShaderLevel[SHADER_DEFERRED];
+        success = gAvatarVelocityProgram.createShader();
     }
 
     return success;

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -2816,7 +2816,7 @@ bool LLViewerShaderMgr::loadShadersDeferred()
                     t2x_defines.emplace("SMAA_GLSL_2", "1");
                 t2x_defines.emplace("SMAA_PREDICATION", "0");
                 t2x_defines.emplace("SMAA_REPROJECTION", "1");
-                t2x_defines.emplace("SMAA_REPROJECTION_WEIGHT_SCALE", "10.0");
+                t2x_defines.emplace("SMAA_REPROJECTION_WEIGHT_SCALE", "30.0");
                 t2x_defines.emplace(smaa_pair.first, "1");
 
                 if (success)

--- a/indra/newview/llviewershadermgr.h
+++ b/indra/newview/llviewershadermgr.h
@@ -250,6 +250,8 @@ extern LLGLSLShader         gFXAAProgram[4];
 extern LLGLSLShader         gSMAAEdgeDetectProgram[4];
 extern LLGLSLShader         gSMAABlendWeightsProgram[4];
 extern LLGLSLShader         gSMAANeighborhoodBlendProgram[4];
+extern LLGLSLShader         gSMAANeighborhoodBlendT2xProgram[4];
+extern LLGLSLShader         gSMAAResolveProgram[4];
 extern LLGLSLShader         gCASProgram;
 extern LLGLSLShader         gCASLegacyGammaProgram;
 extern LLGLSLShader         gDeferredPostNoDoFProgram;

--- a/indra/newview/llviewershadermgr.h
+++ b/indra/newview/llviewershadermgr.h
@@ -254,6 +254,7 @@ extern LLGLSLShader         gCASProgram;
 extern LLGLSLShader         gCASLegacyGammaProgram;
 extern LLGLSLShader         gDeferredPostNoDoFProgram;
 extern LLGLSLShader         gDeferredPostNoDoFNoiseProgram;
+extern LLGLSLShader         gDeferredMotionBlurProgram;
 extern LLGLSLShader         gDeferredPostGammaCorrectProgram;
 extern LLGLSLShader         gLegacyPostGammaCorrectProgram;
 extern LLGLSLShader         gDeferredPostTonemapProgram;
@@ -327,4 +328,10 @@ enum TerrainPaintType : U32
     TERRAIN_PAINT_TYPE_COUNT                = 2,
 };
 extern LLGLSLShader         gDeferredPBRTerrainProgram[TERRAIN_PAINT_TYPE_COUNT];
+
+extern LLGLSLShader         gVelocityProgram;
+extern LLGLSLShader         gVelocitySkinnedProgram;
+extern LLGLSLShader         gVelocityAlphaProgram;
+extern LLGLSLShader         gVelocityAlphaSkinnedProgram;
+extern LLGLSLShader         gAvatarVelocityProgram;
 #endif

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -9988,6 +9988,12 @@ const LLVOAvatar::MatrixPaletteCache& LLVOAvatar::updateSkinInfoMatrixPalette(co
     {
         LL_PROFILE_ZONE_SCOPED_CATEGORY_AVATAR;
 
+        if (entry.mFrame > 0)
+        {
+            entry.mLastGLMp = entry.mGLMp;
+            entry.mLastFrame = entry.mFrame;
+        }
+
         entry.mFrame = gFrameCount;
 
         //build matrix palette

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -833,6 +833,10 @@ public:
         // Float array ready to be sent to GL
         std::vector<F32> mGLMp;
 
+        // Previous frame's mGLMp for velocity buffer
+        std::vector<F32> mLastGLMp;
+        S32 mLastFrame = -1;
+
         MatrixPaletteCache() :
             mFrame(gFrameCount - 1)
         {

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -5496,6 +5496,7 @@ void LLVolumeGeometryManager::registerFace(LLSpatialGroup* group, LLFace* facep,
         draw_vec.push_back(draw_info);
         draw_info->mTextureMatrix = tex_mat;
         draw_info->mModelMatrix = model_mat;
+        draw_info->mLastModelMatrix = &drawable->mLastVelocityMatrix;
 
         draw_info->mBump  = bump;
         draw_info->mShiny = shiny;

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -328,6 +328,7 @@ bool    LLPipeline::sBakeSunlight = false;
 bool    LLPipeline::sNoAlpha = false;
 bool    LLPipeline::sUseFarClip = true;
 bool    LLPipeline::sShadowRender = false;
+bool    LLPipeline::sVelocityRender = false;
 bool    LLPipeline::sRenderGlow = false;
 bool    LLPipeline::sReflectionRender = false;
 bool    LLPipeline::sDefaultProbeRender = false;
@@ -4153,6 +4154,8 @@ void LLPipeline::renderGeomMotionBlur()
     gGL.setColorMask(true, true);
     LLGLDepthTest depth(GL_TRUE, GL_FALSE, GL_LEQUAL);
 
+    sVelocityRender = true;
+
     // Each draw pool is responsible for producing its own velocity
     for (pool_set_t::iterator iter = mPools.begin(); iter != mPools.end(); ++iter)
     {
@@ -4165,6 +4168,8 @@ void LLPipeline::renderGeomMotionBlur()
             poolp->endMotionBlurPass(i);
         }
     }
+
+    sVelocityRender = false;
 
     mVelocityMap.flush();
 }

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -342,6 +342,7 @@ bool    LLPipeline::sRenderDeferred = false;
 bool    LLPipeline::sReflectionProbesEnabled = false;
 S32     LLPipeline::sVisibleLightCount = 0;
 bool    LLPipeline::sRenderingHUDs;
+bool    LLPipeline::sT2xJitterEnabled = false;
 F32     LLPipeline::sDistortionWaterClipPlaneMargin = 1.0125f;
 bool    LLPipeline::RenderMotionBlur = false;
 

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -343,6 +343,7 @@ bool    LLPipeline::sReflectionProbesEnabled = false;
 S32     LLPipeline::sVisibleLightCount = 0;
 bool    LLPipeline::sRenderingHUDs;
 F32     LLPipeline::sDistortionWaterClipPlaneMargin = 1.0125f;
+bool    LLPipeline::RenderMotionBlur = false;
 
 // EventHost API LLPipeline listener.
 static LLPipelineListener sPipelineListener;
@@ -612,6 +613,7 @@ void LLPipeline::init()
     connectRefreshCachedSettingsSafe("RenderHeroProbeUpdateRate");
     connectRefreshCachedSettingsSafe("RenderHeroProbeConservativeUpdateMultiplier");
     connectRefreshCachedSettingsSafe("RenderAvatarCloth");
+    connectRefreshCachedSettingsSafe("RenderMotionBlur");
 
     LLPointer<LLControlVariable> cntrl_ptr = gSavedSettings.getControl("CollectFontVertexBuffers");
     if (cntrl_ptr.notNull())
@@ -923,6 +925,16 @@ bool LLPipeline::allocateScreenBufferInternal(U32 resX, U32 resY)
         mPostPingMap.allocate(resX, resY, GL_RGBA);
         mPostPongMap.allocate(resX, resY, GL_RGBA);
 
+        if (RenderMotionBlur)
+        {
+            mVelocityMap.allocate(resX, resY, GL_RG16F);
+            mRT->deferredScreen.shareDepthBuffer(mVelocityMap);
+        }
+        else
+        {
+            mVelocityMap.release();
+        }
+
         // The water exclusion mask needs its own depth buffer so we can take care of the problem of multiple water planes.
         // Should we ever make water not just a plane, it also aids with that as well as the water planes will be rendered into the mask.
         // Why do we do this? Because it saves us some janky logic in the exclusion shader when we generate the mask.
@@ -1140,6 +1152,7 @@ void LLPipeline::refreshCachedSettings()
     RenderHeroProbeUpdateRate = gSavedSettings.getS32("RenderHeroProbeUpdateRate");
     RenderHeroProbeConservativeUpdateMultiplier = gSavedSettings.getS32("RenderHeroProbeConservativeUpdateMultiplier");
     RenderAvatarCloth = gSavedSettings.getBOOL("RenderAvatarCloth");
+    RenderMotionBlur = gSavedSettings.getBOOL("RenderMotionBlur");
 
     sReflectionProbesEnabled = LLFeatureManager::getInstance()->isFeatureAvailable("RenderReflectionsEnabled") && gSavedSettings.getBOOL("RenderReflectionsEnabled");
     RenderSpotLight = nullptr;
@@ -4119,6 +4132,33 @@ void LLPipeline::renderGeomDeferred(LLCamera& camera, bool do_occlusion)
 
 // Render all of our geometry that's required after our deferred pass.
 // This is gonna be stuff like alpha, water, etc.
+void LLPipeline::renderGeomMotionBlur()
+{
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_DRAWPOOL;
+    LL_PROFILE_GPU_ZONE("renderGeomMotionBlur");
+
+    mVelocityMap.bindTarget();
+    mVelocityMap.clear(GL_COLOR_BUFFER_BIT);
+
+    gGL.setColorMask(true, true);
+    LLGLDepthTest depth(GL_TRUE, GL_FALSE, GL_LEQUAL);
+
+    // Each draw pool is responsible for producing its own velocity
+    for (pool_set_t::iterator iter = mPools.begin(); iter != mPools.end(); ++iter)
+    {
+        LLDrawPool* poolp = *iter;
+        S32 num_passes = poolp->getNumMotionBlurPasses();
+        for (S32 i = 0; i < num_passes; ++i)
+        {
+            poolp->beginMotionBlurPass(i);
+            poolp->renderMotionBlur(i);
+            poolp->endMotionBlurPass(i);
+        }
+    }
+
+    mVelocityMap.flush();
+}
+
 void LLPipeline::renderGeomPostDeferred(LLCamera& camera)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DRAWPOOL;
@@ -7808,6 +7848,28 @@ void LLPipeline::combineGlow(LLRenderTarget* src, LLRenderTarget* dst)
     dst->flush();
 }
 
+void LLPipeline::renderMotionBlurComposite(LLRenderTarget* src, LLRenderTarget* dst)
+{
+    LL_PROFILE_GPU_ZONE("motion blur");
+
+    dst->bindTarget();
+
+    gDeferredMotionBlurProgram.bind();
+    gDeferredMotionBlurProgram.bindTexture(LLShaderMgr::DEFERRED_DIFFUSE, src);
+    gDeferredMotionBlurProgram.bindTexture(LLShaderMgr::DEFERRED_VELOCITY, &mVelocityMap);
+    gDeferredMotionBlurProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES,
+        (GLfloat)src->getWidth(), (GLfloat)src->getHeight());
+
+    static LLCachedControl<S32> blur_strength(gSavedSettings, "RenderMotionBlurStrength", 32);
+    gDeferredMotionBlurProgram.uniform1i(LLShaderMgr::MOTION_BLUR_STRENGTH, blur_strength);
+
+    mScreenTriangleVB->setBuffer();
+    mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+
+    gDeferredMotionBlurProgram.unbind();
+    dst->flush();
+}
+
 void LLPipeline::renderDoF(LLRenderTarget* src, LLRenderTarget* dst)
 {
     LL_PROFILE_GPU_ZONE("dof");
@@ -8057,6 +8119,12 @@ void LLPipeline::renderFinalize()
     combineGlow(sourceBuffer, targetBuffer);
     std::swap(sourceBuffer, targetBuffer);
 
+    if (RenderMotionBlur && !gCubeSnapshot)
+    {
+        renderMotionBlurComposite(sourceBuffer, targetBuffer);
+        std::swap(sourceBuffer, targetBuffer);
+    }
+
     gGLViewport[0] = gViewerWindow->getWorldViewRectRaw().mLeft;
     gGLViewport[1] = gViewerWindow->getWorldViewRectRaw().mBottom;
     gGLViewport[2] = gViewerWindow->getWorldViewRectRaw().getWidth();
@@ -8109,6 +8177,14 @@ void LLPipeline::renderFinalize()
             if (RenderFSAAType == 2)
             {
                 visualizeBuffers(&mSMAABlendBuffer, sourceBuffer, 0);
+            }
+            break;
+        }
+        case 7:
+        {
+            if (RenderMotionBlur)
+            {
+                visualizeBuffers(&mVelocityMap, sourceBuffer, 0);
             }
             break;
         }
@@ -8929,6 +9005,11 @@ void LLPipeline::renderDeferredLighting()
 
         renderGeomPostDeferred(*LLViewerCamera::getInstance());
         popRenderTypeMask();
+    }
+
+    if (RenderMotionBlur)
+    {
+        renderGeomMotionBlur();
     }
 
     screen_target->flush();

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -899,15 +899,24 @@ bool LLPipeline::allocateScreenBufferInternal(U32 resX, U32 resY)
         if (RenderFSAAType > 0)
         {
             if (!mFXAAMap.allocate(resX, resY, GL_RGBA)) return false;
-            if (RenderFSAAType == 2)
+            if (RenderFSAAType == 2 || RenderFSAAType == 3)
             {
                 if (!mSMAABlendBuffer.allocate(resX, resY, GL_RGBA, false)) return false;
+            }
+            if (RenderFSAAType == 3)
+            {
+                if (!mSMAAHistory.allocate(resX, resY, GL_RGBA)) return false;
+            }
+            else
+            {
+                mSMAAHistory.release();
             }
         }
         else
         {
             mFXAAMap.release();
             mSMAABlendBuffer.release();
+            mSMAAHistory.release();
         }
 
         //water reflection texture (always needed as scratch space whether or not transparent water is enabled)
@@ -925,7 +934,7 @@ bool LLPipeline::allocateScreenBufferInternal(U32 resX, U32 resY)
         mPostPingMap.allocate(resX, resY, GL_RGBA);
         mPostPongMap.allocate(resX, resY, GL_RGBA);
 
-        if (RenderMotionBlur)
+        if (RenderMotionBlur || RenderFSAAType == 3)
         {
             mVelocityMap.allocate(resX, resY, GL_RG16F);
             mRT->deferredScreen.shareDepthBuffer(mVelocityMap);
@@ -7628,7 +7637,7 @@ void LLPipeline::applyFXAA(LLRenderTarget* src, LLRenderTarget* dst)
 void LLPipeline::generateSMAABuffers(LLRenderTarget* src)
 {
     llassert(!gCubeSnapshot);
-    bool multisample = RenderFSAAType == 2 && gSMAAEdgeDetectProgram[0].isComplete() && mFXAAMap.isComplete() && mSMAABlendBuffer.isComplete();
+    bool multisample = (RenderFSAAType == 2 || RenderFSAAType == 3) && gSMAAEdgeDetectProgram[0].isComplete() && mFXAAMap.isComplete() && mSMAABlendBuffer.isComplete();
 
     // Present everything.
     if (multisample)
@@ -7702,6 +7711,21 @@ void LLPipeline::generateSMAABuffers(LLRenderTarget* src)
             blend_weights_shader.bind();
             blend_weights_shader.uniform4fv(sSmaaRTMetrics, 1, rt_metrics);
 
+            // T2x subsample indices: alternates between (1,1,1,0) and (2,2,2,0) each frame
+            float subsample[4] = {0.f, 0.f, 0.f, 0.f};
+            if (RenderFSAAType == 3)
+            {
+                if (mSMAAFrameIndex & 1)
+                {
+                    subsample[0] = 2.f; subsample[1] = 2.f; subsample[2] = 2.f; subsample[3] = 0.f;
+                }
+                else
+                {
+                    subsample[0] = 1.f; subsample[1] = 1.f; subsample[2] = 1.f; subsample[3] = 0.f;
+                }
+            }
+            blend_weights_shader.uniform4fv(LLShaderMgr::SMAA_SUBSAMPLE_INDICES, 1, subsample);
+
             S32 edge_tex_channel = blend_weights_shader.enableTexture(LLShaderMgr::SMAA_EDGE_TEX, mFXAAMap.getUsage());
             if (edge_tex_channel > -1)
             {
@@ -7747,9 +7771,8 @@ void LLPipeline::applySMAA(LLRenderTarget* src, LLRenderTarget* dst)
 {
     LL_PROFILE_GPU_ZONE("SMAA");
     llassert(!gCubeSnapshot);
-    bool multisample = RenderFSAAType == 2 && gSMAAEdgeDetectProgram[0].isComplete() && mFXAAMap.isComplete() && mSMAABlendBuffer.isComplete();
+    bool multisample = (RenderFSAAType == 2 || RenderFSAAType == 3) && gSMAAEdgeDetectProgram[0].isComplete() && mFXAAMap.isComplete() && mSMAABlendBuffer.isComplete();
 
-    // Present everything.
     if (multisample)
     {
         static LLCachedControl<U32> aa_quality(gSavedSettings, "RenderFSAASamples", 0U);
@@ -7762,15 +7785,11 @@ void LLPipeline::applySMAA(LLRenderTarget* src, LLRenderTarget* dst)
 
         LLGLDepthTest    depth(GL_FALSE, GL_FALSE);
 
-        static LLCachedControl<bool> use_sample(gSavedSettings, "RenderSMAAUseSample", false);
-        //static LLCachedControl<bool> use_stencil(gSavedSettings, "RenderSMAAUseStencil", true);
-
         {
-            //LLGLDisable stencil(GL_STENCIL_TEST);
-
-            // Bind setup:
             LLRenderTarget* bound_target = dst;
-            LLGLSLShader& blend_shader = gSMAANeighborhoodBlendProgram[fsaa_quality];
+            LLGLSLShader& blend_shader = (RenderFSAAType == 3)
+                ? gSMAANeighborhoodBlendT2xProgram[fsaa_quality]
+                : gSMAANeighborhoodBlendProgram[fsaa_quality];
 
             bound_target->bindTarget();
             bound_target->clear(GL_COLOR_BUFFER_BIT);
@@ -7791,6 +7810,15 @@ void LLPipeline::applySMAA(LLRenderTarget* src, LLRenderTarget* dst)
                 mSMAABlendBuffer.bindTexture(0, blend_channel, LLTexUnit::TFO_BILINEAR);
             }
 
+            if (RenderFSAAType == 3)
+            {
+                S32 vel_channel = blend_shader.enableTexture(LLShaderMgr::SMAA_VELOCITY_TEX);
+                if (vel_channel > -1)
+                {
+                    mVelocityMap.bindTexture(0, vel_channel, LLTexUnit::TFO_BILINEAR);
+                }
+            }
+
             mScreenTriangleVB->setBuffer();
             mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
 
@@ -7804,6 +7832,49 @@ void LLPipeline::applySMAA(LLRenderTarget* src, LLRenderTarget* dst)
     {
         copyRenderTarget(src, dst);
     }
+}
+
+void LLPipeline::resolveSMAAT2x(LLRenderTarget* src, LLRenderTarget* dst)
+{
+    LL_PROFILE_GPU_ZONE("SMAA T2x Resolve");
+
+    static LLCachedControl<U32> aa_quality(gSavedSettings, "RenderFSAASamples", 0U);
+    U32 q = std::clamp(aa_quality(), 0U, 3U);
+
+    dst->bindTarget();
+
+    LLGLSLShader& shader = gSMAAResolveProgram[q];
+    shader.bind();
+
+    S32 cur_ch = shader.enableTexture(LLShaderMgr::SMAA_CURRENT_COLOR_TEX);
+    if (cur_ch > -1)
+    {
+        src->bindTexture(0, cur_ch, LLTexUnit::TFO_POINT);
+    }
+
+    S32 prev_ch = shader.enableTexture(LLShaderMgr::SMAA_PREVIOUS_COLOR_TEX);
+    if (prev_ch > -1)
+    {
+        mSMAAHistory.bindTexture(0, prev_ch, LLTexUnit::TFO_POINT);
+    }
+
+    S32 vel_ch = shader.enableTexture(LLShaderMgr::SMAA_VELOCITY_TEX);
+    if (vel_ch > -1)
+    {
+        mVelocityMap.bindTexture(0, vel_ch, LLTexUnit::TFO_BILINEAR);
+    }
+
+    mScreenTriangleVB->setBuffer();
+    mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+
+    shader.unbind();
+    dst->flush();
+
+    // Save the current SMAA'd frame (not the resolved output) to history.
+    // The resolve blends current and previous SMAA outputs — if we stored
+    // the resolved result, it would create exponential decay instead of a
+    // true 50/50 blend between the two jitter samples.
+    copyRenderTarget(src, &mSMAAHistory);
 }
 
 void LLPipeline::copyRenderTarget(LLRenderTarget* src, LLRenderTarget* dst)
@@ -8149,6 +8220,17 @@ void LLPipeline::renderFinalize()
         generateSMAABuffers(sourceBuffer);
         applySMAA(sourceBuffer, targetBuffer);
         std::swap(sourceBuffer, targetBuffer);
+    }
+    else if (RenderFSAAType == 3)
+    {
+        generateSMAABuffers(sourceBuffer);
+        applySMAA(sourceBuffer, targetBuffer);
+        std::swap(sourceBuffer, targetBuffer);
+
+        resolveSMAAT2x(sourceBuffer, targetBuffer);
+        std::swap(sourceBuffer, targetBuffer);
+
+        mSMAAFrameIndex ^= 1;
     }
 
     if (RenderBufferVisualization > -1)
@@ -9007,7 +9089,7 @@ void LLPipeline::renderDeferredLighting()
         popRenderTypeMask();
     }
 
-    if (RenderMotionBlur)
+    if (RenderMotionBlur || RenderFSAAType == 3)
     {
         renderGeomMotionBlur();
     }

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -671,6 +671,7 @@ public:
     static bool             sNoAlpha;
     static bool             sUseFarClip;
     static bool             sShadowRender;
+    static bool             sVelocityRender;
     static bool             sDynamicLOD;
     static bool             sPickAvatar;
     static bool             sReflectionRender;

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -308,6 +308,8 @@ public:
 
     void renderGeomDeferred(LLCamera& camera, bool do_occlusion = false);
     void renderGeomPostDeferred(LLCamera& camera);
+    void renderGeomMotionBlur();
+    void renderMotionBlurComposite(LLRenderTarget* src, LLRenderTarget* dst);
     void renderGeomShadow(LLCamera& camera);
     void bindLightFunc(LLGLSLShader& shader);
 
@@ -734,6 +736,8 @@ public:
     LLRenderTarget          mPostPingMap;
     LLRenderTarget          mPostPongMap;
 
+    LLRenderTarget          mVelocityMap;
+
     // FXAA helper target
     LLRenderTarget          mFXAAMap;
     LLRenderTarget          mSMAABlendBuffer;
@@ -1089,6 +1093,7 @@ public:
     static S32 RenderHeroProbeUpdateRate;
     static S32 RenderHeroProbeConservativeUpdateMultiplier;
     static bool RenderAvatarCloth;
+    static bool RenderMotionBlur;
 };
 
 void render_bbox(const LLVector3 &min, const LLVector3 &max);

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -162,6 +162,7 @@ public:
     void applyFXAA(LLRenderTarget* src, LLRenderTarget* dst);
     void generateSMAABuffers(LLRenderTarget* src);
     void applySMAA(LLRenderTarget* src, LLRenderTarget* dst);
+    void resolveSMAAT2x(LLRenderTarget* src, LLRenderTarget* dst);
     void renderDoF(LLRenderTarget* src, LLRenderTarget* dst);
     void copyRenderTarget(LLRenderTarget* src, LLRenderTarget* dst);
     void combineGlow(LLRenderTarget* src, LLRenderTarget* dst);
@@ -741,6 +742,8 @@ public:
     // FXAA helper target
     LLRenderTarget          mFXAAMap;
     LLRenderTarget          mSMAABlendBuffer;
+    LLRenderTarget          mSMAAHistory;
+    U32                     mSMAAFrameIndex = 0;
 
     // render ui to buffer target
     LLRenderTarget          mUIScreen;

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -687,6 +687,7 @@ public:
     static bool             sReflectionProbesEnabled;
     static S32              sVisibleLightCount;
     static bool             sRenderingHUDs;
+    static bool             sT2xJitterEnabled;
     static F32              sDistortionWaterClipPlaneMargin;
 
     static LLTrace::EventStatHandle<S64> sStatBatchSize;

--- a/indra/newview/skins/default/xui/en/floater_preferences_graphics_advanced.xml
+++ b/indra/newview/skins/default/xui/en/floater_preferences_graphics_advanced.xml
@@ -428,6 +428,10 @@
           label="SMAA"
           name="SMAA"
           value="2" />
+        <combo_box.item
+          label="SMAA T2x"
+          name="SMAA T2x"
+          value="3" />
     </combo_box>
   <text
     type="string"
@@ -1112,6 +1116,18 @@
   </slider>
   <!-- End of Tone Mapping Settings-->
   <!-- End of Advanced Settings block -->
+  
+  <check_box
+    control_name="RenderMotionBlur"
+    height="16"
+    initial_value="false"
+    label="Motionblur"
+    layout="topleft"
+    left="420"
+    name="Motionblur"
+    top_delta="22"
+    width="240">
+    </check_box>
 	<view_border
       bevel_style="in"
       height="0"


### PR DESCRIPTION
Adds support for velocity buffers in the viewer.  Based off of Dave's old motion blur experiments from a very long time ago.  Also adds motion blur and SMAA T2x support for a bit of temporal AA (though not the strong stuff that you end up needing to sharpen later).

Extended the draw pool interface accordingly to handle the velocity buffer generation as well so we can have a bit of finer control and tuning for each object type as needed.