### PR TITLE
Introduce planar mirrors

### DIFF
--- a/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
@@ -715,7 +715,7 @@ vec3 sampleProbeAmbient(vec3 pos, vec3 dir, vec3 amblit)
 uniform vec4 clipPlane;
 uniform samplerCubeArray   heroProbes;
 
-void tapHeroProbe(inout vec3 glossenv, vec3 pos, vec3 norm, float glossiness)
+void tapHeroProbe(inout vec3 ambenv, inout vec3 glossenv, vec3 pos, vec3 norm, float glossiness)
 {
     float clipDist = dot(pos.xyz, clipPlane.xyz) + clipPlane.w;
     float w = 0;
@@ -770,11 +770,13 @@ void tapHeroProbe(inout vec3 glossenv, vec3 pos, vec3 norm, float glossiness)
             vec4(env_mat * refnormpersp, 0),
             (1.0 - glossiness) * heroMipCount).xyz, w);
     }
+
+    ambenv *= (1.0 - w);
 }
 
 #else
 
-void tapHeroProbe(inout vec3 glossenv, vec3 pos, vec3 norm, float glossiness)
+void tapHeroProbe(inout vec3 ambenv, inout vec3 glossenv, vec3 pos, vec3 norm, float glossiness)
 {
 }
 
@@ -817,7 +819,7 @@ void doProbeSample(inout vec3 ambenv, inout vec3 glossenv,
     }
 #endif
 
-    tapHeroProbe(glossenv, pos, norm, glossiness);
+    tapHeroProbe(ambenv, glossenv, pos, norm, glossiness);
 }
 
 void sampleReflectionProbes(inout vec3 ambenv, inout vec3 glossenv,
@@ -933,8 +935,8 @@ void sampleReflectionProbesLegacy(inout vec3 ambenv, inout vec3 glossenv, inout 
     }
 #endif
 
-    tapHeroProbe(glossenv, pos, norm, glossiness);
-    tapHeroProbe(legacyenv, pos, norm, 1.0);
+    tapHeroProbe(ambenv, glossenv, pos, norm, glossiness);
+    tapHeroProbe(ambenv, legacyenv, pos, norm, 1.0);
 
     glossenv = clamp(glossenv, vec3(0), vec3(10));
 }

--- a/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
@@ -79,6 +79,8 @@ layout (std140) uniform ReflectionProbes
     int heroShape;
     int heroMipCount;
     int heroProbeCount;
+
+    mat4 heroPlaneMatrix;
 };
 
 // Inputs
@@ -720,25 +722,54 @@ void tapHeroProbe(inout vec3 glossenv, vec3 pos, vec3 norm, float glossiness)
     float dw = 0;
     float falloffMult = 10;
     vec3 refnormpersp = reflect(pos.xyz, norm.xyz);
+
     if (heroShape < 1)
