### PR TITLE
#5426 Fix crash in LLPointer<LLImageGL>::notNull

### DIFF
--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -1096,7 +1096,17 @@ F32 LLViewerTextureList::updateImagesCreateTextures(F32 max_time)
 
     while (!mCreateTextureList.empty())
     {
-        LLViewerFetchedTexture* imagep = mCreateTextureList.front();
+        // Hold a smart pointer to keep the texture alive throughout processing,
+        // even if side effects (e.g. pipeline rebuilds, GL operations) indirectly
+        // cause other references to be released. (see: #5426)
+        LLPointer<LLViewerFetchedTexture> imagep = mCreateTextureList.front();
+        mCreateTextureList.pop();
+
+        if (!imagep)
+        {
+            continue;
+        }
+
         llassert(imagep->mCreatePending);
 
         // desired discard may change while an image is being decoded. If the texture in VRAM is sufficient
@@ -1121,8 +1131,6 @@ F32 LLViewerTextureList::updateImagesCreateTextures(F32 max_time)
             LL_WARNS_ONCE("Texture") << "Texture will be downscaled immediately after loading." << LL_ENDL;
             imagep->scaleDown();
         }
-
-        mCreateTextureList.pop();
 
         if (create_timer.getElapsedTimeF32() > max_time)
         {


### PR DESCRIPTION
## Description

Use LLPointer smart pointer to hold texture references during processing in updateImagesCreateTextures(). This ensures the object stays alive even if side effects from image operations cause other references to be released.
Fixes access violation when processing texture queue.

## Related Issues

Issue Link: #5426 