### PR TITLE
#5427 Fix crash in LLViewerObject::getParameterEntry()

### DIFF
--- a/indra/newview/llface.cpp
+++ b/indra/newview/llface.cpp
@@ -2364,7 +2364,7 @@ bool LLFace::calcPixelArea(F32& cos_angle_to_view_dir, F32& radius)
         center.mul(0.5f);
         size.setSub(mRiggedExtents[1], mRiggedExtents[0]);
     }
-    else if (mDrawablep && mVObjp.notNull() && mVObjp->getPartitionType() == LLViewerRegion::PARTITION_PARTICLE && mDrawablep->getSpatialGroup())
+    else if (mDrawablep && mVObjp.notNull() && !mVObjp->isDead() && mVObjp->getPartitionType() == LLViewerRegion::PARTITION_PARTICLE && mDrawablep->getSpatialGroup())
     { // use box of spatial group for particles (over approximates size, but we don't actually have a good size per particle)
         LLSpatialGroup* group = mDrawablep->getSpatialGroup();
         const LLVector4a* extents = group->getExtents();

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -931,7 +931,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
             {
                 LLFace* face = (*(imagep->getFaceList(i)))[fi];
 
-                if (face && face->getViewerObject())
+                if (face && face->getViewerObject() && !face->getViewerObject()->isDead())
                 {
                     F32 radius;
                     F32 cos_angle_to_view_dir;


### PR DESCRIPTION
## Description

Add isDead() checks before accessing viewer object properties during texture updates to prevent crashes when objects are in an invalid/dying state.

Fixes issue where concurrent object deletion and texture priority updates could access properties of dead objects, triggering assertion failures.

## Related Issues

Issue Link: #5427