-    {
+    {   // box
         float d = 0;
         boxIntersect(pos, norm, heroBox, d, 1.0);
-
         w = max(d, 0);
     }
-    else
-    {
+    else if (heroShape == 1)
+    {   // sphere
         float r = heroSphere.w;
-
         w = sphereWeight(pos, refnormpersp, heroSphere.xyz, r, vec4(1), dw);
+    }
+    else
+    {   // planar (heroShape == 2)
+        float d = 0;
+        boxIntersect(pos, norm, heroBox, d, 1.0);
+        w = max(d, 0);
     }
 
     clipDist = clipDist * 0.95 + 0.05;
     clipDist = clamp(clipDist * falloffMult, 0, 1);
     w = clamp(w * falloffMult * clipDist, 0, 1);
-    w = mix(0, w, clamp(glossiness - 0.75, 0, 1) * 4); // We only generate a quarter of the mips for the hero probes.  Linearly interpolate between normal probes and hero probes based upon glossiness.
-    glossenv = mix(glossenv, textureLod(heroProbes, vec4(env_mat * refnormpersp, 0), (1.0-glossiness)*heroMipCount).xyz, w);
+    w = mix(0, w, clamp(glossiness - 0.75, 0, 1) * 4);
+
+    if (heroShape == 2)
+    {
+        // Planar: apply correction matrix then sample face 0
+        vec3 worldDir = env_mat * refnormpersp;
+        vec3 corrected = mat3(heroPlaneMatrix) * worldDir;
+        vec3 cubemapDir = corrected;
+
+        // Angular fade: attenuate for directions near face edges
+        float cosAngle = cubemapDir.x / max(length(cubemapDir), 0.001);
+        w *= smoothstep(0.0, 0.1, cosAngle);
+
+        // Ensure face 0 is sampled
+        cubemapDir.x = max(cubemapDir.x, 0.001);
+
+        glossenv = mix(glossenv, textureLod(heroProbes,
+            vec4(cubemapDir, 0),
+            (1.0 - glossiness) * heroMipCount).xyz, w);
+    }
+    else
+    {
+        glossenv = mix(glossenv, textureLod(heroProbes,
+            vec4(env_mat * refnormpersp, 0),
+            (1.0 - glossiness) * heroMipCount).xyz, w);
+    }
 }
 
 #else

--- a/indra/newview/llheroprobemanager.cpp
+++ b/indra/newview/llheroprobemanager.cpp
@@ -189,6 +189,18 @@ void LLHeroProbeManager::update()
             mMirrorPosition = hero_pos;
             mMirrorNormal   = face_normal;
 
+            mIsPlanar = mNearestHero->getScale().mV[VZ] < 0.02f;
+
+            if (mIsPlanar)
+            {
+                LLVector3 camFwd = LLViewerCamera::instance().getAtAxis();
+                LLVector3 camUp  = LLViewerCamera::instance().getUpAxis();
+                mPlanarLookDir = camFwd - 2.0f * (camFwd * face_normal) * face_normal;
+                mPlanarUpDir   = camUp  - 2.0f * (camUp  * face_normal) * face_normal;
+                mPlanarLookDir.normalize();
+                mPlanarUpDir.normalize();
+            }
+
             probe_pos.load3(point.mV);
 
             // Detect visible faces of a cube based on camera direction and distance
@@ -264,15 +276,27 @@ void LLHeroProbeManager::renderProbes()
             LL_PROFILE_ZONE_NUM(rate);
 
             bool dynamic = mNearestHero->getReflectionProbeIsDynamic() && sDetail() > 0;
-            for (U32 i = 0; i < 6; ++i)
+
+            if (mIsPlanar)
             {
-                if ((gFrameCount % rate) == (i % rate))
-                { // update 6/rate faces per frame
-                    LL_PROFILE_ZONE_NUM(i);
-                    updateProbeFace(mProbes[0], i, dynamic, near_clip);
+                updateProbeFace(mProbes[0], 0, dynamic, near_clip);
+            }
+            else
+            {
+                for (U32 i = 0; i < 6; ++i)
+                {
+                    if ((gFrameCount % rate) == (i % rate))
+                    { // update 6/rate faces per frame
+                        LL_PROFILE_ZONE_NUM(i);
+                        updateProbeFace(mProbes[0], i, dynamic, near_clip);
+                    }
                 }
             }
-            generateRadiance(mProbes[0]);
+
+            if (!mIsPlanar)
+            {
+                generateRadiance(mProbes[0]);
+            }
         }
 
         mRenderingMirror = false;
@@ -300,7 +324,16 @@ void LLHeroProbeManager::updateProbeFace(LLReflectionMap* probe, U32 face, bool 
     // hacky hot-swap of camera specific render targets
     gPipeline.mRT = &gPipeline.mHeroProbeRT;
 
-    probe->update(mRenderTarget.getWidth(), face, is_dynamic, near_clip);
+    if (mIsPlanar)
+    {
+        probe->update(mRenderTarget.getWidth(), face, is_dynamic, near_clip,
+                      true, mCurrentClipPlane, &mPlanarLookDir, &mPlanarUpDir);
+    }
+    else
+    {
+        probe->update(mRenderTarget.getWidth(), face, is_dynamic, near_clip,
+                      true, mCurrentClipPlane);
+    }
 
     gPipeline.mRT = &gPipeline.mMainRT;
 
@@ -398,6 +431,13 @@ void LLHeroProbeManager::updateProbeFace(LLReflectionMap* probe, U32 face, bool 
                 mTexture->bind(0);
 
                 glCopyTexSubImage3D(GL_TEXTURE_CUBE_MAP_ARRAY, mip, 0, 0, sourceIdx * 6 + face, 0, 0, res, res);
+
+                if (mIsPlanar)
+                {
+                    // For planar probes we skip generateRadiance, so copy
+                    // directly to the probe's cubemap layer as well.
+                    glCopyTexSubImage3D(GL_TEXTURE_CUBE_MAP_ARRAY, mip, 0, 0, probe->mCubeIndex * 6 + face, 0, 0, res, res);
+                }
 
                 mTexture->unbind();
             }
@@ -518,6 +558,23 @@ void LLHeroProbeManager::updateUniforms()
 
         mHeroData.heroSphere.set(oa.getF32ptr());
         mHeroData.heroSphere.mV[3] = mProbes[0]->mRadius;
+
+        if (mIsPlanar)
+        {
+            mHeroData.heroShape = 2;
+
+            LLVector3 reflRight = mPlanarLookDir % mPlanarUpDir;
+            reflRight.normalize();
+
+            // Build rotation mapping world directions to face 0 cubemap space.
+            // initRows sets mMatrix[i] which becomes GLSL column i via std140,
+            // so each "row" argument here is actually a GLSL column.
+            mHeroData.heroPlaneMatrix.initRows(
+                LLVector4(mPlanarLookDir.mV[VX], -mPlanarUpDir.mV[VX], -reflRight.mV[VX], 0),
+                LLVector4(mPlanarLookDir.mV[VY], -mPlanarUpDir.mV[VY], -reflRight.mV[VY], 0),
+                LLVector4(mPlanarLookDir.mV[VZ], -mPlanarUpDir.mV[VZ], -reflRight.mV[VZ], 0),
+                LLVector4(0, 0, 0, 1));
+        }
     }
 
     llassert(mMipChain.size() <= size_t(S32_MAX));

--- a/indra/newview/llheroprobemanager.cpp
+++ b/indra/newview/llheroprobemanager.cpp
@@ -255,6 +255,7 @@ void LLHeroProbeManager::renderProbes()
 
         gPipeline.mReflectionMapManager.mRadiancePass = true;
         mRenderingMirror = true;
+        mHeroShadowsComplete = false;
 
         S32 rate = sUpdateRate;
 
@@ -293,10 +294,7 @@ void LLHeroProbeManager::renderProbes()
                 }
             }
 
