### PR TITLE
#5084 Convert watchdog to a simpleton

### DIFF
--- a/indra/llcommon/llwatchdog.cpp
+++ b/indra/llcommon/llwatchdog.cpp
@@ -87,7 +87,7 @@ void LLWatchdogEntry::start()
 void LLWatchdogEntry::stop()
 {
     // this can happen very late in the shutdown sequence
-    if (!LLWatchdog::wasDeleted())
+    if (LLWatchdog::instanceExists())
     {
         LLWatchdog::getInstance()->remove(this);
     }

--- a/indra/llcommon/llwatchdog.h
+++ b/indra/llcommon/llwatchdog.h
@@ -83,12 +83,12 @@ private:
 };
 
 class LLWatchdogTimerThread; // Defined in the cpp
-class LLWatchdog : public LLSingleton<LLWatchdog>
+class LLWatchdog : public LLSimpleton<LLWatchdog>
 {
-    LLSINGLETON(LLWatchdog);
+public:
+    LLWatchdog();
     ~LLWatchdog();
 
-public:
     // Add an entry to the watchdog.
     void add(LLWatchdogEntry* e);
     void remove(LLWatchdogEntry* e);

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -1240,6 +1240,7 @@ bool LLAppViewer::init()
     // TODO: consider moving proxy initialization here or LLCopocedureManager after proxy initialization, may be implement
     // some other protection to make sure we don't use network before initializng proxy
 
+    LLWatchdog::createInstance();
     /*----------------------------------------------------------------------*/
     // nat 2016-06-29 moved the following here from the former mainLoop().
     mMainloopTimeout = new LLWatchdogTimeout("mainloop");


### PR DESCRIPTION
It looks like main thread locks singleton then tries to lock list, while watchdog thread locks list then tries to lock singleton. Converted to simpleton, LLSingleton's dependency and lifetime management is an overkill for watchdog. 