### PR TITLE
[WebRTC] Add new connection when attempting to re-establish a session that's being torn down

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -11,7 +11,7 @@
  * License as published by the Free Software Foundation
  * version 2.1 of the License only.
  *
- * This library is distributed in the hope that it will be useful,
+ * This library is distributed in the hope that it will be useful,VOICE_STATE
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
@@ -2054,6 +2054,26 @@ void LLWebRTCVoiceClient::sessionState::revive()
     mShuttingDown = false;
 }
 
+void LLWebRTCVoiceClient::parcelSessionState::revive()
+{
+    sessionState::revive();
+    LLUUID region_id = gAgent.getRegion()->getRegionID();
+    connectionPtr_t connection = std::make_shared<LLVoiceWebRTCSpatialConnection>(region_id, mParcelLocalID, mChannelID);
+    mWebRTCConnections.push_back(connection);
+    connection->setMuteMic(mMuted);
+    connection->setSpeakerVolume(mSpeakerVolume);
+}
+
+void LLWebRTCVoiceClient::adhocSessionState::revive()
+{
+    sessionState::revive();
+    LLUUID region_id = gAgent.getRegion()->getRegionID();
+    connectionPtr_t connection = std::make_shared<LLVoiceWebRTCAdHocConnection>(region_id, mChannelID, mCredentials);
+    mWebRTCConnections.push_back(connection);
+    connection->setMuteMic(mMuted);
+    connection->setSpeakerVolume(mSpeakerVolume);
+}
+
 //=========================================================================
 // the following are methods to support the coroutine implementation of the
 // voice connection and processing.  They should only be called in the context
@@ -2202,6 +2222,7 @@ LLWebRTCVoiceClient::estateSessionState::estateSessionState()
 }
 
 LLWebRTCVoiceClient::parcelSessionState::parcelSessionState(const std::string &channelID, S32 parcel_local_id)
+    : mParcelLocalID(parcel_local_id)
 {
     mHangupOnLastLeave = false;
     mNotifyOnFirstJoin = false;

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -284,7 +284,7 @@ public:
         static ptr_t matchSessionByChannelID(const std::string& channel_id);
 
         void shutdownAllConnections();
-        void revive();
+        virtual void revive();
 
         static void processSessionStates();
 
@@ -361,9 +361,14 @@ public:
       public:
         parcelSessionState(const std::string& channelID, S32 parcel_local_id);
 
+        void revive() override;
+
         bool isSpatial() override { return true; }
         bool isEstate() override { return false; }
         bool isCallbackPossible() override { return false; }
+
+      private:
+        S32 mParcelLocalID;
     };
 
     class adhocSessionState : public sessionState
@@ -373,6 +378,8 @@ public:
             const std::string& credentials,
             bool notify_on_first_join,
             bool hangup_on_last_leave);
+
+        void revive() override;
 
         bool isSpatial() override { return false; }
         bool isEstate() override { return false; }


### PR DESCRIPTION
In WebRTC, when tearing down a session with one or more connections, we run into a case where we want to re-establish that session.  We need to let the existing connections die, and add new ones to replace them.

Estate voice does this automatically, but parcel and adhoc did not. This changes it so that reviving sessions does add the appropriate connections.