-            if (!mIsPlanar)
-            {
-                generateRadiance(mProbes[0]);
-            }
+            generateRadiance(mProbes[0]);
         }
 
         mRenderingMirror = false;
@@ -431,13 +429,6 @@ void LLHeroProbeManager::updateProbeFace(LLReflectionMap* probe, U32 face, bool 
                 mTexture->bind(0);
 
                 glCopyTexSubImage3D(GL_TEXTURE_CUBE_MAP_ARRAY, mip, 0, 0, sourceIdx * 6 + face, 0, 0, res, res);
-
-                if (mIsPlanar)
-                {
-                    // For planar probes we skip generateRadiance, so copy
-                    // directly to the probe's cubemap layer as well.
-                    glCopyTexSubImage3D(GL_TEXTURE_CUBE_MAP_ARRAY, mip, 0, 0, probe->mCubeIndex * 6 + face, 0, 0, res, res);
-                }
 
                 mTexture->unbind();
             }

--- a/indra/newview/llheroprobemanager.h
+++ b/indra/newview/llheroprobemanager.h
@@ -92,6 +92,8 @@ public:
     LLVector3     mMirrorNormal;
     HeroProbeData mHeroData;
 
+    bool mHeroShadowsComplete = false;
+
 private:
     friend class LLPipeline;
     friend class LLReflectionMapManager;

--- a/indra/newview/llheroprobemanager.h
+++ b/indra/newview/llheroprobemanager.h
@@ -45,6 +45,7 @@ struct HeroProbeData
     GLint     heroShape;
     GLint     heroMipCount;
     GLint     heroProbeCount;
+    LLMatrix4 heroPlaneMatrix;
 };
 
 class alignas(16) LLHeroProbeManager
@@ -113,6 +114,10 @@ private:
     LLPointer<LLVertexBuffer> mVertexBuffer;
 
     LLPlane mCurrentClipPlane;
+
+    bool mIsPlanar = false;
+    LLVector3 mPlanarLookDir;
+    LLVector3 mPlanarUpDir;
 
 
     // update the specified face of the specified probe

--- a/indra/newview/llreflectionmap.cpp
+++ b/indra/newview/llreflectionmap.cpp
@@ -49,7 +49,8 @@ LLReflectionMap::~LLReflectionMap()
     }
 }
 
-void LLReflectionMap::update(U32 resolution, U32 face, bool force_dynamic, F32 near_clip, bool useClipPlane, LLPlane clipPlane)
+void LLReflectionMap::update(U32 resolution, U32 face, bool force_dynamic, F32 near_clip, bool useClipPlane, LLPlane clipPlane,
+    const LLVector3* overrideLookDir, const LLVector3* overrideUpDir)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DISPLAY;
     if (!mCubeArray.notNull())
@@ -70,7 +71,8 @@ void LLReflectionMap::update(U32 resolution, U32 face, bool force_dynamic, F32 n
     F32 clip = (near_clip > 0) ? near_clip : getNearClip();
     bool dynamic = force_dynamic || getIsDynamic();
 
-    gViewerWindow->cubeSnapshot(LLVector3(mOrigin), mCubeArray, mCubeIndex, face, clip, dynamic, useClipPlane, clipPlane);
+    gViewerWindow->cubeSnapshot(LLVector3(mOrigin), mCubeArray, mCubeIndex, face, clip, dynamic, useClipPlane, clipPlane,
+        overrideLookDir, overrideUpDir);
 }
 
 void LLReflectionMap::autoAdjustOrigin()

--- a/indra/newview/llreflectionmap.h
+++ b/indra/newview/llreflectionmap.h
@@ -52,7 +52,8 @@ public:
 
     // update this environment map
     // resolution - size of cube map to generate
-    void update(U32 resolution, U32 face, bool force_dynamic = false, F32 near_clip = -1.f, bool useClipPlane = false, LLPlane clipPlane = LLPlane(LLVector3(0, 0, 0), LLVector3(0, 0, 1)));
+    void update(U32 resolution, U32 face, bool force_dynamic = false, F32 near_clip = -1.f, bool useClipPlane = false, LLPlane clipPlane = LLPlane(LLVector3(0, 0, 0), LLVector3(0, 0, 1)),
+                const LLVector3* overrideLookDir = nullptr, const LLVector3* overrideUpDir = nullptr);
 
     // for volume partition probes, try to place this probe in the best spot
     void autoAdjustOrigin();

--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -1302,6 +1302,7 @@ void LLReflectionMapManager::updateUniforms()
     mProbeData.heroShape  = gPipeline.mHeroProbeManager.mHeroData.heroShape;
     mProbeData.heroMipCount   = gPipeline.mHeroProbeManager.mHeroData.heroMipCount;
     mProbeData.heroProbeCount = gPipeline.mHeroProbeManager.mHeroData.heroProbeCount;
+    mProbeData.heroPlaneMatrix = gPipeline.mHeroProbeManager.mHeroData.heroPlaneMatrix;
 
     //copy mProbeData into uniform buffer object
     if (mUBO == 0)

--- a/indra/newview/llreflectionmapmanager.h
+++ b/indra/newview/llreflectionmapmanager.h
@@ -99,6 +99,8 @@ public:
         GLint heroShape;
         GLint heroMipCount;
         GLint heroProbeCount;
+
+        LLMatrix4 heroPlaneMatrix;
     };
 
     // allocate an environment map of the given resolution

--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -1195,9 +1195,14 @@ void display_cube_face()
     display_update_camera();
 
     {
-        LL_PROFILE_ZONE_NAMED_CATEGORY_DISPLAY("Env Update");
-        // update all the sky/atmospheric/water settings
-        LLEnvironment::instance().update(LLViewerCamera::getInstance());
+        bool heroSkipEnv = gPipeline.mHeroProbeManager.isMirrorPass()
+                        && gPipeline.mHeroProbeManager.mHeroShadowsComplete;
+        if (!heroSkipEnv)
+        {
+            LL_PROFILE_ZONE_NAMED_CATEGORY_DISPLAY("Env Update");
+            // update all the sky/atmospheric/water settings
+            LLEnvironment::instance().update(LLViewerCamera::getInstance());
+        }
     }
 
     LLSpatialGroup::sNoDelete = true;
@@ -1214,7 +1219,17 @@ void display_cube_face()
     gGL.setColorMask(true, true);
 
     glClearColor(0.f, 0.f, 0.f, 0.f);
-    gPipeline.generateSunShadow(*LLViewerCamera::getInstance());
+
+    {
+        bool heroSkipShadow = gPipeline.mHeroProbeManager.isMirrorPass()
+                           && gPipeline.mHeroProbeManager.mHeroShadowsComplete;
+        if (!heroSkipShadow)
+        {
+            gPipeline.generateSunShadow(*LLViewerCamera::getInstance());
+            if (gPipeline.mHeroProbeManager.isMirrorPass())
+                gPipeline.mHeroProbeManager.mHeroShadowsComplete = true;
+        }
+    }
 
     glClear(GL_DEPTH_BUFFER_BIT); // | GL_STENCIL_BUFFER_BIT);
 

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -5481,7 +5481,8 @@ bool LLViewerWindow::simpleSnapshot(LLImageRaw* raw, S32 image_width, S32 image_
 
 void display_cube_face();
 
-bool LLViewerWindow::cubeSnapshot(const LLVector3& origin, LLCubeMapArray* cubearray, S32 cubeIndex, S32 face, F32 near_clip, bool dynamic_render, bool useCustomClipPlane, LLPlane clipPlane)
+bool LLViewerWindow::cubeSnapshot(const LLVector3& origin, LLCubeMapArray* cubearray, S32 cubeIndex, S32 face, F32 near_clip, bool dynamic_render, bool useCustomClipPlane, LLPlane clipPlane,
+    const LLVector3* overrideLookDir, const LLVector3* overrideUpDir)
 {
     // NOTE: implementation derived from LLFloater360Capture::capture360Images() and simpleSnapshot
     LL_PROFILE_ZONE_SCOPED_CATEGORY_APP;
@@ -5584,7 +5585,10 @@ bool LLViewerWindow::cubeSnapshot(const LLVector3& origin, LLCubeMapArray* cubea
     int i = face;
     {
         // set up camera to look in each direction
-        camera->lookDir(look_dirs[i], look_upvecs[i]);
+        if (overrideLookDir && overrideUpDir)
+            camera->lookDir(*overrideLookDir, *overrideUpDir);
+        else
+            camera->lookDir(look_dirs[i], look_upvecs[i]);
 
         // turning this flag off here prohibits the screen swap
         // to present the new page to the viewer - this stops

--- a/indra/newview/llviewerwindow.h
+++ b/indra/newview/llviewerwindow.h
@@ -388,7 +388,8 @@ public:
     // face - which cube face to update
     // near_clip - near clip setting to use
     bool cubeSnapshot(const LLVector3 &origin, LLCubeMapArray *cubearray, S32 index, S32 face, F32 near_clip, bool render_avatars,
-                      bool customCullingPlane = false, LLPlane cullingPlane = LLPlane(LLVector3(0, 0, 0), LLVector3(0, 0, 1)));
+                      bool customCullingPlane = false, LLPlane cullingPlane = LLPlane(LLVector3(0, 0, 0), LLVector3(0, 0, 1)),
+                      const LLVector3* overrideLookDir = nullptr, const LLVector3* overrideUpDir = nullptr);
 
 
     // special implementation of simpleSnapshot for reflection maps


### PR DESCRIPTION
Planar mirrors work by rendering only one of the six probe faces, significantly improving performance for "thin" or "planar" mirror probe volumes.  Also: only render shadow once per mirror probe.