### PR TITLE
Introduce separable SSR and Hi-Z tracing.

### DIFF
--- a/indra/llrender/llrendertarget.cpp
+++ b/indra/llrender/llrendertarget.cpp
@@ -383,6 +383,32 @@ void LLRenderTarget::resetDepthMipLevel()
     glDrawBuffers((GLsizei)mTex.size(), drawbuffers);
 }
 
+void LLRenderTarget::bindColorMipLevel(S32 level, U32 attachment)
+{
+    llassert(mFBO);
+    llassert(attachment < mTex.size());
+    llassert(level < (S32)mMipLevels);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, mFBO);
+    sCurFBO = mFBO;
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + attachment,
+        LLTexUnit::getInternalType(mUsage), mTex[attachment], level);
+
+    S32 w = llmax(1, (S32)(mResX >> level));
+    S32 h = llmax(1, (S32)(mResY >> level));
+    glViewport(0, 0, w, h);
+}
+
+void LLRenderTarget::resetColorMipLevel(U32 attachment)
+{
+    llassert(mFBO);
+    llassert(attachment < mTex.size());
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + attachment,
+        LLTexUnit::getInternalType(mUsage), mTex[attachment], 0);
+    glViewport(0, 0, mResX, mResY);
+}
+
 void LLRenderTarget::shareDepthBuffer(LLRenderTarget& target)
 {
     llassert(!isBoundInStack());

--- a/indra/llrender/llrendertarget.cpp
+++ b/indra/llrender/llrendertarget.cpp
@@ -95,9 +95,28 @@ void LLRenderTarget::resize(U32 resx, U32 resy)
     {
         gGL.getTexUnit(0)->bindManual(mUsage, mDepth);
         U32 internal_type = LLTexUnit::getInternalType(mUsage);
-        LLImageGL::setManualImage(internal_type, 0, GL_DEPTH_COMPONENT24, mResX, mResY, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL, false);
 
-        sBytesAllocated += pix_diff*4;
+        if (mGenerateMipMaps != LLTexUnit::TMG_NONE && mMipLevels > 1)
+        {
+            // Recalculate mip levels for new resolution
+            mMipLevels = 1 + (U32)floor(log10((float)llmax(mResX, mResY)) / log10(2.0));
+
+            for (U32 level = 0; level < mMipLevels; level++)
+            {
+                U32 w = llmax(1U, mResX >> level);
+                U32 h = llmax(1U, mResY >> level);
+                glTexImage2D(internal_type, level, GL_DEPTH_COMPONENT24, w, h, 0,
+                             GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
+            }
+            glTexParameteri(internal_type, GL_TEXTURE_MAX_LEVEL, mMipLevels - 1);
+
+            sBytesAllocated += (S32)(pix_diff * 4 * 1.33f);
+        }
+        else
+        {
+            LLImageGL::setManualImage(internal_type, 0, GL_DEPTH_COMPONENT24, mResX, mResY, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL, false);
+            sBytesAllocated += pix_diff * 4;
+        }
     }
 }
 
@@ -300,10 +319,29 @@ bool LLRenderTarget::allocateDepth()
     U32 internal_type = LLTexUnit::getInternalType(mUsage);
     stop_glerror();
     clear_glerror();
-    LLImageGL::setManualImage(internal_type, 0, GL_DEPTH_COMPONENT24, mResX, mResY, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL, false);
-    gGL.getTexUnit(0)->setTextureFilteringOption(LLTexUnit::TFO_POINT);
 
-    sBytesAllocated += mResX*mResY*4;
+    if (mGenerateMipMaps != LLTexUnit::TMG_NONE && mMipLevels > 1)
+    {
+        // Allocate depth mip chain for Hi-Z pyramid generation.
+        for (U32 level = 0; level < mMipLevels; level++)
+        {
+            U32 w = llmax(1U, mResX >> level);
+            U32 h = llmax(1U, mResY >> level);
+            glTexImage2D(internal_type, level, GL_DEPTH_COMPONENT24, w, h, 0,
+                         GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
+        }
+        glTexParameteri(internal_type, GL_TEXTURE_MAX_LEVEL, mMipLevels - 1);
+
+        // ~33% extra for mip chain
+        sBytesAllocated += (U32)(mResX * mResY * 4 * 1.33f);
+    }
+    else
+    {
+        LLImageGL::setManualImage(internal_type, 0, GL_DEPTH_COMPONENT24, mResX, mResY, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL, false);
+        sBytesAllocated += mResX * mResY * 4;
+    }
+
+    gGL.getTexUnit(0)->setTextureFilteringOption(LLTexUnit::TFO_POINT);
 
     if (glGetError() != GL_NO_ERROR)
     {
@@ -312,6 +350,37 @@ bool LLRenderTarget::allocateDepth()
     }
 
     return true;
+}
+
+void LLRenderTarget::bindDepthMipLevel(S32 level)
+{
+    llassert(mFBO);
+    llassert(mDepth);
+    llassert(level < (S32)mMipLevels);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, mFBO);
+    sCurFBO = mFBO;
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+        LLTexUnit::getInternalType(mUsage), mDepth, level);
+    glDrawBuffer(GL_NONE);
+
+    S32 w = llmax(1, (S32)(mResX >> level));
+    S32 h = llmax(1, (S32)(mResY >> level));
+    glViewport(0, 0, w, h);
+}
+
+void LLRenderTarget::resetDepthMipLevel()
+{
+    llassert(mFBO);
+    llassert(mDepth);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+        LLTexUnit::getInternalType(mUsage), mDepth, 0);
+    glViewport(0, 0, mResX, mResY);
+
+    GLenum drawbuffers[] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1,
+                            GL_COLOR_ATTACHMENT2, GL_COLOR_ATTACHMENT3};
+    glDrawBuffers((GLsizei)mTex.size(), drawbuffers);
 }
 
 void LLRenderTarget::shareDepthBuffer(LLRenderTarget& target)

--- a/indra/llrender/llrendertarget.cpp
+++ b/indra/llrender/llrendertarget.cpp
@@ -416,6 +416,21 @@ void LLRenderTarget::shareDepthBuffer(LLRenderTarget& target)
     }
 }
 
+void LLRenderTarget::blitDepthFrom(LLRenderTarget& source)
+{
+    llassert(mFBO);
+    llassert(source.mFBO);
+    llassert(mDepth);       // this target must own its depth buffer
+    llassert(source.mDepth); // source must have depth
+
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, source.mFBO);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mFBO);
+    glBlitFramebuffer(0, 0, source.mResX, source.mResY,
+                      0, 0, mResX, mResY,
+                      GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+    glBindFramebuffer(GL_FRAMEBUFFER, sCurFBO);
+}
+
 void LLRenderTarget::release()
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DISPLAY;

--- a/indra/llrender/llrendertarget.h
+++ b/indra/llrender/llrendertarget.h
@@ -162,6 +162,13 @@ public:
     // Restore FBO depth attachment to mip level 0 and full viewport.
     void resetDepthMipLevel();
 
+    // Rebind FBO color attachment at a specific mip level and set viewport.
+    // Used for per-mip SSR filter. Caller must call resetColorMipLevel() when done.
+    void bindColorMipLevel(S32 level, U32 attachment = 0);
+
+    // Restore FBO color attachment to mip level 0 and full viewport.
+    void resetColorMipLevel(U32 attachment = 0);
+
     void bindTexture(U32 index, S32 channel, LLTexUnit::eTextureFilterOptions filter_options = LLTexUnit::TFO_BILINEAR);
 
     //flush rendering operations

--- a/indra/llrender/llrendertarget.h
+++ b/indra/llrender/llrendertarget.h
@@ -148,6 +148,14 @@ public:
     U32 getNumTextures() const;
 
     U32 getDepth(void) const { return mDepth; }
+    U32 getMipLevels() const { return mMipLevels; }
+
+    // Rebind FBO depth attachment at a specific mip level and set viewport.
+    // Used for Hi-Z pyramid generation. Caller must call resetDepthMipLevel() when done.
+    void bindDepthMipLevel(S32 level);
+
+    // Restore FBO depth attachment to mip level 0 and full viewport.
+    void resetDepthMipLevel();
 
     void bindTexture(U32 index, S32 channel, LLTexUnit::eTextureFilterOptions filter_options = LLTexUnit::TFO_BILINEAR);
 

--- a/indra/llrender/llrendertarget.h
+++ b/indra/llrender/llrendertarget.h
@@ -116,6 +116,11 @@ public:
     //share depth buffer with provided render target
     void shareDepthBuffer(LLRenderTarget& target);
 
+    //blit depth from source render target into this target's depth buffer
+    //supports different resolutions (nearest-filter downsample/upsample)
+    //this target must have its own depth buffer allocated
+    void blitDepthFrom(LLRenderTarget& source);
+
     //free any allocated resources
     //safe to call redundantly
     // asserts that this target is not currently bound or present in the RT stack

--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -1389,14 +1389,10 @@ void LLShaderMgr::initAttribsAndUniforms()
     llassert(mReservedUniforms.size() == LLShaderMgr::DEFERRED_SHADOW_TARGET_WIDTH + 1);
 
     mReservedUniforms.push_back("iterationCount");
-    mReservedUniforms.push_back("rayStep");
-    mReservedUniforms.push_back("distanceBias");
-    mReservedUniforms.push_back("depthRejectBias");
+    mReservedUniforms.push_back("maxThickness");
+    mReservedUniforms.push_back("depthBias");
     mReservedUniforms.push_back("glossySampleCount");
     mReservedUniforms.push_back("noiseSine");
-    mReservedUniforms.push_back("adaptiveStepMultiplier");
-    mReservedUniforms.push_back("splitParamsStart");
-    mReservedUniforms.push_back("splitParamsEnd");
     mReservedUniforms.push_back("maxZDepth");
     mReservedUniforms.push_back("maxRoughness");
 

--- a/indra/llrender/llshadermgr.h
+++ b/indra/llrender/llshadermgr.h
@@ -184,14 +184,10 @@ public:
         DEFERRED_SHADOW_TARGET_WIDTH,       //  "shadow_target_width"
 
         DEFERRED_SSR_ITR_COUNT,             //  "iterationCount"
-        DEFERRED_SSR_RAY_STEP,              //  "rayStep"
-        DEFERRED_SSR_DIST_BIAS,             //  "distanceBias"
-        DEFERRED_SSR_REJECT_BIAS,           //  "depthRejectBias"
+        DEFERRED_SSR_MAX_THICKNESS,         //  "maxThickness"
+        DEFERRED_SSR_DEPTH_BIAS,            //  "depthBias"
         DEFERRED_SSR_GLOSSY_SAMPLES,        //  "glossySampleCount"
         DEFERRED_SSR_NOISE_SINE,            //  "noiseSine"
-        DEFERRED_SSR_ADAPTIVE_STEP_MULT,    //  "adaptiveStepMultiplier"
-        DEFERRED_SSR_SPLIT_START,           //  "splitParamsStart"
-        DEFERRED_SSR_SPLIT_END,             //  "splitParamsEnd"
         DEFERRED_SSR_MAX_Z,                 //  "maxZDepth"
         DEFERRED_SSR_MAX_ROUGHNESS,         //  "maxRoughness"
 

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -7720,107 +7720,35 @@
   <key>RenderScreenSpaceReflectionIterations</key>
   <map>
     <key>Comment</key>
-    <string>X = max ray march steps. Y, Z unused.</string>
+    <string>Maximum ray march iterations for Hi-Z SSR trace.</string>
     <key>Persist</key>
     <integer>1</integer>
     <key>Type</key>
-    <string>Vector3</string>
+    <string>S32</string>
     <key>Value</key>
-    <array>
-      <real>64</real>
-      <real>16</real>
-      <real>16</real>
-    </array>
+    <integer>48</integer>
   </map>
-  <key>RenderScreenSpaceReflectionRayStep</key>
+  <key>RenderScreenSpaceReflectionMaxThickness</key>
   <map>
     <key>Comment</key>
-    <string>X = initial ray march step size. Y, Z unused.</string>
+    <string>Maximum thickness for SSR hit validation (view-space units).</string>
     <key>Persist</key>
     <integer>1</integer>
     <key>Type</key>
-    <string>Vector3</string>
+    <string>F32</string>
     <key>Value</key>
-    <array>
-      <real>0.025</real>
-      <real>0.75</real>
-      <real>1</real>
-    </array>
+    <real>1.0</real>
   </map>
-  <key>RenderScreenSpaceReflectionDistanceBias</key>
+  <key>RenderScreenSpaceReflectionDepthBias</key>
   <map>
     <key>Comment</key>
-    <string>X = max step size cap. Y, Z unused.</string>
+    <string>Depth bias scale for SSR ray origin offset along surface normal.</string>
     <key>Persist</key>
     <integer>1</integer>
     <key>Type</key>
-    <string>Vector3</string>
+    <string>F32</string>
     <key>Value</key>
-    <array>
-      <real>10.0</real>
-      <real>0.4</real>
-      <real>10</real>
-    </array>
-  </map>
-  <key>RenderScreenSpaceReflectionDepthRejectBias</key>
-  <map>
-    <key>Comment</key>
-    <string>X = max thickness for hit validation. Y = depth bias scale for ray origin offset. Z unused.</string>
-    <key>Persist</key>
-    <integer>1</integer>
-    <key>Type</key>
-    <string>Vector3</string>
-    <key>Value</key>
-    <array>
-      <real>1.0</real>
-      <real>0</real>
-      <real>0.001</real>
-    </array>
-  </map>
-  <key>RenderScreenSpaceReflectionAdaptiveStepMultiplier</key>
-  <map>
-    <key>Comment</key>
-    <string>X = step growth rate per iteration. Y, Z unused.</string>
-    <key>Persist</key>
-    <integer>1</integer>
-    <key>Type</key>
-    <string>Vector3</string>
-    <key>Value</key>
-    <array>
-      <real>1.13</real>
-      <real>1.5</real>
-      <real>2</real>
-    </array>
-  </map>
-  <key>RenderScreenSpaceReflectionSplitStart</key>
-  <map>
-    <key>Comment</key>
-    <string>Starting splits for each SSR pass.</string>
-    <key>Persist</key>
-    <integer>1</integer>
-    <key>Type</key>
-    <string>Vector3</string>
-    <key>Value</key>
-    <array>
-      <real>0</real>
-      <real>5</real>
-      <real>50</real>
-    </array>
-  </map>
-  <key>RenderScreenSpaceReflectionSplitEnd</key>
-  <map>
-    <key>Comment</key>
-    <string>Ending splits for each SSR pass.</string>
-    <key>Persist</key>
-    <integer>1</integer>
-    <key>Type</key>
-    <string>Vector3</string>
-    <key>Value</key>
-    <array>
-      <real>25</real>
-      <real>150</real>
-      <real>1000</real>
-    </array>
+    <real>0.0</real>
   </map>
   <key>RenderScreenSpaceReflectionGlossySamples</key>
   <map>
@@ -7831,7 +7759,7 @@
     <key>Type</key>
     <string>S32</string>
     <key>Value</key>
-    <integer>4</integer>
+    <integer>2</integer>
   </map>
   <key>RenderScreenSpaceReflectionMaxDepth</key>
   <map>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -7855,6 +7855,28 @@
     <key>Value</key>
     <real>1</real>
   </map>
+  <key>RenderScreenSpaceReflectionsFilterScale</key>
+  <map>
+    <key>Comment</key>
+    <string>Blur size for the SSR spatial filter (0.0 to disable, default 2.0).</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>F32</string>
+    <key>Value</key>
+    <real>2.0</real>
+  </map>
+  <key>RenderScreenSpaceReflectionsResolutionMultiplier</key>
+  <map>
+    <key>Comment</key>
+    <string>Resolution multiplier for the SSR buffer (0.25 to 1.0).</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>F32</string>
+    <key>Value</key>
+    <real>1.0</real>
+  </map>
   <key>RenderBumpmapMinDistanceSquared</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/app_settings/shaders/class1/deferred/hiZReduceF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/hiZReduceF.glsl
@@ -1,0 +1,66 @@
+/**
+ * @file class1/deferred/hiZReduceF.glsl
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2024, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+// Min-reduce downsample for Hi-Z pyramid generation.
+// Reads 2x2 block from source mip level, outputs min to gl_FragDepth.
+// Handles odd source dimensions by sampling the extra column/row,
+// matching Godot's MODE_ODD_WIDTH / MODE_ODD_HEIGHT behavior.
+
+uniform sampler2D depthMap;
+uniform int srcLevel;
+
+void main()
+{
+    ivec2 destCoord = ivec2(gl_FragCoord.xy);
+    ivec2 srcCoord  = destCoord * 2;
+    ivec2 srcSize   = textureSize(depthMap, srcLevel);
+
+    float d0 = texelFetch(depthMap, srcCoord, srcLevel).r;
+    float d1 = texelFetch(depthMap, min(srcCoord + ivec2(1, 0), srcSize - 1), srcLevel).r;
+    float d2 = texelFetch(depthMap, min(srcCoord + ivec2(0, 1), srcSize - 1), srcLevel).r;
+    float d3 = texelFetch(depthMap, min(srcCoord + ivec2(1, 1), srcSize - 1), srcLevel).r;
+
+    float depth = min(min(d0, d1), min(d2, d3));
+
+    // When the source has an odd dimension, the last dest texel's 2x2 block
+    // doesn't cover the final row/column. Sample the extra texels so the
+    // Hi-Z guarantee (min of all covered texels) is maintained.
+    if ((srcSize.x & 1) == 1)
+    {
+        depth = min(depth, texelFetch(depthMap, min(srcCoord + ivec2(2, 0), srcSize - 1), srcLevel).r);
+        depth = min(depth, texelFetch(depthMap, min(srcCoord + ivec2(2, 1), srcSize - 1), srcLevel).r);
+    }
+    if ((srcSize.y & 1) == 1)
+    {
+        depth = min(depth, texelFetch(depthMap, min(srcCoord + ivec2(0, 2), srcSize - 1), srcLevel).r);
+        depth = min(depth, texelFetch(depthMap, min(srcCoord + ivec2(1, 2), srcSize - 1), srcLevel).r);
+    }
+    if ((srcSize.x & 1) == 1 && (srcSize.y & 1) == 1)
+    {
+        depth = min(depth, texelFetch(depthMap, min(srcCoord + ivec2(2, 2), srcSize - 1), srcLevel).r);
+    }
+
+    gl_FragDepth = depth;
+}

--- a/indra/newview/app_settings/shaders/class1/deferred/postDeferredVisualizeBuffers.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/postDeferredVisualizeBuffers.glsl
@@ -36,6 +36,6 @@ void main()
 {
     vec4 diff = textureLod(diffuseRect, vary_fragcoord.xy, mipLevel);
 
-    frag_color = (diff * 0.5 + 0.5);
+    frag_color = diff;
 }
 

--- a/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
@@ -25,14 +25,11 @@
 
 #define FLT_MAX 3.402823466e+38
 
-#if defined(SSR)
-float tapScreenSpaceReflection(int totalSamples, vec2 tc, vec3 viewPos, vec3 n, inout vec4 collectedColor, sampler2D source, float glossiness);
-#endif
-
 uniform samplerCubeArray   reflectionProbes;
 uniform samplerCubeArray   irradianceProbes;
 
 uniform sampler2D sceneMap;
+uniform vec2 screen_res;
 uniform int cube_snapshot;
 uniform float max_probe_lod;
 
@@ -803,17 +800,10 @@ void doProbeSample(inout vec3 ambenv, inout vec3 glossenv,
 #if defined(SSR)
     if (cube_snapshot != 1)
     {
-        vec4 ssr = vec4(0);
-        if (transparent)
-        {
-            tapScreenSpaceReflection(1, tc, pos, norm, ssr, sceneMap, 1);
-            ssr.a *= glossiness;
-        }
-        else
-        {
-            tapScreenSpaceReflection(1, tc, pos, norm, ssr, sceneMap, glossiness);
-        }
+        vec4 ssr = texture(sceneMap, tc);
 
+        if (transparent)
+            ssr.a *= glossiness;
 
         glossenv = mix(glossenv, ssr.rgb, ssr.a);
     }
@@ -918,17 +908,10 @@ void sampleReflectionProbesLegacy(inout vec3 ambenv, inout vec3 glossenv, inout 
 #if defined(SSR)
     if (cube_snapshot != 1)
     {
-        vec4 ssr = vec4(0);
+        vec4 ssr = texture(sceneMap, tc);
 
         if (transparent)
-        {
-            tapScreenSpaceReflection(1, tc, pos, norm, ssr, sceneMap, 1);
             ssr.a *= glossiness;
-        }
-        else
-        {
-            tapScreenSpaceReflection(1, tc, pos, norm, ssr, sceneMap, glossiness);
-        }
 
         glossenv = mix(glossenv, ssr.rgb, ssr.a);
         legacyenv = mix(legacyenv, ssr.rgb, ssr.a);

--- a/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
@@ -35,6 +35,8 @@ uniform float max_probe_lod;
 
 uniform bool transparent_surface;
 
+uniform float ssrMipScale;
+
 uniform int classic_mode;
 
 #define MAX_REFMAP_COUNT 256  // must match LL_MAX_REFLECTION_PROBE_COUNT
@@ -800,12 +802,30 @@ void doProbeSample(inout vec3 ambenv, inout vec3 glossenv,
 #if defined(SSR)
     if (cube_snapshot != 1)
     {
-        vec4 ssr = texture(sceneMap, tc);
+        float roughness = 1.0 - glossiness;
+        if (roughness < 0.7)
+        {
+            float ssrLod = clamp(log2(1.0 + roughness * roughness * ssrMipScale * 4.0), 0.0, ssrMipScale);
+            vec4 ssr = textureLod(sceneMap, tc, roughness * ssrMipScale);
 
-        if (transparent)
-            ssr.a *= glossiness;
+            if (ssr.a > 0.001)
+            {
+                // Un-premultiply (recover validity-weighted average)
+                ssr.rgb /= ssr.a;
 
-        glossenv = mix(glossenv, ssr.rgb, ssr.a);
+                // Inverse tone map (undo Reinhard from trace)
+                float l = dot(ssr.rgb, vec3(0.2126, 0.7152, 0.0722));
+                ssr.rgb /= max(1.0 - l, 0.001);
+
+                // Roughness fade (Godot: smoothstep 0.6-0.7)
+                ssr.a *= 1.0 - smoothstep(0.6, 0.7, roughness);
+
+                if (transparent)
+                    ssr.a *= glossiness;
+
+                glossenv = mix(glossenv, ssr.rgb, ssr.a);
+            }
+        }
     }
 #endif
 
@@ -908,13 +928,27 @@ void sampleReflectionProbesLegacy(inout vec3 ambenv, inout vec3 glossenv, inout 
 #if defined(SSR)
     if (cube_snapshot != 1)
     {
-        vec4 ssr = texture(sceneMap, tc);
+        float roughness = 1.0 - glossiness;
+        if (roughness < 0.7)
+        {
+            float ssrLod = clamp(log2(1.0 + roughness * roughness * ssrMipScale * 4.0), 0.0, ssrMipScale);
+            vec4 ssr = textureLod(sceneMap, tc, ssrLod);
 
-        if (transparent)
-            ssr.a *= glossiness;
+            if (ssr.a > 0.001)
+            {
+                ssr.rgb /= ssr.a;
+                float l = dot(ssr.rgb, vec3(0.2126, 0.7152, 0.0722));
+                ssr.rgb /= max(1.0 - l, 0.001);
 
-        glossenv = mix(glossenv, ssr.rgb, ssr.a);
-        legacyenv = mix(legacyenv, ssr.rgb, ssr.a);
+                ssr.a *= 1.0 - smoothstep(0.6, 0.7, roughness);
+
+                if (transparent)
+                    ssr.a *= glossiness;
+
+                glossenv = mix(glossenv, ssr.rgb, ssr.a);
+                legacyenv = mix(legacyenv, ssr.rgb, ssr.a);
+            }
+        }
     }
 #endif
 

--- a/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/reflectionProbeF.glsl
@@ -37,6 +37,8 @@ uniform bool transparent_surface;
 
 uniform float ssrMipScale;
 
+float tapScreenSpaceReflection(int totalSamples, vec2 tc, vec3 viewPos, vec3 n, inout vec4 collectedColor, sampler2D source, float glossiness);
+
 uniform int classic_mode;
 
 #define MAX_REFMAP_COUNT 256  // must match LL_MAX_REFLECTION_PROBE_COUNT
@@ -805,19 +807,24 @@ void doProbeSample(inout vec3 ambenv, inout vec3 glossenv,
         float roughness = 1.0 - glossiness;
         if (roughness < 0.7)
         {
-            float ssrLod = clamp(log2(1.0 + roughness * roughness * ssrMipScale * 4.0), 0.0, ssrMipScale);
-            vec4 ssr = textureLod(sceneMap, tc, roughness * ssrMipScale);
+            vec4 ssr = vec4(0.0);
+
+            if (transparent)
+            {
+                tapScreenSpaceReflection(1, tc, pos.xyz, norm, ssr, sceneMap, glossiness);
+            }
+            else
+            {
+                ssr = textureLod(sceneMap, tc, roughness * ssrMipScale);
+            }
 
             if (ssr.a > 0.001)
             {
-                // Un-premultiply (recover validity-weighted average)
                 ssr.rgb /= ssr.a;
 
-                // Inverse tone map (undo Reinhard from trace)
                 float l = dot(ssr.rgb, vec3(0.2126, 0.7152, 0.0722));
                 ssr.rgb /= max(1.0 - l, 0.001);
 
-                // Roughness fade (Godot: smoothstep 0.6-0.7)
                 ssr.a *= 1.0 - smoothstep(0.6, 0.7, roughness);
 
                 if (transparent)
@@ -931,8 +938,17 @@ void sampleReflectionProbesLegacy(inout vec3 ambenv, inout vec3 glossenv, inout 
         float roughness = 1.0 - glossiness;
         if (roughness < 0.7)
         {
-            float ssrLod = clamp(log2(1.0 + roughness * roughness * ssrMipScale * 4.0), 0.0, ssrMipScale);
-            vec4 ssr = textureLod(sceneMap, tc, ssrLod);
+            vec4 ssr = vec4(0.0);
+
+            if (transparent)
+            {
+                tapScreenSpaceReflection(1, tc, pos.xyz, norm, ssr, sceneMap, glossiness);
+            }
+            else
+            {
+                float ssrLod = clamp(log2(1.0 + roughness * roughness * ssrMipScale * 4.0), 0.0, ssrMipScale);
+                ssr = textureLod(sceneMap, tc, ssrLod);
+            }
 
             if (ssr.a > 0.001)
             {

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflAlphaF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflAlphaF.glsl
@@ -64,4 +64,5 @@ void main()
     vec4 ssrColor = vec4(0.0);
     tapScreenSpaceReflection(1, tc, vary_position, norm, ssrColor, sceneMap, glossiness);
     frag_color = ssrColor;
+    frag_color.a *= alpha;
 }

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflAlphaF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflAlphaF.glsl
@@ -1,0 +1,67 @@
+/**
+ * @file class3/deferred/screenSpaceReflAlphaF.glsl
+ *
+ * $LicenseInfo:firstyear=2007&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2007, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+/*[EXTRA_CODE_HERE]*/
+
+out vec4 frag_color;
+
+in vec3 vary_position;
+in vec3 vary_normal;
+in vec2 base_color_texcoord;
+in vec2 metallic_roughness_texcoord;
+in vec4 vertex_color;
+
+uniform sampler2D diffuseMap;
+uniform sampler2D specularMap;
+uniform sampler2D sceneMap;
+uniform vec2 screen_res;
+uniform float roughnessFactor;
+uniform float minimum_alpha;
+
+float tapScreenSpaceReflection(int totalSamples, vec2 tc, vec3 viewPos, vec3 n, inout vec4 collectedColor, sampler2D source, float glossiness);
+void bayerDitherDiscard(float alpha, float threshold);
+
+void main()
+{
+    vec4 baseColor = texture(diffuseMap, base_color_texcoord);
+    float alpha = baseColor.a * vertex_color.a;
+
+    // Alpha mask test
+    if (minimum_alpha >= 0.0 && alpha < minimum_alpha)
+        discard;
+
+    bayerDitherDiscard(alpha, 1.0);
+
+    // Per-pixel roughness from ORM green channel, scaled by material factor
+    float roughness = texture(specularMap, metallic_roughness_texcoord).g * roughnessFactor;
+    float glossiness = 1.0 - roughness;
+
+    vec2 tc = gl_FragCoord.xy / screen_res;
+    vec3 norm = normalize(vary_normal);
+
+    vec4 ssrColor = vec4(0.0);
+    tapScreenSpaceReflection(1, tc, vary_position, norm, ssrColor, sceneMap, glossiness);
+    frag_color = ssrColor;
+}

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflAlphaV.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflAlphaV.glsl
@@ -1,0 +1,72 @@
+/**
+ * @file class3/deferred/screenSpaceReflAlphaV.glsl
+ *
+ * $LicenseInfo:firstyear=2007&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2007, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+uniform mat4 modelview_matrix;
+
+#ifdef HAS_SKIN
+uniform mat4 projection_matrix;
+mat4 getObjectSkinnedTransform();
+#else
+uniform mat3 normal_matrix;
+uniform mat4 modelview_projection_matrix;
+#endif
+
+uniform mat4 texture_matrix0;
+uniform vec4[2] texture_base_color_transform;
+uniform vec4[2] texture_metallic_roughness_transform;
+
+in vec3 position;
+in vec3 normal;
+in vec2 texcoord0;
+in vec4 diffuse_color;
+
+out vec3 vary_position;
+out vec3 vary_normal;
+out vec2 base_color_texcoord;
+out vec2 metallic_roughness_texcoord;
+out vec4 vertex_color;
+
+vec2 texture_transform(vec2 vertex_texcoord, vec4[2] khr_gltf_transform, mat4 sl_animation_transform);
+
+void main()
+{
+#ifdef HAS_SKIN
+    mat4 mat = getObjectSkinnedTransform();
+    mat = modelview_matrix * mat;
+    vec3 pos = (mat * vec4(position.xyz, 1.0)).xyz;
+    vary_normal = normalize((mat * vec4(normal.xyz + position.xyz, 1.0)).xyz - pos.xyz);
+    gl_Position = projection_matrix * vec4(pos, 1.0);
+#else
+    vary_normal = normalize(normal_matrix * normal);
+    vec3 pos = (modelview_matrix * vec4(position.xyz, 1.0)).xyz;
+    gl_Position = modelview_projection_matrix * vec4(position.xyz, 1.0);
+#endif
+    vary_position = pos;
+
+    base_color_texcoord = texture_transform(texcoord0, texture_base_color_transform, texture_matrix0);
+    metallic_roughness_texcoord = texture_transform(texcoord0, texture_metallic_roughness_transform, texture_matrix0);
+
+    vertex_color = diffuse_color;
+}

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflFilterF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflFilterF.glsl
@@ -28,117 +28,41 @@
 out vec4 frag_color;
 
 uniform sampler2D diffuseMap;
-uniform vec2 screen_res;
-uniform vec2 delta;
-uniform vec3 kern[4];
-uniform float kern_scale;
+uniform vec2 pixelSize;
+uniform int filterDir;
+uniform float filterScale;
 
 in vec2 vary_fragcoord;
-
-GBufferInfo getGBuffer(vec2 screenpos);
-vec4 getPosition(vec2 pos_screen);
 
 void main()
 {
     vec2 tc = vary_fragcoord.xy;
-    vec3 pos = getPosition(tc).xyz;
-    GBufferInfo gb = getGBuffer(tc);
 
-    vec4 ccol = texture(diffuseMap, tc);
+    const float weights[4] = float[](0.214607, 0.189879, 0.131514, 0.071303);
 
-    // Skip pixels with no SSR data (alpha == 0)
-    if (ccol.a <= 0.0)
+    vec2 dir = (filterDir == 0) ? vec2(pixelSize.x, 0.0) : vec2(0.0, pixelSize.y);
+    dir *= filterScale;
+
+    vec4 center = texture(diffuseMap, tc);
+    float w0 = weights[0] * center.a;
+
+    vec4 color = center * w0;
+    float total_weight = w0;
+
+    for (int i = 1; i < 4; i++)
     {
-        frag_color = ccol;
-        return;
+        vec2 offset = dir * float(i);
+
+        vec4 s1 = texture(diffuseMap, tc + offset);
+        float w1 = weights[i] * s1.a;
+        color += s1 * w1;
+        total_weight += w1;
+
+        vec4 s2 = texture(diffuseMap, tc - offset);
+        float w2 = weights[i] * s2.a;
+        color += s2 * w2;
+        total_weight += w2;
     }
 
-    // Per-pixel roughness drives blur width: smooth = no blur, rough = full blur
-    float roughness;
-    if (GET_GBUFFER_FLAG(gb.gbufferFlag, GBUFFER_FLAG_HAS_PBR))
-        roughness = gb.specular.g;       // ORM: g = perceptualRoughness
-    else
-        roughness = 1.0 - gb.specular.a; // Legacy: a = glossiness
-
-    // Edge-aware contact heuristic: sample depth and normals at 4 axis-aligned
-    // neighbors. High depth variance or normal divergence = geometric edge =
-    // reduce blur to preserve contact reflections and sharp creases.
-    vec2 texel = 1.0 / screen_res;
-    float z0 = pos.z;
-    float zL = getPosition(tc - vec2(texel.x, 0.0)).z;
-    float zR = getPosition(tc + vec2(texel.x, 0.0)).z;
-    float zU = getPosition(tc - vec2(0.0, texel.y)).z;
-    float zD = getPosition(tc + vec2(0.0, texel.y)).z;
-
-    float maxDeltaZ = max(max(abs(zL - z0), abs(zR - z0)),
-                          max(abs(zU - z0), abs(zD - z0)));
-    float depthEdge = maxDeltaZ / max(-z0 * 0.01, 0.1);
-
-    vec3 nL = getGBuffer(tc - vec2(texel.x, 0.0)).normal;
-    vec3 nR = getGBuffer(tc + vec2(texel.x, 0.0)).normal;
-    vec3 nU = getGBuffer(tc - vec2(0.0, texel.y)).normal;
-    vec3 nD = getGBuffer(tc + vec2(0.0, texel.y)).normal;
-
-    float minNdot = min(min(dot(gb.normal, nL), dot(gb.normal, nR)),
-                        min(dot(gb.normal, nU), dot(gb.normal, nD)));
-    float normalEdge = 1.0 - clamp(minNdot, 0.0, 1.0);
-
-    float edge = max(depthEdge, normalEdge);
-    float contactFactor = 1.0 - smoothstep(0.0, 1.0, edge);
-
-    vec2 dlt = kern_scale * delta * roughness * contactFactor;
-    // Scale kernel by distance to reduce over-blur at far range
-    dlt /= max(-pos.z * 0.01, 1.0);
-
-    float defined_weight = kern[0].x;
-    vec4 col = ccol * kern[0].x;
-
-    // Plane-distance threshold, relaxed with distance
-    float tolerance = pos.z * pos.z * 0.00005;
-
-    // Perturb sample origin to hide edge ghosting (same pattern as blurLightF)
-    vec2 stc = tc * screen_res;
-    float tc_mod = 0.5 * (stc.x + stc.y);
-    tc_mod -= floor(tc_mod);
-    tc_mod *= 2.0;
-    stc += (tc_mod - 0.5) * kern[1].z * dlt * 0.5;
-
-    // Build 7-tap kernel from 4 control points
-    vec3 k[7];
-    k[0] = kern[0];
-    k[2] = kern[1];
-    k[4] = kern[2];
-    k[6] = kern[3];
-    k[1] = (k[0] + k[2]) * 0.5;
-    k[3] = (k[2] + k[4]) * 0.5;
-    k[5] = (k[4] + k[6]) * 0.5;
-
-    for (int i = 1; i < 7; i++)
-    {
-        vec2 samptc = (stc + k[i].z * dlt * 2.0) / screen_res;
-        vec3 samppos = getPosition(samptc).xyz;
-        float d = dot(gb.normal, samppos - pos);
-        if (d * d <= tolerance)
-        {
-            vec4 s = texture(diffuseMap, samptc);
-            col += s * k[i].x;
-            defined_weight += k[i].x;
-        }
-    }
-
-    for (int i = 1; i < 7; i++)
-    {
-        vec2 samptc = (stc - k[i].z * dlt * 2.0) / screen_res;
-        vec3 samppos = getPosition(samptc).xyz;
-        float d = dot(gb.normal, samppos - pos);
-        if (d * d <= tolerance)
-        {
-            vec4 s = texture(diffuseMap, samptc);
-            col += s * k[i].x;
-            defined_weight += k[i].x;
-        }
-    }
-
-    col /= defined_weight;
-    frag_color = max(col, vec4(0));
+    frag_color = color / max(total_weight, 0.001);
 }

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflFilterF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflFilterF.glsl
@@ -1,0 +1,144 @@
+/**
+ * @file screenSpaceReflFilterF.glsl
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2024, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+/*[EXTRA_CODE_HERE]*/
+
+out vec4 frag_color;
+
+uniform sampler2D diffuseMap;
+uniform vec2 screen_res;
+uniform vec2 delta;
+uniform vec3 kern[4];
+uniform float kern_scale;
+
+in vec2 vary_fragcoord;
+
+GBufferInfo getGBuffer(vec2 screenpos);
+vec4 getPosition(vec2 pos_screen);
+
+void main()
+{
+    vec2 tc = vary_fragcoord.xy;
+    vec3 pos = getPosition(tc).xyz;
+    GBufferInfo gb = getGBuffer(tc);
+
+    vec4 ccol = texture(diffuseMap, tc);
+
+    // Skip pixels with no SSR data (alpha == 0)
+    if (ccol.a <= 0.0)
+    {
+        frag_color = ccol;
+        return;
+    }
+
+    // Per-pixel roughness drives blur width: smooth = no blur, rough = full blur
+    float roughness;
+    if (GET_GBUFFER_FLAG(gb.gbufferFlag, GBUFFER_FLAG_HAS_PBR))
+        roughness = gb.specular.g;       // ORM: g = perceptualRoughness
+    else
+        roughness = 1.0 - gb.specular.a; // Legacy: a = glossiness
+
+    // Edge-aware contact heuristic: sample depth and normals at 4 axis-aligned
+    // neighbors. High depth variance or normal divergence = geometric edge =
+    // reduce blur to preserve contact reflections and sharp creases.
+    vec2 texel = 1.0 / screen_res;
+    float z0 = pos.z;
+    float zL = getPosition(tc - vec2(texel.x, 0.0)).z;
+    float zR = getPosition(tc + vec2(texel.x, 0.0)).z;
+    float zU = getPosition(tc - vec2(0.0, texel.y)).z;
+    float zD = getPosition(tc + vec2(0.0, texel.y)).z;
+
+    float maxDeltaZ = max(max(abs(zL - z0), abs(zR - z0)),
+                          max(abs(zU - z0), abs(zD - z0)));
+    float depthEdge = maxDeltaZ / max(-z0 * 0.01, 0.1);
+
+    vec3 nL = getGBuffer(tc - vec2(texel.x, 0.0)).normal;
+    vec3 nR = getGBuffer(tc + vec2(texel.x, 0.0)).normal;
+    vec3 nU = getGBuffer(tc - vec2(0.0, texel.y)).normal;
+    vec3 nD = getGBuffer(tc + vec2(0.0, texel.y)).normal;
+
+    float minNdot = min(min(dot(gb.normal, nL), dot(gb.normal, nR)),
+                        min(dot(gb.normal, nU), dot(gb.normal, nD)));
+    float normalEdge = 1.0 - clamp(minNdot, 0.0, 1.0);
+
+    float edge = max(depthEdge, normalEdge);
+    float contactFactor = 1.0 - smoothstep(0.0, 1.0, edge);
+
+    vec2 dlt = kern_scale * delta * roughness * contactFactor;
+    // Scale kernel by distance to reduce over-blur at far range
+    dlt /= max(-pos.z * 0.01, 1.0);
+
+    float defined_weight = kern[0].x;
+    vec4 col = ccol * kern[0].x;
+
+    // Plane-distance threshold, relaxed with distance
+    float tolerance = pos.z * pos.z * 0.00005;
+
+    // Perturb sample origin to hide edge ghosting (same pattern as blurLightF)
+    vec2 stc = tc * screen_res;
+    float tc_mod = 0.5 * (stc.x + stc.y);
+    tc_mod -= floor(tc_mod);
+    tc_mod *= 2.0;
+    stc += (tc_mod - 0.5) * kern[1].z * dlt * 0.5;
+
+    // Build 7-tap kernel from 4 control points
+    vec3 k[7];
+    k[0] = kern[0];
+    k[2] = kern[1];
+    k[4] = kern[2];
+    k[6] = kern[3];
+    k[1] = (k[0] + k[2]) * 0.5;
+    k[3] = (k[2] + k[4]) * 0.5;
+    k[5] = (k[4] + k[6]) * 0.5;
+
+    for (int i = 1; i < 7; i++)
+    {
+        vec2 samptc = (stc + k[i].z * dlt * 2.0) / screen_res;
+        vec3 samppos = getPosition(samptc).xyz;
+        float d = dot(gb.normal, samppos - pos);
+        if (d * d <= tolerance)
+        {
+            vec4 s = texture(diffuseMap, samptc);
+            col += s * k[i].x;
+            defined_weight += k[i].x;
+        }
+    }
+
+    for (int i = 1; i < 7; i++)
+    {
+        vec2 samptc = (stc - k[i].z * dlt * 2.0) / screen_res;
+        vec3 samppos = getPosition(samptc).xyz;
+        float d = dot(gb.normal, samppos - pos);
+        if (d * d <= tolerance)
+        {
+            vec4 s = texture(diffuseMap, samptc);
+            col += s * k[i].x;
+            defined_weight += k[i].x;
+        }
+    }
+
+    col /= defined_weight;
+    frag_color = max(col, vec4(0));
+}

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflTraceF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflTraceF.glsl
@@ -1,5 +1,5 @@
 /**
- * @file class3/deferred/screenSpaceReflPostF.glsl
+ * @file class3/deferred/screenSpaceReflTraceF.glsl
  *
  * $LicenseInfo:firstyear=2007&license=viewerlgpl$
  * Second Life Viewer Source Code
@@ -27,57 +27,39 @@
 
 out vec4 frag_color;
 
-uniform vec2 screen_res;
-uniform mat4 projection_matrix;
-uniform mat4 inv_proj;
-uniform float zNear;
-uniform float zFar;
-
 in vec2 vary_fragcoord;
 in vec3 camera_ray;
 
-uniform sampler2D diffuseMap;
+uniform sampler2D sceneMap;
 
 GBufferInfo getGBuffer(vec2 screenpos);
 float getDepth(vec2 pos_screen);
-float linearDepth(float d, float znear, float zfar);
-float linearDepth01(float d, float znear, float zfar);
-
 vec4 getPositionWithDepth(vec2 pos_screen, float depth);
-vec4 getPosition(vec2 pos_screen);
-
-float random (vec2 uv);
 
 float tapScreenSpaceReflection(int totalSamples, vec2 tc, vec3 viewPos, vec3 n, inout vec4 collectedColor, sampler2D source, float glossiness);
 
 void main()
 {
-    vec2  tc = vary_fragcoord.xy;
-    float depth = linearDepth01(getDepth(tc), zNear, zFar);
-    GBufferInfo gb = getGBuffer(tc);
-    vec3 pos = getPositionWithDepth(tc, getDepth(tc)).xyz;
-    vec2 hitpixel;
+    vec2 tc = vary_fragcoord.xy;
+    float depth = getDepth(tc);
 
-    vec3 specCol = gb.specular.rgb;
-
-    vec4 fcol = texture(diffuseMap, tc);
-
-    if (GET_GBUFFER_FLAG(gb.gbufferFlag, GBUFFER_FLAG_HAS_PBR))
+    // skip sky pixels
+    if (depth >= 1.0)
     {
-        vec3 orm = specCol.rgb;
-        float metallic = orm.b;
-        vec3 f0 = vec3(0.04);
-        vec3 baseColor = gb.albedo.rgb;
-
-        specCol = mix(f0, baseColor.rgb, metallic);
+        frag_color = vec4(0.0);
+        return;
     }
 
-    vec4 collectedColor = vec4(0);
+    GBufferInfo gb = getGBuffer(tc);
+    vec3 pos = getPositionWithDepth(tc, depth).xyz;
 
-    float w = tapScreenSpaceReflection(4, tc, pos, gb.normal, collectedColor, diffuseMap, 0.f);
+    float glossiness;
+    if (GET_GBUFFER_FLAG(gb.gbufferFlag, GBUFFER_FLAG_HAS_PBR))
+        glossiness = 1.0 - gb.specular.g;   // ORM: g = perceptualRoughness
+    else
+        glossiness = gb.specular.a;          // Legacy: a = glossiness
 
-    collectedColor.rgb *= specCol.rgb;
-
-    fcol += collectedColor * w;
-    frag_color = max(fcol, vec4(0));
+    vec4 ssrColor = vec4(0.0);
+    tapScreenSpaceReflection(1, tc, pos, gb.normal, ssrColor, sceneMap, glossiness);
+    frag_color = ssrColor;
 }

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflUtil.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflUtil.glsl
@@ -34,23 +34,15 @@ uniform mat4 inv_proj;
 uniform mat4 modelview_delta;
 uniform mat4 inv_modelview_delta;
 
-// Declared to keep pipeline uniform setup happy
-uniform vec3 iterationCount;
-uniform vec3 rayStep;
-uniform vec3 distanceBias;
-uniform vec3 depthRejectBias;
-uniform vec3 adaptiveStepMultiplier;
-uniform vec3 splitParamsStart;
-uniform vec3 splitParamsEnd;
+uniform int iterationCount;
+uniform float maxThickness;
+uniform float depthBias;
 uniform float glossySampleCount;
 uniform float noiseSine;
 uniform float maxZDepth;
 uniform float maxRoughness;
 uniform vec2 ssrJitterOffset;
 uniform int hizMipCount;
-
-#define MAX_THICKNESS   depthRejectBias.x
-#define DEPTH_BIAS      depthRejectBias.y
 
 vec4 getPositionWithDepth(vec2 pos_screen, float depth);
 
@@ -186,7 +178,7 @@ vec4 hiZTrace(vec3 origin, vec3 dir, int maxIterations)
         {
             float z0 = getPositionWithDepth(pos.xy, cellDepth).z;
             float z1 = getPositionWithDepth(pos.xy, pos.z).z;
-            if ((z0 - z1) > MAX_THICKNESS)
+            if ((z0 - z1) > maxThickness)
             {
                 hit = false;
                 mipOffset = 0;  // Stay at mip 0, march cell-by-cell.
@@ -262,8 +254,8 @@ float tapScreenSpaceReflection(
     // Bias the ray origin along the normal, scaled by distance.
     // Prevents grazing-angle rays from scraping the originating surface
     // at distance where depth precision breaks down.
-    float depthBias = max(0.01, -viewPos.z * DEPTH_BIAS);
-    vec3 biasedPos = viewPos - normal * depthBias;
+    float biasAmount = max(0.01, -viewPos.z * depthBias);
+    vec3 biasedPos = viewPos - normal * biasAmount;
 
     vec3 transformedPos = (inv_modelview_delta * vec4(biasedPos, 1.0)).xyz;
     float startDepth = -transformedPos.z;
@@ -334,7 +326,7 @@ float tapScreenSpaceReflection(
                           projectDepth(transformedEnd));
         vec3 ssDir = ssFar - ssOrigin;
 
-        vec4 result = hiZTrace(ssOrigin, ssDir, int(iterationCount.x));
+        vec4 result = hiZTrace(ssOrigin, ssDir, iterationCount);
 
         if (result.x < 0.0)
             continue;
@@ -358,7 +350,7 @@ float tapScreenSpaceReflection(
         vec3 viewSpaceSurface = getPositionWithDepth(hitTC, hitSurfaceDepth).xyz;
         vec3 viewSpaceHit = getPositionWithDepth(hitTC, result.z).xyz;
         float hitDistance = length(viewSpaceSurface - viewSpaceHit);
-        float confidence = 1.0 - smoothstep(0.0, MAX_THICKNESS, hitDistance);
+        float confidence = 1.0 - smoothstep(0.0, maxThickness, hitDistance);
         confidence *= confidence;
 
         // Short-ray back-face check (Godot-style):
@@ -387,18 +379,19 @@ float tapScreenSpaceReflection(
         float zFadeStart = maxZDepth * 0.8;
         float zFade = 1.0 - smoothstep(zFadeStart, maxZDepth, hitDepth);
 
-        float maxMipLevels = floor(log2(max(screen_res.x, screen_res.y)));
-        float distanceFactor = clamp(rayLen, 0.0, 1.0);
-        float effectiveRoughness = clamp(roughness + distanceFactor * roughness, 0.0, 1.0);
-        float mipLevel = maxMipLevels * effectiveRoughness;
-        vec4 sampledColor = textureLod(source, hitTC, mipLevel);
+        vec4 sampledColor = textureLod(source, hitTC, 0.0);
+
+        // Tone map hit color (Reinhard on luminance) to compress brights
+        // before mip chain averaging — prevents fireflies.
+        float luma = dot(sampledColor.rgb, vec3(0.2126, 0.7152, 0.0722));
+        sampledColor.rgb /= (1.0 + luma);
 
         // Fade-in: suppress near-origin artifacts from self-intersection.
         float fadeIn = smoothstep(0.0, 0.01, rayLen);
         float rayFade = 1.0 - smoothstep(0.6, 1.0, rayLen);
         float sampleFade = edgeFade * zFade * fadeIn * rayFade * confidence;
 
-        accumColor += sampledColor.rgb;
+        accumColor += sampledColor.rgb * sampleFade;
         accumFade += sampleFade;
         hits++;
     }
@@ -412,11 +405,8 @@ float tapScreenSpaceReflection(
     accumColor /= float(numSamples);
     accumFade /= float(numSamples);
 
-    float remappedRoughness = clamp((roughness - (maxRoughness * 0.6)) / (maxRoughness - (maxRoughness * 0.6)), 0.0, 1.0);
-    float roughnessFade = 1.0 - remappedRoughness;
+    float combinedFade = accumFade * baseEdgeFade;
 
-    float combinedFade = accumFade * roughnessFade * baseEdgeFade;
-
-    collectedColor = vec4(accumColor, combinedFade);
+    collectedColor = vec4(accumColor * baseEdgeFade, combinedFade);
     return 1.0;
 }

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflUtil.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflUtil.glsl
@@ -46,19 +46,11 @@ uniform float glossySampleCount;
 uniform float noiseSine;
 uniform float maxZDepth;
 uniform float maxRoughness;
+uniform vec2 ssrJitterOffset;
+uniform int hizMipCount;
 
-// Ray march parameters wired to uniforms (.x component of each)
-//   rayStep.x              = step size (default 0.5)
-//   iterationCount.x       = max steps (default 96)
-//   adaptiveStepMultiplier.x = step growth rate (default 1.03)
-//   distanceBias.x         = max step size cap (default 5.0)
-//   depthRejectBias.x      = max thickness for hit validation (default 1.0)
-#define STEP_SIZE       rayStep.x
-#define STEP_GROWTH     adaptiveStepMultiplier.x
-#define MAX_STEP_SIZE   distanceBias.x
 #define MAX_THICKNESS   depthRejectBias.x
 #define DEPTH_BIAS      depthRejectBias.y
-const int   BINARY_STEPS    = 8;
 
 vec4 getPositionWithDepth(vec2 pos_screen, float depth);
 
@@ -71,86 +63,160 @@ vec2 generateProjectedPosition(vec3 pos)
 {
     vec4 samplePosition = projection_matrix * vec4(pos, 1.0);
     samplePosition.xy = (samplePosition.xy / samplePosition.w) * 0.5 + 0.5;
+    // Compensate for SMAA T2x jitter difference between current and previous frame.
+    // mSceneMap was rendered with the previous frame's jittered projection;
+    // offset the UV so depth/color lookups hit the correct texels.
+    samplePosition.xy += ssrJitterOffset;
     return samplePosition.xy;
 }
 
 float getLinearDepth(vec2 tc)
 {
-    float depth = texture(sceneDepth, tc).r;
+    // Force LOD 0 — sceneDepth now carries the Hi-Z mip chain,
+    // and reflected UVs have chaotic derivatives that could cause
+    // auto-LOD selection to sample coarse Hi-Z levels.
+    float depth = textureLod(sceneDepth, tc, 0).r;
     vec4 pos = getPositionWithDepth(tc, depth);
     return -pos.z;
 }
 
-vec3 binarySearch(vec3 dir, inout vec3 hitCoord, inout float dDepth)
+float projectDepth(vec3 viewPos)
 {
-    float depth;
-    float initialStepLen = length(dir);
-
-    for (int i = 0; i < BINARY_STEPS; i++)
-    {
-        vec2 projectedCoord = generateProjectedPosition(hitCoord);
-        depth = getLinearDepth(projectedCoord);
-        dDepth = abs(hitCoord.z) - depth;
-
-        dir *= 0.5;
-        if (dDepth > 0.0)
-            hitCoord -= dir;
-        else
-            hitCoord += dir;
-    }
-
-    vec2 projectedCoord = generateProjectedPosition(hitCoord);
-
-    // After 8 binary steps, precision is initialStep / 256.
-    // Scale acceptance with depth — precision degrades at distance.
-    float depthScale = max(1.0, depth * 0.01);
-    float maxError = max(initialStepLen * 0.1, 0.05) * depthScale;
-    if (abs(dDepth) > maxError)
-        return vec3(-1.0, -1.0, depth);
-
-    return vec3(projectedCoord, depth);
+    vec4 clip = projection_matrix * vec4(viewPos, 1.0);
+    return (clip.z / clip.w) * 0.5 + 0.5;
 }
 
-vec3 rayMarch(vec3 dir, inout vec3 hitCoord, out float dDepth, float startDepth)
+// Hi-Z hierarchical screen-space ray trace (Godot parametric-T approach).
+// origin/dir are in UV+depth space: (u, v, rawDepth) where depth is [0,1].
+// Returns hit position (uv + raw depth) or vec3(-1) on miss.
+//
+// Uses parametric T along the ray for all comparisons, avoiding the AMD
+// absolute-depth comparison that breaks for camera-facing rays (dir.z < 0).
+// Z is normalized so dir.z = ±1, making depth_t = (cellDepth - origin.z) / dir.z
+// trivially comparable with the edge_t from cell boundary intersections.
+//
+// Our Hi-Z stores MIN depth (standard GL: 0=near, 1=far), so min = closest.
+// Godot uses reversed-Z with MAX depth, but the logic maps cleanly:
+//   Godot: max(a,b,c,d) with reversed-Z → closest surface
+//   Ours:  min(a,b,c,d) with standard-Z → closest surface
+// The comparison flips accordingly.
+//
+// References:
+//   Godot Engine SSR: screen_space_reflection.glsl (MIT license)
+//   Sugulee/GPU Pro 5: Hi-Z Screen-Space Cone-Traced Reflections
+vec3 hiZTrace(vec3 origin, vec3 dir, int maxIterations)
 {
-    dir *= STEP_SIZE;
+    int maxLevel = hizMipCount - 1;
 
-    for (int i = 0; i < int(iterationCount.x); i++)
+    // Guard near-zero Z direction — treat as Z+ epsilon.
+    if (abs(dir.z) < 1e-7)
+        dir.z = 1e-7;
+
+    // Normalize direction so |dir.z| = 1.
+    // This makes depth_t = (cellDepth - origin.z) * zDir directly comparable
+    // with edge_t values along the XY axes.
+    // Reference: https://hacksoflife.blogspot.com/2020/10/a-tip-for-hiz-ssr-parametric-t-tracing.html
+    vec3 rayDir = dir / abs(dir.z);
+
+    // Standard GL: 0=near, 1=far. Camera-facing rays move toward 0 (dir.z < 0).
+    // Godot (reversed-Z): facing_camera = rayDir.z >= 0 (toward near=1.0).
+    // For standard GL: facing_camera = dir.z < 0 (toward near=0.0).
+    bool facingCamera = dir.z < 0.0;
+    float zDir = rayDir.z;  // ±1 after normalization
+
+    // Cell step direction: +1 or -1 per axis (matches Godot cell_step).
+    vec2 cellStep = vec2(rayDir.x < 0.0 ? -1.0 : 1.0,
+                         rayDir.y < 0.0 ? -1.0 : 1.0);
+
+    int curLevel = 0;
+    float t = 0.0;
+
+    // Compute t_max: parametric T to the screen edge where we stop tracing.
+    vec2 t0 = (vec2(0.0) - origin.xy) / rayDir.xy;
+    vec2 t1 = (vec2(1.0) - origin.xy) / rayDir.xy;
+    vec2 t2 = max(t0, t1);
+    float tMax = min(t2.x, t2.y);
+
+    // Initial advance: push past origin cell to avoid self-intersection.
+    // Matches Godot's initial advance exactly.
     {
-        hitCoord += dir;
-
-        vec2 projectedCoord = generateProjectedPosition(hitCoord);
-
-        if (projectedCoord.x < 0.0 || projectedCoord.x > 1.0 ||
-            projectedCoord.y < 0.0 || projectedCoord.y > 1.0)
-            return vec3(-1.0);
-
-        float depth = getLinearDepth(projectedCoord);
-        dDepth = abs(hitCoord.z) - depth;
-
-        if (i < 1)
-            continue;
-
-        if (depth > maxZDepth)
-            return vec3(-1.0);
-
-        if (dDepth > 0.0)
-        {
-            float stepLen = length(dir);
-            float thickness = max(MAX_THICKNESS, stepLen * 1.5);
-            if (dDepth > thickness)
-            {
-                dir = normalize(dir) * min(stepLen * STEP_GROWTH, MAX_STEP_SIZE);
-                continue;
-            }
-            return binarySearch(dir, hitCoord, dDepth);
-        }
-
-        // Grow step but cap at max to avoid skipping geometry
-        dir = normalize(dir) * min(length(dir) * STEP_GROWTH, MAX_STEP_SIZE);
+        vec2 cellIndex = floor(origin.xy * screen_res);
+        vec2 newCellIndex = cellIndex + clamp(cellStep, vec2(0.0), vec2(1.0));
+        vec2 newCellPos = (newCellIndex / screen_res) + cellStep * 0.000001;
+        vec2 posT = (newCellPos - origin.xy) / rayDir.xy;
+        t = min(posT.x, posT.y);
     }
 
-    return vec3(-1.0);
+    for (int i = 0; i < maxIterations && curLevel >= 0 && t < tMax; i++)
+    {
+        vec3 pos = origin + rayDir * t;
+
+        // Cell lookup at current mip level.
+        vec2 cellCount = vec2(max(1, int(screen_res.x) >> curLevel),
+                              max(1, int(screen_res.y) >> curLevel));
+        ivec2 cellIndex = ivec2(floor(pos.xy * cellCount));
+        cellIndex = clamp(cellIndex, ivec2(0), ivec2(cellCount) - 1);
+
+        // Min depth in this cell (closest surface, standard GL).
+        float cellDepth = texelFetch(sceneDepth, cellIndex, curLevel).r;
+
+        // Parametric T to the depth surface.
+        // Since rayDir.z = ±1, this is (cellDepth - origin.z) * (±1).
+        float depthT = (cellDepth - origin.z) * zDir;
+
+        // Parametric T to the nearest cell boundary in XY.
+        vec2 newCellIndex = vec2(cellIndex) + clamp(cellStep, vec2(0.0), vec2(1.0));
+        vec2 newCellPos = (newCellIndex / cellCount) + cellStep * 0.000001;
+        vec2 posT = (newCellPos - origin.xy) / rayDir.xy;
+        float edgeT = min(posT.x, posT.y);
+
+        // Hit detection (matches Godot exactly):
+        // Forward rays: hit if depth surface is reached before cell boundary.
+        // Camera-facing rays: hit if ray hasn't traveled past the depth surface.
+        bool hit = facingCamera ? (t <= depthT) : (depthT <= edgeT);
+
+        int mipOffset = hit ? -1 : 1;
+
+        // Thickness gate at mip 0 (matches Godot depth_tolerance check):
+        // Linearize depths and reject if surface is too far behind ray.
+        if (curLevel == 0 && hit)
+        {
+            float z0 = getPositionWithDepth(pos.xy, cellDepth).z;
+            float z1 = getPositionWithDepth(pos.xy, pos.z).z;
+            if ((z0 - z1) > MAX_THICKNESS)
+            {
+                hit = false;
+                mipOffset = 0;  // Stay at mip 0, march cell-by-cell.
+            }
+        }
+
+        // Advance parametric T (matches Godot exactly):
+        // Only advance to depthT for non-facing-camera hits.
+        // For facing-camera hits, descend without advancing — the ray
+        // hasn't reached the surface yet, and advancing at coarse mip
+        // levels would snap the UV to the cell's min-depth location.
+        if (hit)
+        {
+            if (!facingCamera)
+                t = max(t, depthT);
+        }
+        else
+        {
+            t = edgeT;
+        }
+
+        curLevel = min(curLevel + mipOffset, maxLevel);
+    }
+
+    vec3 hitPos = origin + rayDir * t;
+
+    // Final bounds check.
+    if (hitPos.x < 0.0 || hitPos.x > 1.0 ||
+        hitPos.y < 0.0 || hitPos.y > 1.0 ||
+        t >= tMax)
+        return vec3(-1.0);
+
+    return hitPos;
 }
 
 float calculateEdgeFade(vec2 screenPos)
@@ -256,31 +322,105 @@ float tapScreenSpaceReflection(
         // Push ray origin along surface normal to prevent self-intersection.
         // Deterministic (not random) to avoid per-pixel noise.
         // Scales with distance to match depth-buffer precision degradation.
-        float clearance = max(STEP_SIZE * 2.0, -viewPos.z * 0.002);
+        float clearance = max(0.05, -viewPos.z * 0.002);
         vec3 clearedPos = biasedPos + normal * clearance;
         vec3 transformedClearedPos = (inv_modelview_delta * vec4(clearedPos, 1.0)).xyz;
-        vec3 hitCoord = transformedClearedPos;
-        float dDepth;
 
-        // Sub-step dither: offset start along ray by a fraction of one step.
-        // Breaks step-boundary striations without shifting the ray origin.
-        float dither = random(tc * screen_res + float(s) * 0.789);
-        hitCoord += transformedReflDir * STEP_SIZE * dither;
+        // Project ray origin and a nearby point to screen space (UV + raw depth).
+        // Use a short step (fraction of distance-to-camera) to ensure the end
+        // point stays in front of the camera — projecting at maxZDepth can wrap
+        // behind the camera for reflections going toward the viewer.
+        vec3 ssOrigin = vec3(generateProjectedPosition(transformedClearedPos),
+                             projectDepth(transformedClearedPos));
+        float stepDist = max(0.1, -transformedClearedPos.z * 0.1);
+        vec3 transformedEnd = transformedClearedPos + transformedReflDir * stepDist;
+        vec3 ssFar = vec3(generateProjectedPosition(transformedEnd),
+                          projectDepth(transformedEnd));
+        vec3 ssDir = normalize(ssFar - ssOrigin);
 
-        vec3 result = rayMarch(transformedReflDir, hitCoord, dDepth, startDepth);
+        vec3 result = hiZTrace(ssOrigin, ssDir, int(iterationCount.x));
 
         if (result.x < 0.0)
             continue;
 
+        // Post-trace refinement: Hi-Z returns cell-boundary-aligned positions.
+        // At depth edges, the trace can overshoot by up to one Hi-Z cell width.
+        // Walk backward along the ray to find the actual surface crossing, then
+        // binary-refine for sub-pixel precision.
+        {
+            float tHit;
+            if (abs(ssDir.x) >= abs(ssDir.y))
+                tHit = (result.x - ssOrigin.x) / ssDir.x;
+            else
+                tHit = (result.y - ssOrigin.y) / ssDir.y;
+
+            float majorLen = max(abs(ssDir.x), abs(ssDir.y));
+            float pixelStep = 1.0 / (max(screen_res.x, screen_res.y) * majorLen);
+
+            // Walk backward up to 8 pixels to find the nearest above-surface point.
+            // This catches overshoots at depth discontinuities (silhouette edges)
+            // where the Hi-Z trace skips past thin geometry at coarse mip levels.
+            float tAbove = max(0.0, tHit - pixelStep);
+            for (int r = 1; r <= 8; r++)
+            {
+                float tTest = tHit - pixelStep * float(r);
+                if (tTest <= 0.0) break;
+                vec3 testPos = ssOrigin + ssDir * tTest;
+                float surfZ = textureLod(sceneDepth, testPos.xy, 0).r;
+                if (surfZ > testPos.z)
+                {
+                    tAbove = tTest;
+                    break;
+                }
+            }
+
+            // Binary-refine between above-surface and below-surface points.
+            float tLo = tAbove;
+            float tHi = tHit;
+            for (int r = 0; r < 4; r++)
+            {
+                float tMid = (tLo + tHi) * 0.5;
+                vec3 midPos = ssOrigin + ssDir * tMid;
+                float surfZ = textureLod(sceneDepth, midPos.xy, 0).r;
+                if (surfZ > midPos.z)
+                    tLo = tMid;
+                else
+                    tHi = tMid;
+            }
+            result = ssOrigin + ssDir * tHi;
+        }
+
         vec2 hitTC = result.xy;
-        float hitDepth = result.z;
+
+        float hitDepth = getLinearDepth(hitTC);
+
+        // Reject sky / far-plane hits
+        if (hitDepth > maxZDepth)
+            continue;
+
+        // Continuous thickness validation (AMD FidelityFX ValidateHit approach).
+        // Read surface depth from mip 1 — neighborhood min-depth over a 2×2 block —
+        // matching AMD's FFX_SSSR_LoadDepth(texel_coords / 2, 1). This gives a more
+        // forgiving depth comparison at edges where mip 0 texels straddle a depth
+        // discontinuity, reducing comb/staircase artifacts.
+        ivec2 hitTexel = ivec2(hitTC * screen_res);
+        ivec2 mip1Size = textureSize(sceneDepth, 1);
+        float hitRawDepth = texelFetch(sceneDepth, clamp(hitTexel / 2, ivec2(0), mip1Size - 1), 1).r;
+        vec3 viewSpaceSurface = getPositionWithDepth(hitTC, hitRawDepth).xyz;
+        vec3 viewSpaceHit = getPositionWithDepth(hitTC, result.z).xyz;
+        float hitDistance = length(viewSpaceSurface - viewSpaceHit);
+        float confidence = 1.0 - smoothstep(0.0, MAX_THICKNESS, hitDistance);
+        confidence *= confidence;
+
+        if (confidence <= 0.001)
+            continue;
 
         float edgeFade = calculateEdgeFade(hitTC);
 
         float zFadeStart = maxZDepth * 0.8;
         float zFade = 1.0 - smoothstep(zFadeStart, maxZDepth, hitDepth);
 
-        float rayLength = length(hitCoord - transformedClearedPos);
+        float rayLength = length(result - ssOrigin) * maxZDepth;
         float maxMipLevels = floor(log2(max(screen_res.x, screen_res.y)));
         float distanceFactor = clamp(rayLength / maxZDepth, 0.0, 1.0);
         float effectiveRoughness = clamp(roughness + distanceFactor * roughness, 0.0, 1.0);
@@ -288,7 +428,7 @@ float tapScreenSpaceReflection(
         vec4 sampledColor = textureLod(source, hitTC, mipLevel);
 
         float rayFade = 1.0 - smoothstep(maxZDepth * 0.6, maxZDepth, rayLength);
-        float sampleFade = edgeFade * zFade * rayFade;
+        float sampleFade = edgeFade * zFade * rayFade * confidence;
 
         accumColor += sampledColor.rgb;
         accumFade += sampleFade;

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflUtil.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflUtil.glsl
@@ -192,9 +192,7 @@ vec3 hiZTrace(vec3 origin, vec3 dir, int maxIterations)
 
         // Advance parametric T (matches Godot exactly):
         // Only advance to depthT for non-facing-camera hits.
-        // For facing-camera hits, descend without advancing — the ray
-        // hasn't reached the surface yet, and advancing at coarse mip
-        // levels would snap the UV to the cell's min-depth location.
+        // For facing-camera hits, descend without advancing.
         if (hit)
         {
             if (!facingCamera)
@@ -343,91 +341,46 @@ float tapScreenSpaceReflection(
         if (result.x < 0.0)
             continue;
 
-        // Post-trace refinement: Hi-Z returns cell-boundary-aligned positions.
-        // At depth edges, the trace can overshoot by up to one Hi-Z cell width.
-        // Walk backward along the ray to find the actual surface crossing, then
-        // binary-refine for sub-pixel precision.
-        {
-            float tHit;
-            if (abs(ssDir.x) >= abs(ssDir.y))
-                tHit = (result.x - ssOrigin.x) / ssDir.x;
-            else
-                tHit = (result.y - ssOrigin.y) / ssDir.y;
-
-            float majorLen = max(abs(ssDir.x), abs(ssDir.y));
-            float pixelStep = 1.0 / (max(screen_res.x, screen_res.y) * majorLen);
-
-            // Walk backward up to 8 pixels to find the nearest above-surface point.
-            // This catches overshoots at depth discontinuities (silhouette edges)
-            // where the Hi-Z trace skips past thin geometry at coarse mip levels.
-            float tAbove = max(0.0, tHit - pixelStep);
-            for (int r = 1; r <= 8; r++)
-            {
-                float tTest = tHit - pixelStep * float(r);
-                if (tTest <= 0.0) break;
-                vec3 testPos = ssOrigin + ssDir * tTest;
-                float surfZ = textureLod(sceneDepth, testPos.xy, 0).r;
-                if (surfZ > testPos.z)
-                {
-                    tAbove = tTest;
-                    break;
-                }
-            }
-
-            // Binary-refine between above-surface and below-surface points.
-            float tLo = tAbove;
-            float tHi = tHit;
-            for (int r = 0; r < 4; r++)
-            {
-                float tMid = (tLo + tHi) * 0.5;
-                vec3 midPos = ssOrigin + ssDir * tMid;
-                float surfZ = textureLod(sceneDepth, midPos.xy, 0).r;
-                if (surfZ > midPos.z)
-                    tLo = tMid;
-                else
-                    tHi = tMid;
-            }
-            result = ssOrigin + ssDir * tHi;
-        }
-
         vec2 hitTC = result.xy;
 
-        float hitDepth = getLinearDepth(hitTC);
+        // Read actual surface depth at the hit pixel (mip 0, exact pixel).
+        ivec2 hitPixel = ivec2(hitTC * screen_res);
+        hitPixel = clamp(hitPixel, ivec2(0), ivec2(screen_res) - 1);
+        float hitSurfaceDepth = texelFetch(sceneDepth, hitPixel, 0).r;
 
-        // Reject sky / far-plane hits
+        // Reject sky / far-plane hits (forward-Z: 1.0 = far).
+        float hitDepth = -getPositionWithDepth(hitTC, hitSurfaceDepth).z;
         if (hitDepth > maxZDepth)
             continue;
 
-        // Continuous thickness validation (AMD FidelityFX ValidateHit approach).
-        // Read surface depth from mip 1 — neighborhood min-depth over a 2×2 block —
-        // matching AMD's FFX_SSSR_LoadDepth(texel_coords / 2, 1). This gives a more
-        // forgiving depth comparison at edges where mip 0 texels straddle a depth
-        // discontinuity, reducing comb/staircase artifacts.
-        ivec2 hitTexel = ivec2(hitTC * screen_res);
-        ivec2 mip1Size = textureSize(sceneDepth, 1);
-        float hitRawDepth = texelFetch(sceneDepth, clamp(hitTexel / 2, ivec2(0), mip1Size - 1), 1).r;
-        vec3 viewSpaceSurface = getPositionWithDepth(hitTC, hitRawDepth).xyz;
+        // Confidence validation:
+        // Compare the trace's final depth with the actual surface depth at that pixel.
+        // Use a dead zone so small mismatches (from cell-boundary snapping) don't
+        // reduce confidence — only penalize when the gap is significant.
+        // No squaring: let the smoothstep gradient be gentle to avoid banding.
+        vec3 viewSpaceSurface = getPositionWithDepth(hitTC, hitSurfaceDepth).xyz;
         vec3 viewSpaceHit = getPositionWithDepth(hitTC, result.z).xyz;
         float hitDistance = length(viewSpaceSurface - viewSpaceHit);
-        float confidence = 1.0 - smoothstep(0.0, MAX_THICKNESS, hitDistance);
-        confidence *= confidence;
+        float confidenceStart = MAX_THICKNESS * 0.25;
+        float confidence = 1.0 - smoothstep(confidenceStart, MAX_THICKNESS, hitDistance);
 
-        if (confidence <= 0.001)
-            continue;
+        // Screen-space ray length in UV units (matches Godot ray_len).
+        // Godot: ray_len = length(screen_ray_dir.xy * t)
+        // Here we approximate with the UV displacement of the hit.
+        float rayLen = length(result.xy - ssOrigin.xy);
 
         float edgeFade = calculateEdgeFade(hitTC);
 
         float zFadeStart = maxZDepth * 0.8;
         float zFade = 1.0 - smoothstep(zFadeStart, maxZDepth, hitDepth);
 
-        float rayLength = length(result - ssOrigin) * maxZDepth;
         float maxMipLevels = floor(log2(max(screen_res.x, screen_res.y)));
-        float distanceFactor = clamp(rayLength / maxZDepth, 0.0, 1.0);
+        float distanceFactor = clamp(rayLen, 0.0, 1.0);
         float effectiveRoughness = clamp(roughness + distanceFactor * roughness, 0.0, 1.0);
         float mipLevel = maxMipLevels * effectiveRoughness;
         vec4 sampledColor = textureLod(source, hitTC, mipLevel);
 
-        float rayFade = 1.0 - smoothstep(maxZDepth * 0.6, maxZDepth, rayLength);
+        float rayFade = 1.0 - smoothstep(0.6, 1.0, rayLen);
         float sampleFade = edgeFade * zFade * rayFade * confidence;
 
         accumColor += sampledColor.rgb;

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflUtil.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflUtil.glsl
@@ -332,7 +332,7 @@ float tapScreenSpaceReflection(
         vec3 transformedEnd = transformedClearedPos + transformedReflDir * stepDist;
         vec3 ssFar = vec3(generateProjectedPosition(transformedEnd),
                           projectDepth(transformedEnd));
-        vec3 ssDir = normalize(ssFar - ssOrigin);
+        vec3 ssDir = ssFar - ssOrigin;
 
         vec4 result = hiZTrace(ssOrigin, ssDir, int(iterationCount.x));
 
@@ -361,10 +361,26 @@ float tapScreenSpaceReflection(
         float confidence = 1.0 - smoothstep(0.0, MAX_THICKNESS, hitDistance);
         confidence *= confidence;
 
-        // Screen-space ray length in UV units (matches Godot ray_len).
-        // Godot: ray_len = length(screen_ray_dir.xy * t)
-        // Here we approximate with the UV displacement of the hit.
+        // Short-ray back-face check (Godot-style):
+        // For rays that traveled < 3 pixels, compute a geometric normal at the
+        // hit point from depth buffer cross-derivatives. Reject if the reflected
+        // ray exits the surface (dot >= 0), which indicates self-intersection.
         float rayLen = length(result.xy - ssOrigin.xy);
+        float rayPixelLen = rayLen * max(screen_res.x, screen_res.y);
+        if (rayPixelLen < 3.0)
+        {
+            float dR = texelFetch(sceneDepth, hitPixel + ivec2(1, 0), 0).r;
+            float dD = texelFetch(sceneDepth, hitPixel + ivec2(0, 1), 0).r;
+            vec3 posR = getPositionWithDepth((vec2(hitPixel) + vec2(1.5, 0.5)) / screen_res, dR).xyz;
+            vec3 posD = getPositionWithDepth((vec2(hitPixel) + vec2(0.5, 1.5)) / screen_res, dD).xyz;
+            vec3 hitGeomNormal = cross(posR - viewSpaceSurface, posD - viewSpaceSurface);
+            // Ensure normal faces toward camera (positive Z in view space).
+            if (hitGeomNormal.z < 0.0) hitGeomNormal = -hitGeomNormal;
+            hitGeomNormal = normalize(hitGeomNormal);
+
+            if (dot(reflectDir, hitGeomNormal) >= 0.0)
+                continue;
+        }
 
         float edgeFade = calculateEdgeFade(hitTC);
 

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflUtil.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflUtil.glsl
@@ -104,7 +104,10 @@ float projectDepth(vec3 viewPos)
 // References:
 //   Godot Engine SSR: screen_space_reflection.glsl (MIT license)
 //   Sugulee/GPU Pro 5: Hi-Z Screen-Space Cone-Traced Reflections
-vec3 hiZTrace(vec3 origin, vec3 dir, int maxIterations)
+// Returns vec4: xyz = hit position (UV + raw depth), w = 1.0 on hit.
+// Returns vec4(-1) on miss (ray exits screen or runs out of iterations).
+// Thickness-rejected surfaces are skipped (mip-0 march) but don't kill the trace.
+vec4 hiZTrace(vec3 origin, vec3 dir, int maxIterations)
 {
     int maxLevel = hizMipCount - 1;
 
@@ -212,9 +215,9 @@ vec3 hiZTrace(vec3 origin, vec3 dir, int maxIterations)
     if (hitPos.x < 0.0 || hitPos.x > 1.0 ||
         hitPos.y < 0.0 || hitPos.y > 1.0 ||
         t >= tMax)
-        return vec3(-1.0);
+        return vec4(-1.0);
 
-    return hitPos;
+    return vec4(hitPos, 1.0);
 }
 
 float calculateEdgeFade(vec2 screenPos)
@@ -233,11 +236,6 @@ float tapScreenSpaceReflection(
     sampler2D source,
     float glossiness)
 {
-#ifdef TRANSPARENT_SURFACE
-    collectedColor = vec4(1, 0, 1, 1);
-    return 0;
-#endif
-
     float roughness = 1.0 - glossiness;
 
     if (roughness >= maxRoughness)
@@ -336,7 +334,7 @@ float tapScreenSpaceReflection(
                           projectDepth(transformedEnd));
         vec3 ssDir = normalize(ssFar - ssOrigin);
 
-        vec3 result = hiZTrace(ssOrigin, ssDir, int(iterationCount.x));
+        vec4 result = hiZTrace(ssOrigin, ssDir, int(iterationCount.x));
 
         if (result.x < 0.0)
             continue;
@@ -353,16 +351,15 @@ float tapScreenSpaceReflection(
         if (hitDepth > maxZDepth)
             continue;
 
-        // Confidence validation:
+        // Confidence validation (matches Godot):
         // Compare the trace's final depth with the actual surface depth at that pixel.
-        // Use a dead zone so small mismatches (from cell-boundary snapping) don't
-        // reduce confidence — only penalize when the gap is significant.
-        // No squaring: let the smoothstep gradient be gentle to avoid banding.
+        // No dead zone — smoothstep from 0 penalizes any mismatch.
+        // Squared for strong near-hits with rapid falloff.
         vec3 viewSpaceSurface = getPositionWithDepth(hitTC, hitSurfaceDepth).xyz;
         vec3 viewSpaceHit = getPositionWithDepth(hitTC, result.z).xyz;
         float hitDistance = length(viewSpaceSurface - viewSpaceHit);
-        float confidenceStart = MAX_THICKNESS * 0.25;
-        float confidence = 1.0 - smoothstep(confidenceStart, MAX_THICKNESS, hitDistance);
+        float confidence = 1.0 - smoothstep(0.0, MAX_THICKNESS, hitDistance);
+        confidence *= confidence;
 
         // Screen-space ray length in UV units (matches Godot ray_len).
         // Godot: ray_len = length(screen_ray_dir.xy * t)
@@ -380,8 +377,10 @@ float tapScreenSpaceReflection(
         float mipLevel = maxMipLevels * effectiveRoughness;
         vec4 sampledColor = textureLod(source, hitTC, mipLevel);
 
+        // Fade-in: suppress near-origin artifacts from self-intersection.
+        float fadeIn = smoothstep(0.0, 0.01, rayLen);
         float rayFade = 1.0 - smoothstep(0.6, 1.0, rayLen);
-        float sampleFade = edgeFade * zFade * rayFade * confidence;
+        float sampleFade = edgeFade * zFade * fadeIn * rayFade * confidence;
 
         accumColor += sampledColor.rgb;
         accumFade += sampleFade;

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflWaterF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflWaterF.glsl
@@ -1,0 +1,90 @@
+/**
+ * @file class3/deferred/screenSpaceReflWaterF.glsl
+ *
+ * $LicenseInfo:firstyear=2007&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2007, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+/*[EXTRA_CODE_HERE]*/
+
+out vec4 frag_color;
+
+uniform sampler2D bumpMap;
+uniform sampler2D bumpMap2;
+uniform float     blend_factor;
+uniform vec3      normScale;
+uniform float     blurMultiplier;
+uniform vec2      screen_res;
+
+in vec4 refCoord;
+in vec4 littleWave;
+in vec4 view;
+in vec3 vary_position;
+in vec3 vary_normal;
+in vec3 vary_tangent;
+
+float tapScreenSpaceReflection(int totalSamples, vec2 tc, vec3 viewPos, vec3 n, inout vec4 collectedColor, sampler2D source, float glossiness);
+
+uniform sampler2D sceneMap;
+
+vec3 BlendNormal(vec3 bump1, vec3 bump2)
+{
+    return mix(bump1, bump2, blend_factor);
+}
+
+void main()
+{
+    vec3 vN = vary_normal;
+    vec3 vT = vary_tangent;
+    vec3 vB = cross(vN, vT);
+
+    // Generate wave normals (same as waterF.glsl)
+    vec2 bigwave = vec2(refCoord.w, view.w);
+
+    vec3 wave1_a = texture(bumpMap, bigwave).xyz * 2.0 - 1.0;
+    vec3 wave2_a = texture(bumpMap, littleWave.xy).xyz * 2.0 - 1.0;
+    vec3 wave3_a = texture(bumpMap, littleWave.zw).xyz * 2.0 - 1.0;
+
+    vec3 wave1_b = texture(bumpMap2, bigwave).xyz * 2.0 - 1.0;
+    vec3 wave2_b = texture(bumpMap2, littleWave.xy).xyz * 2.0 - 1.0;
+    vec3 wave3_b = texture(bumpMap2, littleWave.zw).xyz * 2.0 - 1.0;
+
+    vec3 wave1 = BlendNormal(wave1_a, wave1_b);
+    vec3 wave2 = BlendNormal(wave2_a, wave2_b);
+    vec3 wave3 = BlendNormal(wave3_a, wave3_b);
+
+    vec3 wavef = (wave1 + wave2 * 0.4 + wave3 * 0.6) * 0.5;
+
+    // Same IBL normal computation as waterF.glsl
+    vec3 wave_ibl = wavef * normScale;
+    wave_ibl.z *= 2.0;
+    wave_ibl = normalize(wave_ibl.x * vT + wave_ibl.y * vB + wave_ibl.z * vN);
+
+    // Water glossiness (same as waterF.glsl)
+    float perceptualRoughness = blurMultiplier * blurMultiplier;
+    float glossiness = 1.0 - perceptualRoughness;
+
+    vec2 tc = gl_FragCoord.xy / screen_res;
+
+    vec4 ssrColor = vec4(0.0);
+    tapScreenSpaceReflection(1, tc, vary_position, wave_ibl, ssrColor, sceneMap, glossiness);
+    frag_color = ssrColor;
+}

--- a/indra/newview/featuretable.txt
+++ b/indra/newview/featuretable.txt
@@ -74,6 +74,8 @@ RenderGLMultiThreadedTextures      1   0
 RenderGLMultiThreadedMedia         1   1
 RenderReflectionProbeResolution 1 128
 RenderScreenSpaceReflections 1  1
+RenderScreenSpaceReflectionGlossySamples 1 8
+RenderScreenSpaceReflectionsResolutionMultiplier 1 1
 RenderMirrors				1	1
 RenderHeroProbeResolution	1	2048
 RenderHeroProbeDistance		1	16
@@ -118,6 +120,8 @@ WLSkyDetail					1	96
 RenderFSAAType  			1	0
 RenderFSAASamples			1	0
 RenderScreenSpaceReflections 1  0
+RenderScreenSpaceReflectionGlossySamples 1 1
+RenderScreenSpaceReflectionsResolutionMultiplier 1 0.25
 RenderReflectionProbeLevel  1   0
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	256
@@ -162,6 +166,8 @@ WLSkyDetail					1	96
 RenderFSAAType  			1	0
 RenderFSAASamples			1	0
 RenderScreenSpaceReflections 1  0
+RenderScreenSpaceReflectionGlossySamples 1 1
+RenderScreenSpaceReflectionsResolutionMultiplier 1 0.25
 RenderReflectionProbeLevel  1   0
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	256
@@ -206,6 +212,8 @@ RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	0
 RenderReflectionProbeQuality	1	1
 RenderScreenSpaceReflections 1  0
+RenderScreenSpaceReflectionGlossySamples 1 2
+RenderScreenSpaceReflectionsResolutionMultiplier 1 0.25
 RenderReflectionProbeLevel  1   1
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	512
@@ -249,6 +257,8 @@ RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
 RenderReflectionProbeQuality	1	1
 RenderScreenSpaceReflections 1  0
+RenderScreenSpaceReflectionGlossySamples 1 2
+RenderScreenSpaceReflectionsResolutionMultiplier 1 0.25
 RenderReflectionProbeLevel  1   1
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	512
@@ -291,7 +301,9 @@ RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
 RenderReflectionProbeQuality	1	1
-RenderScreenSpaceReflections 1  0
+RenderScreenSpaceReflections 1  1
+RenderScreenSpaceReflectionGlossySamples 1 4
+RenderScreenSpaceReflectionsResolutionMultiplier 1 0.5
 RenderReflectionProbeLevel  1   2
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	512
@@ -334,7 +346,9 @@ RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
 RenderReflectionProbeQuality	1	1
-RenderScreenSpaceReflections 1  0
+RenderScreenSpaceReflections 1  1
+RenderScreenSpaceReflectionGlossySamples 1 4
+RenderScreenSpaceReflectionsResolutionMultiplier 1 1
 RenderReflectionProbeLevel  1   3
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	1024
@@ -378,6 +392,8 @@ RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
 RenderReflectionProbeQuality	1	1
 RenderScreenSpaceReflections 1  1
+RenderScreenSpaceReflectionGlossySamples 1 8
+RenderScreenSpaceReflectionsResolutionMultiplier 1 1
 RenderReflectionProbeLevel  1   3
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	2048

--- a/indra/newview/featuretable_mac.txt
+++ b/indra/newview/featuretable_mac.txt
@@ -74,6 +74,8 @@ RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	2
 RenderReflectionProbeQuality 1  1
 RenderScreenSpaceReflections 1  1
+RenderScreenSpaceReflectionGlossySamples 1 8
+RenderScreenSpaceReflectionsResolutionMultiplier 1 1
 RenderReflectionProbeLevel  1   3
 RenderMirrors				1	1
 RenderHeroProbeResolution	1	2048
@@ -119,6 +121,8 @@ RenderReflectionsEnabled    1   0
 RenderReflectionProbeDetail	1	0
 RenderReflectionProbeQuality 1  0
 RenderScreenSpaceReflections 1  0
+RenderScreenSpaceReflectionGlossySamples 1 1
+RenderScreenSpaceReflectionsResolutionMultiplier 1 0.25
 RenderReflectionProbeLevel  1   0
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	256
@@ -163,6 +167,8 @@ RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	0
 RenderReflectionProbeQuality 1  0
 RenderScreenSpaceReflections 1  0
+RenderScreenSpaceReflectionGlossySamples 1 1
+RenderScreenSpaceReflectionsResolutionMultiplier 1 0.25
 RenderReflectionProbeLevel  1   0
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	256
@@ -207,6 +213,8 @@ RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	0
 RenderReflectionProbeQuality 1  1
 RenderScreenSpaceReflections 1  0
+RenderScreenSpaceReflectionGlossySamples 1 2
+RenderScreenSpaceReflectionsResolutionMultiplier 1 0.25
 RenderReflectionProbeLevel  1   0
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	512
@@ -250,6 +258,8 @@ RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	0
 RenderReflectionProbeQuality 1  1
 RenderScreenSpaceReflections 1  0
+RenderScreenSpaceReflectionGlossySamples 1 2
+RenderScreenSpaceReflectionsResolutionMultiplier 1 0.25
 RenderReflectionProbeLevel  1   0
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	512
@@ -292,7 +302,9 @@ RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
 RenderReflectionProbeQuality 1  1
-RenderScreenSpaceReflections 1  0
+RenderScreenSpaceReflections 1  1
+RenderScreenSpaceReflectionGlossySamples 1 4
+RenderScreenSpaceReflectionsResolutionMultiplier 1 0.5
 RenderReflectionProbeLevel  1   1
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	512
@@ -335,7 +347,9 @@ RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
 RenderReflectionProbeQuality 1  1
-RenderScreenSpaceReflections 1  0
+RenderScreenSpaceReflections 1  1
+RenderScreenSpaceReflectionGlossySamples 1 4
+RenderScreenSpaceReflectionsResolutionMultiplier 1 1
 RenderReflectionProbeLevel  1   2
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	512
@@ -379,6 +393,8 @@ RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	1
 RenderReflectionProbeQuality 1  1
 RenderScreenSpaceReflections 1  1
+RenderScreenSpaceReflectionGlossySamples 1 8
+RenderScreenSpaceReflectionsResolutionMultiplier 1 1
 RenderReflectionProbeLevel  1   3
 RenderMirrors				1	0
 RenderHeroProbeResolution	1	1024

--- a/indra/newview/lldrawpoolwater.cpp
+++ b/indra/newview/lldrawpoolwater.cpp
@@ -335,3 +335,71 @@ LLColor3 LLDrawPoolWater::getDebugColor() const
 {
     return LLColor3(0.f, 1.f, 1.f);
 }
+
+void LLDrawPoolWater::renderSSR()
+{
+    if (!gSSRWaterProgram.isComplete()) return;
+    if (mDrawFace.empty()) return;
+
+    LL_PROFILE_GPU_ZONE("SSR water");
+
+    LLEnvironment& environment = LLEnvironment::instance();
+    LLSettingsWater::ptr_t pwater = environment.getCurrentWater();
+
+    bool has_normal_mips = gSavedSettings.getBOOL("RenderWaterMipNormal");
+    LLTexUnit::eTextureFilterOptions filter_mode = has_normal_mips ? LLTexUnit::TFO_ANISOTROPIC : LLTexUnit::TFO_POINT;
+
+    F32 phase_time = (F32)LLFrameTimer::getElapsedSeconds() * 0.5f;
+    F32 blend_factor = (F32)pwater->getBlendFactor();
+
+    gPipeline.bindDeferredShader(gSSRWaterProgram);
+
+    LLViewerTexture* tex_a = mWaterNormp[0];
+    LLViewerTexture* tex_b = mWaterNormp[1];
+
+    if (tex_a && (!tex_b || (tex_a == tex_b)))
+    {
+        gSSRWaterProgram.bindTexture(LLViewerShaderMgr::BUMP_MAP, tex_a);
+        tex_a->setFilteringOption(filter_mode);
+        blend_factor = 0;
+    }
+    else if (tex_b && !tex_a)
+    {
+        gSSRWaterProgram.bindTexture(LLViewerShaderMgr::BUMP_MAP, tex_b);
+        tex_b->setFilteringOption(filter_mode);
+        blend_factor = 0;
+    }
+    else if (tex_b != tex_a)
+    {
+        gSSRWaterProgram.bindTexture(LLViewerShaderMgr::BUMP_MAP, tex_a);
+        tex_a->setFilteringOption(filter_mode);
+        gSSRWaterProgram.bindTexture(LLViewerShaderMgr::BUMP_MAP2, tex_b);
+        tex_b->setFilteringOption(filter_mode);
+    }
+
+    gSSRWaterProgram.uniform1f(LLShaderMgr::BLEND_FACTOR, blend_factor);
+
+    F32 water_height = environment.getWaterHeight();
+    F32 camera_height = LLViewerCamera::getInstance()->getOrigin().mV[2];
+    gSSRWaterProgram.uniform1f(LLShaderMgr::WATER_WATERHEIGHT, camera_height - water_height);
+    gSSRWaterProgram.uniform1f(LLShaderMgr::WATER_TIME, phase_time);
+    gSSRWaterProgram.uniform3fv(LLShaderMgr::WATER_EYEVEC, 1, LLViewerCamera::getInstance()->getOrigin().mV);
+    gSSRWaterProgram.uniform2fv(LLShaderMgr::WATER_WAVE_DIR1, 1, pwater->getWave1Dir().mV);
+    gSSRWaterProgram.uniform2fv(LLShaderMgr::WATER_WAVE_DIR2, 1, pwater->getWave2Dir().mV);
+
+    LLVector3 light_dir = environment.getLightDirection();
+    light_dir.normalize();
+    gSSRWaterProgram.uniform3fv(LLShaderMgr::WATER_LIGHT_DIR, 1, light_dir.mV);
+    gSSRWaterProgram.uniform3fv(LLShaderMgr::WATER_NORM_SCALE, 1, pwater->getNormalScale().mV);
+    gSSRWaterProgram.uniform1f(LLShaderMgr::WATER_BLUR_MULTIPLIER, fmaxf(0, pwater->getBlurMultiplier()) * 2);
+
+    LLVector4 rotated_light_direction = LLEnvironment::instance().getClampedLightNorm();
+    gSSRWaterProgram.uniform3fv(LLViewerShaderMgr::LIGHTNORM, 1, rotated_light_direction.mV);
+    gSSRWaterProgram.uniform3fv(LLShaderMgr::WL_CAMPOSLOCAL, 1, LLViewerCamera::getInstance()->getOrigin().mV);
+
+    LLGLDisable cullface(GL_CULL_FACE);
+
+    pushWaterPlanes(0);
+
+    gPipeline.unbindDeferredShader(gSSRWaterProgram);
+}

--- a/indra/newview/lldrawpoolwater.h
+++ b/indra/newview/lldrawpoolwater.h
@@ -75,6 +75,7 @@ public:
     void setNormalMaps(const LLUUID& normalMapId, const LLUUID& nextNormalMapId);
 
     void pushWaterPlanes(int pass);
+    void renderSSR();
 
 protected:
     void renderOpaqueLegacyWater();

--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -868,6 +868,7 @@ void settings_setup_listeners()
     setting_setup_signal_listener(gSavedSettings, "RenderAppleUseMultGL", handleAppleUseMultGLChanged);
 #endif
     setting_setup_signal_listener(gSavedSettings, "RenderScreenSpaceReflections", handleReflectionProbeDetailChanged);
+    setting_setup_signal_listener(gSavedSettings, "RenderScreenSpaceReflectionsResolutionMultiplier", handleWindowResized);
     setting_setup_signal_listener(gSavedSettings, "RenderMirrors", handleReflectionProbeDetailChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderHeroProbeResolution", handleHeroProbeResolutionChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderShadowDetail", handleSetShaderChanged);

--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -1040,13 +1040,6 @@ void display(bool rebuild, F32 zoom_factor, int subfield, bool for_snapshot)
             gPipeline.renderSSRWater();
             gPipeline.filterSSRBuffer();
 
-            // Generate mipmaps for roughness-based blur
-            if (LLPipeline::RenderScreenSpaceReflections && gPipeline.mSSRBuffer.isComplete())
-            {
-                gGL.getTexUnit(0)->bind(&gPipeline.mSSRBuffer);
-                glGenerateMipmap(GL_TEXTURE_2D);
-            }
-
             gPipeline.renderDeferredLighting();
 
             // Copy screen to scene map for SSR to trace against next frame/pass.

--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -1035,6 +1035,18 @@ void display(bool rebuild, F32 zoom_factor, int subfield, bool for_snapshot)
 
         if (LLPipeline::sRenderDeferred)
         {
+            gPipeline.renderSSRTrace();
+            gPipeline.renderSSRAlpha();
+            gPipeline.renderSSRWater();
+            gPipeline.filterSSRBuffer();
+
+            // Generate mipmaps for roughness-based blur
+            if (LLPipeline::RenderScreenSpaceReflections && gPipeline.mSSRBuffer.isComplete())
+            {
+                gGL.getTexUnit(0)->bind(&gPipeline.mSSRBuffer);
+                glGenerateMipmap(GL_TEXTURE_2D);
+            }
+
             gPipeline.renderDeferredLighting();
 
             // Copy screen to scene map for SSR to trace against next frame/pass.

--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -1040,6 +1040,7 @@ void display(bool rebuild, F32 zoom_factor, int subfield, bool for_snapshot)
             // Copy screen to scene map for SSR to trace against next frame/pass.
             // Must happen after deferred lighting so the lit scene is available.
             gPipeline.copyScreenSpaceReflections(&gPipeline.mRT->screen, &gPipeline.mSceneMap);
+            gPipeline.buildHiZBuffer();
         }
 
         LLPipeline::sUnderWaterRender = false;

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -136,6 +136,10 @@ LLGLSLShader        gImpostorProgram;
 LLGLSLShader            gGlowProgram;
 LLGLSLShader            gGlowExtractProgram;
 LLGLSLShader            gPostScreenSpaceReflectionProgram;
+LLGLSLShader            gScreenSpaceReflTraceProgram;
+LLGLSLShader            gSSRAlphaProgram;
+LLGLSLShader            gSkinnedSSRAlphaProgram;
+LLGLSLShader            gSSRWaterProgram;
 
 // Deferred rendering shaders
 LLGLSLShader            gDeferredImpostorProgram;
@@ -162,6 +166,7 @@ LLGLSLShader            gDeferredSunProbeProgram;
 LLGLSLShader            gHazeProgram;
 LLGLSLShader            gHazeWaterProgram;
 LLGLSLShader            gDeferredBlurLightProgram;
+LLGLSLShader            gSSRFilterProgram;
 LLGLSLShader            gDeferredSoftenProgram;
 LLGLSLShader            gDeferredSoftenCubeProgram;
 LLGLSLShader            gDeferredShadowProgram;
@@ -1115,6 +1120,7 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         gDeferredMultiSpotLightProgram.unload();
         gDeferredSunProgram.unload();
         gDeferredBlurLightProgram.unload();
+        gSSRFilterProgram.unload();
         gDeferredSoftenProgram.unload();
         gDeferredSoftenCubeProgram.unload();
         gDeferredShadowProgram.unload();
@@ -1779,6 +1785,19 @@ bool LLViewerShaderMgr::loadShadersDeferred()
 
         success = gDeferredBlurLightProgram.createShader();
         llassert(success);
+    }
+
+    if (success)
+    {
+        gSSRFilterProgram.mName = "SSR Filter Shader";
+        gSSRFilterProgram.mFeatures.isDeferred = true;
+        gSSRFilterProgram.mFeatures.hasFullGBuffer = true;
+        gSSRFilterProgram.mShaderFiles.clear();
+        gSSRFilterProgram.mShaderFiles.push_back(make_pair("deferred/blurLightV.glsl", GL_VERTEX_SHADER));
+        gSSRFilterProgram.mShaderFiles.push_back(make_pair("deferred/screenSpaceReflFilterF.glsl", GL_FRAGMENT_SHADER));
+        gSSRFilterProgram.mShaderLevel = mShaderLevel[SHADER_DEFERRED];
+        add_common_permutations(&gSSRFilterProgram);
+        success = gSSRFilterProgram.createShader();
     }
 
     if (success)
@@ -3140,8 +3159,52 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         gPostScreenSpaceReflectionProgram.mShaderFiles.push_back(make_pair("deferred/screenSpaceReflPostF.glsl", GL_FRAGMENT_SHADER));
         gPostScreenSpaceReflectionProgram.mFeatures.hasScreenSpaceReflections = true;
         gPostScreenSpaceReflectionProgram.mFeatures.isDeferred                = true;
+        gPostScreenSpaceReflectionProgram.mFeatures.hasFullGBuffer            = true;
         gPostScreenSpaceReflectionProgram.mShaderLevel = 3;
         success = gPostScreenSpaceReflectionProgram.createShader();
+    }
+
+    if (success) {
+        gScreenSpaceReflTraceProgram.mName = "Screen Space Reflection Trace";
+        gScreenSpaceReflTraceProgram.mShaderFiles.clear();
+        gScreenSpaceReflTraceProgram.mShaderFiles.push_back(make_pair("deferred/screenSpaceReflPostV.glsl", GL_VERTEX_SHADER));
+        gScreenSpaceReflTraceProgram.mShaderFiles.push_back(make_pair("deferred/screenSpaceReflTraceF.glsl", GL_FRAGMENT_SHADER));
+        gScreenSpaceReflTraceProgram.mFeatures.hasScreenSpaceReflections = true;
+        gScreenSpaceReflTraceProgram.mFeatures.isDeferred                = true;
+        gScreenSpaceReflTraceProgram.mFeatures.hasFullGBuffer            = true;
+        gScreenSpaceReflTraceProgram.mShaderLevel = 3;
+        success = gScreenSpaceReflTraceProgram.createShader();
+    }
+
+    if (success) {
+        gSSRAlphaProgram.mName = "SSR Alpha";
+        gSSRAlphaProgram.mShaderFiles.clear();
+        gSSRAlphaProgram.mShaderFiles.push_back(make_pair("deferred/screenSpaceReflAlphaV.glsl", GL_VERTEX_SHADER));
+        gSSRAlphaProgram.mShaderFiles.push_back(make_pair("deferred/screenSpaceReflAlphaF.glsl", GL_FRAGMENT_SHADER));
+        gSSRAlphaProgram.mFeatures.hasScreenSpaceReflections = true;
+        gSSRAlphaProgram.mFeatures.isDeferred                = true;
+        gSSRAlphaProgram.mShaderLevel = 3;
+        success = gSSRAlphaProgram.createShader();
+    }
+
+    if (success)
+    {
+        success = make_rigged_variant(gSSRAlphaProgram, gSkinnedSSRAlphaProgram);
+    }
+
+    if (success)
+    {
+        gSSRWaterProgram.mName = "SSR Water";
+        gSSRWaterProgram.mShaderFiles.clear();
+        gSSRWaterProgram.mShaderFiles.push_back(make_pair("environment/waterV.glsl", GL_VERTEX_SHADER));
+        gSSRWaterProgram.mShaderFiles.push_back(make_pair("deferred/screenSpaceReflWaterF.glsl", GL_FRAGMENT_SHADER));
+        gSSRWaterProgram.mFeatures.calculatesAtmospherics  = true;
+        gSSRWaterProgram.mFeatures.hasAtmospherics         = true;
+        gSSRWaterProgram.mFeatures.hasScreenSpaceReflections = true;
+        gSSRWaterProgram.mFeatures.isDeferred              = true;
+        gSSRWaterProgram.mShaderLevel = 3;
+        gSSRWaterProgram.mShaderGroup = LLGLSLShader::SG_WATER;
+        success = gSSRWaterProgram.createShader();
     }
 
     if (success) {

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -1791,7 +1791,6 @@ bool LLViewerShaderMgr::loadShadersDeferred()
     {
         gSSRFilterProgram.mName = "SSR Filter Shader";
         gSSRFilterProgram.mFeatures.isDeferred = true;
-        gSSRFilterProgram.mFeatures.hasFullGBuffer = true;
         gSSRFilterProgram.mShaderFiles.clear();
         gSSRFilterProgram.mShaderFiles.push_back(make_pair("deferred/blurLightV.glsl", GL_VERTEX_SHADER));
         gSSRFilterProgram.mShaderFiles.push_back(make_pair("deferred/screenSpaceReflFilterF.glsl", GL_FRAGMENT_SHADER));

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -99,6 +99,7 @@ LLGLSLShader    gBenchmarkProgram;
 LLGLSLShader    gReflectionProbeDisplayProgram;
 LLGLSLShader    gCopyProgram;
 LLGLSLShader    gCopyDepthProgram;
+LLGLSLShader    gHiZReduceProgram;
 LLGLSLShader    gPBRTerrainBakeProgram;
 LLGLSLShader    gDrawColorProgram;
 
@@ -3628,6 +3629,16 @@ bool LLViewerShaderMgr::loadShadersInterface()
         gCopyDepthProgram.addPermutation("COPY_DEPTH", "1");
         gCopyDepthProgram.mShaderLevel = mShaderLevel[SHADER_INTERFACE];
         success = gCopyDepthProgram.createShader();
+    }
+
+    if (success)
+    {
+        gHiZReduceProgram.mName = "Hi-Z Reduce Shader";
+        gHiZReduceProgram.mShaderFiles.clear();
+        gHiZReduceProgram.mShaderFiles.push_back(make_pair("interface/copyV.glsl", GL_VERTEX_SHADER));
+        gHiZReduceProgram.mShaderFiles.push_back(make_pair("deferred/hiZReduceF.glsl", GL_FRAGMENT_SHADER));
+        gHiZReduceProgram.mShaderLevel = mShaderLevel[SHADER_INTERFACE];
+        success = gHiZReduceProgram.createShader();
     }
 
     if (success)

--- a/indra/newview/llviewershadermgr.h
+++ b/indra/newview/llviewershadermgr.h
@@ -215,6 +215,12 @@ extern LLGLSLShader         gImpostorProgram;
 // Post Process Shaders
 extern LLGLSLShader         gPostScreenSpaceReflectionProgram;
 
+// SSR Trace
+extern LLGLSLShader         gScreenSpaceReflTraceProgram;
+extern LLGLSLShader         gSSRAlphaProgram;
+extern LLGLSLShader         gSkinnedSSRAlphaProgram;
+extern LLGLSLShader         gSSRWaterProgram;
+
 // Deferred rendering shaders
 extern LLGLSLShader         gDeferredImpostorProgram;
 extern LLGLSLShader         gDeferredDiffuseProgram;
@@ -235,6 +241,7 @@ extern LLGLSLShader         gDeferredSunProbeProgram;
 extern LLGLSLShader         gHazeProgram;
 extern LLGLSLShader         gHazeWaterProgram;
 extern LLGLSLShader         gDeferredBlurLightProgram;
+extern LLGLSLShader         gSSRFilterProgram;
 extern LLGLSLShader         gDeferredAvatarProgram;
 extern LLGLSLShader         gDeferredSoftenProgram;
 extern LLGLSLShader         gDeferredSoftenCubeProgram;

--- a/indra/newview/llviewershadermgr.h
+++ b/indra/newview/llviewershadermgr.h
@@ -174,6 +174,7 @@ extern LLGLSLShader         gBenchmarkProgram;
 extern LLGLSLShader         gReflectionProbeDisplayProgram;
 extern LLGLSLShader         gCopyProgram;
 extern LLGLSLShader         gCopyDepthProgram;
+extern LLGLSLShader         gHiZReduceProgram;
 extern LLGLSLShader         gPBRTerrainBakeProgram;
 extern LLGLSLShader         gDrawColorProgram;
 

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -928,10 +928,27 @@ bool LLPipeline::allocateScreenBufferInternal(U32 resX, U32 resY)
         if(RenderScreenSpaceReflections)
         {
             mSceneMap.allocate(resX, resY, screenFormat, true, LLTexUnit::TT_TEXTURE, LLTexUnit::TMG_AUTO);
+
+            static LLCachedControl<F32> ssrScale(gSavedSettings, "RenderScreenSpaceReflectionsResolutionMultiplier", 1.0f);
+            F32 scale = llclamp((F32)ssrScale, 0.25f, 1.0f);
+            U32 ssrW = (U32)(resX * scale);
+            U32 ssrH = (U32)(resY * scale);
+            bool fullRes = (ssrW == resX && ssrH == resY);
+            // At full res: no own depth, share from deferred (zero-copy).
+            // At reduced res: allocate own depth, blit from deferred before alpha/water passes.
+            mSSRBuffer.allocate(ssrW, ssrH, GL_RGBA16F, !fullRes, LLTexUnit::TT_TEXTURE, LLTexUnit::TMG_AUTO);
+            mSSRFilterTemp.allocate(ssrW, ssrH, GL_RGBA16F);
+
+            if (fullRes)
+            {
+                mRT->deferredScreen.shareDepthBuffer(mSSRBuffer);
+            }
         }
         else
         {
             mSceneMap.release();
+            mSSRBuffer.release();
+            mSSRFilterTemp.release();
         }
 
         mPostPingMap.allocate(resX, resY, GL_RGBA);
@@ -1273,6 +1290,9 @@ void LLPipeline::releaseScreenBuffers()
     mHeroProbeRT.screen.release();
     mHeroProbeRT.deferredScreen.release();
     mHeroProbeRT.deferredLight.release();
+
+    mSSRBuffer.release();
+    mSSRFilterTemp.release();
 }
 
 void LLPipeline::releaseSunShadowTarget(U32 index)
@@ -7382,6 +7402,292 @@ void LLPipeline::gammaCorrect(LLRenderTarget* src, LLRenderTarget* dst)
     dst->flush();
 }
 
+void LLPipeline::renderSSRTrace()
+{
+    if (!RenderScreenSpaceReflections || gCubeSnapshot) return;
+    if (!gScreenSpaceReflTraceProgram.isComplete()) return;
+    if (!mSSRBuffer.isComplete()) return;
+
+    LL_PROFILE_GPU_ZONE("SSR trace");
+
+    gGL.setColorMask(true, true);
+    mSSRBuffer.bindTarget();
+    mSSRBuffer.clear(GL_COLOR_BUFFER_BIT);
+
+    LLGLDepthTest depth(GL_FALSE);
+    LLGLDisable blend(GL_BLEND);
+
+    bindDeferredShader(gScreenSpaceReflTraceProgram);
+
+    mScreenTriangleVB->setBuffer();
+    mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+
+    unbindDeferredShader(gScreenSpaceReflTraceProgram);
+    mSSRBuffer.flush();
+}
+
+void LLPipeline::renderSSRAlpha()
+{
+    if (!RenderScreenSpaceReflections || gCubeSnapshot) return;
+    if (!gSSRAlphaProgram.isComplete()) return;
+    if (!mSSRBuffer.isComplete()) return;
+
+    // If the SSR buffer owns its own depth (reduced resolution), blit the
+    // deferred depth down so alpha/water passes can depth-test correctly.
+    if (mSSRBuffer.getDepth() != 0
+        && mSSRBuffer.getDepth() != mRT->deferredScreen.getDepth())
+    {
+        mSSRBuffer.blitDepthFrom(mRT->deferredScreen);
+    }
+
+    LL_PROFILE_GPU_ZONE("SSR alpha");
+
+    gGL.setColorMask(true, true);
+    mSSRBuffer.bindTarget();
+
+    // Read-only depth test: discard alpha fragments behind opaque geometry
+    LLGLDepthTest depth(GL_TRUE, GL_FALSE, GL_LEQUAL);
+    LLGLDisable blend(GL_BLEND);
+
+    // Identity texture transform for legacy materials
+    static const F32 sIdentityTransform[8] = { 1.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f };
+
+    const LLVOAvatar* lastAvatar = nullptr;
+    U64 lastMeshId = 0;
+    bool skipLastSkin = false;
+
+    for (int pass = 0; pass < 2; ++pass)
+    {
+        bool rigged = (pass == 1);
+
+        LLGLSLShader* shader = &gSSRAlphaProgram;
+        if (rigged && shader->mRiggedVariant)
+        {
+            shader = shader->mRiggedVariant;
+        }
+
+        // Bind shader once per pass, then use fast path for re-syncing
+        bindDeferredShader(*shader);
+        shader->mCanBindFast = true;
+
+        LLCullResult::sg_iterator begin;
+        LLCullResult::sg_iterator end;
+
+        if (rigged)
+        {
+            begin = beginRiggedAlphaGroups();
+            end = endRiggedAlphaGroups();
+        }
+        else
+        {
+            begin = beginAlphaGroups();
+            end = endAlphaGroups();
+        }
+
+        for (LLCullResult::sg_iterator i = begin; i != end; ++i)
+        {
+            LLSpatialGroup* group = *i;
+            if (!group || group->isDead()) continue;
+            if (!group->getSpatialPartition()->mRenderByGroup) continue;
+
+            U32 passType = rigged ? LLRenderPass::PASS_ALPHA_RIGGED : LLRenderPass::PASS_ALPHA;
+            LLSpatialGroup::drawmap_elem_t& draw_info = group->mDrawMap[passType];
+
+            for (auto k = draw_info.begin(); k != draw_info.end(); ++k)
+            {
+                LLDrawInfo& params = **k;
+                if ((bool)params.mAvatar != rigged)
+                {
+                    continue;
+                }
+
+                LLRenderPass::applyModelMatrix(params);
+                bindDeferredShaderFast(*shader);
+
+                bool tex_setup = false;
+
+                if (params.mGLTFMaterial)
+                {
+                    // PBR: bind all material textures and uniforms
+                    // (diffuseMap, specularMap/ORM, bumpMap, emissiveMap,
+                    //  roughnessFactor, texture transforms, etc.)
+                    LLGLDisable cull_face(params.mGLTFMaterial->mDoubleSided ? GL_CULL_FACE : 0);
+                    params.mGLTFMaterial->bind(params.mTexture);
+
+                    // Handle texture animation (LSL texture anim on PBR objects)
+                    if (params.mTextureMatrix)
+                    {
+                        tex_setup = true;
+                        gGL.getTexUnit(0)->activate();
+                        gGL.matrixMode(LLRender::MM_TEXTURE);
+                        gGL.loadMatrix((GLfloat*)params.mTextureMatrix->mMatrix);
+                    }
+                }
+                else
+                {
+                    // Legacy: bind diffuse texture for alpha sampling
+                    if (params.mTexture.notNull())
+                    {
+                        shader->bindTexture(LLShaderMgr::DIFFUSE_MAP, params.mTexture);
+                    }
+                    else
+                    {
+                        shader->bindTexture(LLShaderMgr::DIFFUSE_MAP, LLViewerFetchedTexture::sWhiteImagep);
+                    }
+
+                    // Legacy: bind white for ORM so shader reads roughness=1.0 from green channel,
+                    // making final roughness = roughness_factor directly
+                    shader->bindTexture(LLShaderMgr::SPECULAR_MAP, LLViewerFetchedTexture::sWhiteImagep);
+
+                    // Legacy glossiness from specular color alpha
+                    F32 roughness = 1.0f - params.mSpecColor.mV[3];
+                    shader->uniform1f(LLShaderMgr::ROUGHNESS_FACTOR, roughness);
+
+                    // Identity PBR texture transforms for legacy materials
+                    shader->uniform4fv(LLShaderMgr::TEXTURE_BASE_COLOR_TRANSFORM, 2, sIdentityTransform);
+                    shader->uniform4fv(LLShaderMgr::TEXTURE_METALLIC_ROUGHNESS_TRANSFORM, 2, sIdentityTransform);
+                    shader->uniform1f(LLShaderMgr::MINIMUM_ALPHA, -1.0f);
+
+                    // Handle legacy texture matrix (texture animation)
+                    if (params.mTextureMatrix)
+                    {
+                        tex_setup = true;
+                        gGL.getTexUnit(0)->activate();
+                        gGL.matrixMode(LLRender::MM_TEXTURE);
+                        gGL.loadMatrix((GLfloat*)params.mTextureMatrix->mMatrix);
+                    }
+                }
+
+                if (rigged)
+                {
+                    LLRenderPass::uploadMatrixPalette(params.mAvatar, params.mSkinInfo,
+                        lastAvatar, lastMeshId, skipLastSkin);
+                }
+
+                params.mVertexBuffer->setBuffer();
+                params.mVertexBuffer->drawRange(LLRender::TRIANGLES,
+                    params.mStart, params.mEnd, params.mCount, params.mOffset);
+
+                if (tex_setup)
+                {
+                    gGL.getTexUnit(0)->activate();
+                    gGL.matrixMode(LLRender::MM_TEXTURE);
+                    gGL.loadIdentity();
+                    gGL.matrixMode(LLRender::MM_MODELVIEW);
+                }
+            }
+        }
+
+        unbindDeferredShader(*shader);
+    }
+
+    mSSRBuffer.flush();
+}
+
+void LLPipeline::renderSSRWater()
+{
+    if (!RenderScreenSpaceReflections || gCubeSnapshot) return;
+    if (!gSSRWaterProgram.isComplete()) return;
+    if (!mSSRBuffer.isComplete()) return;
+
+    LLDrawPool* pool = findPool(LLDrawPool::POOL_WATER);
+    if (!pool) return;
+
+    LL_PROFILE_GPU_ZONE("SSR water");
+
+    gGL.setColorMask(true, true);
+    mSSRBuffer.bindTarget();
+
+    // Read-only depth test: discard water fragments behind opaque geometry.
+    // Treat water as opaque in the SSR buffer.
+    LLGLDepthTest depth(GL_TRUE, GL_FALSE, GL_LEQUAL);
+    LLGLDisable blend(GL_BLEND);
+
+    static_cast<LLDrawPoolWater*>(pool)->renderSSR();
+
+    mSSRBuffer.flush();
+}
+
+void LLPipeline::filterSSRBuffer()
+{
+    if (!RenderScreenSpaceReflections || gCubeSnapshot) return;
+    if (!mSSRBuffer.isComplete() || !mSSRFilterTemp.isComplete()) return;
+    if (!gSSRFilterProgram.isComplete()) return;
+
+    LL_PROFILE_GPU_ZONE("SSR filter");
+
+    LLVector3 go = RenderShadowGaussian;
+    const U32 kern_length = 4;
+    F32 x = 0.f;
+    LLVector3 gauss[32];
+    for (U32 i = 0; i < kern_length; i++)
+    {
+        gauss[i].mV[0] = llgaussian(x, go.mV[0]);
+        gauss[i].mV[1] = llgaussian(x, go.mV[1]);
+        gauss[i].mV[2] = x;
+        x += 1.f;
+    }
+
+    static LLCachedControl<F32> ssrFilterScale(gSavedSettings, "RenderScreenSpaceReflectionsFilterScale", 2.0f);
+    F32 blur_size = (F32)ssrFilterScale;
+
+    // --- Horizontal pass: mSSRBuffer -> mSSRFilterTemp ---
+    mSSRFilterTemp.bindTarget();
+    mSSRFilterTemp.clear(GL_COLOR_BUFFER_BIT);
+
+    bindDeferredShader(gSSRFilterProgram);
+
+    // Override screen_res to match SSR buffer dimensions (bindDeferredShader
+    // sets it to the full-res deferred target, but the filter operates at
+    // SSR buffer resolution).
+    gSSRFilterProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES,
+        (GLfloat)mSSRBuffer.getWidth(), (GLfloat)mSSRBuffer.getHeight());
+
+    S32 channel = gSSRFilterProgram.enableTexture(LLShaderMgr::DIFFUSE_MAP);
+    if (channel > -1)
+        gGL.getTexUnit(channel)->bind(&mSSRBuffer);
+
+    gSSRFilterProgram.uniform2f(sDelta, 1.f, 0.f);
+    gSSRFilterProgram.uniform3fv(sKern, kern_length, gauss[0].mV);
+    gSSRFilterProgram.uniform1f(sKernScale, blur_size * (kern_length / 2.f - 0.5f));
+
+    {
+        LLGLDisable blend(GL_BLEND);
+        LLGLDepthTest depth(GL_FALSE);
+        mScreenTriangleVB->setBuffer();
+        mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+    }
+
+    mSSRFilterTemp.flush();
+    unbindDeferredShader(gSSRFilterProgram);
+
+    // --- Vertical pass: mSSRFilterTemp -> mSSRBuffer ---
+    mSSRBuffer.bindTarget();
+    mSSRBuffer.clear(GL_COLOR_BUFFER_BIT);
+
+    bindDeferredShader(gSSRFilterProgram);
+    gSSRFilterProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES,
+        (GLfloat)mSSRBuffer.getWidth(), (GLfloat)mSSRBuffer.getHeight());
+
+    channel = gSSRFilterProgram.enableTexture(LLShaderMgr::DIFFUSE_MAP);
+    if (channel > -1)
+        gGL.getTexUnit(channel)->bind(&mSSRFilterTemp);
+
+    gSSRFilterProgram.uniform2f(sDelta, 0.f, 1.f);
+    gSSRFilterProgram.uniform3fv(sKern, kern_length, gauss[0].mV);
+    gSSRFilterProgram.uniform1f(sKernScale, blur_size * (kern_length / 2.f - 0.5f));
+
+    {
+        LLGLDisable blend(GL_BLEND);
+        LLGLDepthTest depth(GL_FALSE);
+        mScreenTriangleVB->setBuffer();
+        mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+    }
+
+    mSSRBuffer.flush();
+    unbindDeferredShader(gSSRFilterProgram);
+}
+
 void LLPipeline::copyScreenSpaceReflections(LLRenderTarget* src, LLRenderTarget* dst)
 {
 
@@ -8333,6 +8639,14 @@ void LLPipeline::renderFinalize()
             if (RenderMotionBlur)
             {
                 visualizeBuffers(&mVelocityMap, sourceBuffer, 0);
+            }
+            break;
+        }
+        case 8:
+        {
+            if (mSSRBuffer.isComplete())
+            {
+                visualizeBuffers(&mSSRBuffer, sourceBuffer, 0);
             }
             break;
         }
@@ -9591,74 +9905,95 @@ void LLPipeline::bindReflectionProbes(LLGLSLShader& shader)
 
     if (RenderScreenSpaceReflections)
     {
-        // reflection probe shaders generally sample the scene map as well for SSR
+        // Determine if this shader is performing the SSR trace (needs previous
+        // frame scene map + trace uniforms) or reading pre-computed SSR results
+        // from the SSR buffer.
+        bool inSSRTracePass = (&shader == &gScreenSpaceReflTraceProgram)
+                           || (&shader == &gSSRAlphaProgram)
+                           || (&shader == &gSkinnedSSRAlphaProgram)
+                           || (&shader == &gSSRWaterProgram);
+
         channel = shader.enableTexture(LLShaderMgr::SCENE_MAP);
         if (channel > -1)
         {
-            gGL.getTexUnit(channel)->bind(&mSceneMap);
+            if (inSSRTracePass)
+            {
+                // Trace pass: bind previous frame's lit scene for ray marching
+                gGL.getTexUnit(channel)->bind(&mSceneMap);
+            }
+            else if (mSSRBuffer.isComplete())
+            {
+                // Lighting pass: bind pre-computed SSR buffer
+                gGL.getTexUnit(channel)->bind(&mSSRBuffer);
+            }
+            else
+            {
+                // Fallback: bind scene map
+                gGL.getTexUnit(channel)->bind(&mSceneMap);
+            }
         }
 
-        static LLCachedControl<LLVector3> traceIterations(gSavedSettings, "RenderScreenSpaceReflectionIterations");
-        static LLCachedControl<LLVector3> traceSteps(gSavedSettings, "RenderScreenSpaceReflectionRayStep");
-        static LLCachedControl<LLVector3> traceDistanceBias(gSavedSettings, "RenderScreenSpaceReflectionDistanceBias");
-        static LLCachedControl<LLVector3> traceRejectBias(gSavedSettings, "RenderScreenSpaceReflectionDepthRejectBias");
-        static LLCachedControl<LLVector3> traceStepMultiplier(gSavedSettings, "RenderScreenSpaceReflectionAdaptiveStepMultiplier");
-        static LLCachedControl<LLVector3> traceSplitStart(gSavedSettings, "RenderScreenSpaceReflectionSplitStart");
-        static LLCachedControl<LLVector3> traceSplitEnd(gSavedSettings, "RenderScreenSpaceReflectionSplitEnd");
-        static LLCachedControl<F32> traceMaxDepth(gSavedSettings, "RenderScreenSpaceReflectionMaxDepth");
-        static LLCachedControl<F32> traceMaxRoughness(gSavedSettings, "RenderScreenSpaceReflectionMaxRoughness");
-
-        shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_ITR_COUNT, 1, traceIterations().mV);
-        shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_DIST_BIAS, 1, traceDistanceBias().mV);
-        shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_RAY_STEP, 1, traceSteps().mV);
-        shader.uniform1f(LLShaderMgr::DEFERRED_SSR_GLOSSY_SAMPLES, (GLfloat)RenderScreenSpaceReflectionGlossySamples);
-        shader.uniform3fv(sTraceDepthRejectBias, 1, traceRejectBias().mV);
-        mPoissonOffset++;
-
-        if (mPoissonOffset > 128 - RenderScreenSpaceReflectionGlossySamples)
-            mPoissonOffset = 0;
-
-        shader.uniform1f(LLShaderMgr::DEFERRED_SSR_NOISE_SINE, (GLfloat)mPoissonOffset);
-        shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_ADAPTIVE_STEP_MULT, 1, traceStepMultiplier().mV);
-        shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_SPLIT_START, 1, traceSplitStart().mV);
-        shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_SPLIT_END, 1, traceSplitEnd().mV);
-
-        shader.uniform1f(LLShaderMgr::DEFERRED_SSR_MAX_Z, traceMaxDepth());
-        shader.uniform1f(LLShaderMgr::DEFERRED_SSR_MAX_ROUGHNESS, traceMaxRoughness());
-
-        // Compute jitter compensation for SMAA T2x.
-        // mSceneMap was rendered with the previous frame's jittered projection.
-        // SSR projects positions using the current frame's projection.
-        // Correct the UV offset so mSceneMap lookups hit the right texels.
-        float jitterOffsetX = 0.f;
-        float jitterOffsetY = 0.f;
-        if (sT2xJitterEnabled)
+        if (inSSRTracePass)
         {
-            static const float jitters[2][2] = {
-                { 0.25f, -0.25f },
-                {-0.25f,  0.25f },
-            };
-            U32 curIdx  = mSMAAFrameIndex & 1;
-            U32 prevIdx = curIdx ^ 1;
-            float width  = (float)gViewerWindow->getWorldViewWidthRaw();
-            float height = (float)gViewerWindow->getWorldViewHeightRaw();
-            // Jitter is applied to proj[2][0/1] as j * 2 / dim.
-            // NDC offset from jitter = -j_ndc (perspective divide flips sign).
-            // UV = NDC * 0.5 + 0.5, so UV delta = NDC delta * 0.5.
-            // Correction = (cur_j - prev_j) / dim  (the 2 and 0.5 cancel).
-            jitterOffsetX = (jitters[curIdx][0] - jitters[prevIdx][0]) / width;
-            jitterOffsetY = (jitters[curIdx][1] - jitters[prevIdx][1]) / height;
-        }
-        shader.uniform2f(sSSRJitterOffset, jitterOffsetX, jitterOffsetY);
+            // Set all SSR trace uniforms (only needed for trace shaders)
+            static LLCachedControl<LLVector3> traceIterations(gSavedSettings, "RenderScreenSpaceReflectionIterations");
+            static LLCachedControl<LLVector3> traceSteps(gSavedSettings, "RenderScreenSpaceReflectionRayStep");
+            static LLCachedControl<LLVector3> traceDistanceBias(gSavedSettings, "RenderScreenSpaceReflectionDistanceBias");
+            static LLCachedControl<LLVector3> traceRejectBias(gSavedSettings, "RenderScreenSpaceReflectionDepthRejectBias");
+            static LLCachedControl<LLVector3> traceStepMultiplier(gSavedSettings, "RenderScreenSpaceReflectionAdaptiveStepMultiplier");
+            static LLCachedControl<LLVector3> traceSplitStart(gSavedSettings, "RenderScreenSpaceReflectionSplitStart");
+            static LLCachedControl<LLVector3> traceSplitEnd(gSavedSettings, "RenderScreenSpaceReflectionSplitEnd");
+            static LLCachedControl<F32> traceMaxDepth(gSavedSettings, "RenderScreenSpaceReflectionMaxDepth");
+            static LLCachedControl<F32> traceMaxRoughness(gSavedSettings, "RenderScreenSpaceReflectionMaxRoughness");
 
-        channel = shader.enableTexture(LLShaderMgr::SCENE_DEPTH);
-        if (channel > -1)
-        {
-            gGL.getTexUnit(channel)->bind(&mSceneMap, true);
-        }
+            shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_ITR_COUNT, 1, traceIterations().mV);
+            shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_DIST_BIAS, 1, traceDistanceBias().mV);
+            shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_RAY_STEP, 1, traceSteps().mV);
+            shader.uniform1f(LLShaderMgr::DEFERRED_SSR_GLOSSY_SAMPLES, (GLfloat)RenderScreenSpaceReflectionGlossySamples);
+            shader.uniform3fv(sTraceDepthRejectBias, 1, traceRejectBias().mV);
+            mPoissonOffset++;
 
-        static LLStaticHashedString sHiZMipCount("hizMipCount");
-        shader.uniform1i(sHiZMipCount, (GLint)mSceneMap.getMipLevels());
+            if (mPoissonOffset > 128 - RenderScreenSpaceReflectionGlossySamples)
+                mPoissonOffset = 0;
+
+            shader.uniform1f(LLShaderMgr::DEFERRED_SSR_NOISE_SINE, (GLfloat)mPoissonOffset);
+            shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_ADAPTIVE_STEP_MULT, 1, traceStepMultiplier().mV);
+            shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_SPLIT_START, 1, traceSplitStart().mV);
+            shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_SPLIT_END, 1, traceSplitEnd().mV);
+
+            shader.uniform1f(LLShaderMgr::DEFERRED_SSR_MAX_Z, traceMaxDepth());
+            shader.uniform1f(LLShaderMgr::DEFERRED_SSR_MAX_ROUGHNESS, traceMaxRoughness());
+
+            // Compute jitter compensation for SMAA T2x.
+            // mSceneMap was rendered with the previous frame's jittered projection.
+            // SSR projects positions using the current frame's projection.
+            // Correct the UV offset so mSceneMap lookups hit the right texels.
+            float jitterOffsetX = 0.f;
+            float jitterOffsetY = 0.f;
+            if (sT2xJitterEnabled)
+            {
+                static const float jitters[2][2] = {
+                    { 0.25f, -0.25f },
+                    {-0.25f,  0.25f },
+                };
+                U32 curIdx  = mSMAAFrameIndex & 1;
+                U32 prevIdx = curIdx ^ 1;
+                float width  = (float)gViewerWindow->getWorldViewWidthRaw();
+                float height = (float)gViewerWindow->getWorldViewHeightRaw();
+                jitterOffsetX = (jitters[curIdx][0] - jitters[prevIdx][0]) / width;
+                jitterOffsetY = (jitters[curIdx][1] - jitters[prevIdx][1]) / height;
+            }
+            shader.uniform2f(sSSRJitterOffset, jitterOffsetX, jitterOffsetY);
+
+            channel = shader.enableTexture(LLShaderMgr::SCENE_DEPTH);
+            if (channel > -1)
+            {
+                gGL.getTexUnit(channel)->bind(&mSceneMap, true);
+            }
+
+            static LLStaticHashedString sHiZMipCount("hizMipCount");
+            shader.uniform1i(sHiZMipCount, (GLint)mSceneMap.getMipLevels());
+        }
     }
 }
 

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -7412,7 +7412,7 @@ void LLPipeline::renderSSRTrace()
     mSSRBuffer.bindTarget();
     mSSRBuffer.clear(GL_COLOR_BUFFER_BIT);
 
-    LLGLDepthTest depth(GL_FALSE);
+    LLGLDepthTest depth(GL_FALSE, GL_FALSE);
     LLGLDisable blend(GL_BLEND);
 
     bindDeferredShader(gScreenSpaceReflTraceProgram);
@@ -7580,6 +7580,14 @@ void LLPipeline::renderSSRAlpha()
     }
 
     mSSRBuffer.flush();
+
+    // Reset modelview to camera-only — applyModelMatrix leaves a stale
+    // object transform that would corrupt light volume positions in
+    // renderDeferredLighting (the point light vertex shader multiplies by
+    // modelview_projection_matrix via syncMatrices).
+    gGLLastMatrix = NULL;
+    gGL.matrixMode(LLRender::MM_MODELVIEW);
+    gGL.loadMatrix(gGLModelView);
 }
 
 void LLPipeline::renderSSRWater()
@@ -7604,6 +7612,12 @@ void LLPipeline::renderSSRWater()
     static_cast<LLDrawPoolWater*>(pool)->renderSSR();
 
     mSSRBuffer.flush();
+
+    // Same matrix reset as renderSSRAlpha — water geometry may leave a stale
+    // modelview that would corrupt light volume positions in deferred lighting.
+    gGLLastMatrix = NULL;
+    gGL.matrixMode(LLRender::MM_MODELVIEW);
+    gGL.loadMatrix(gGLModelView);
 }
 
 void LLPipeline::filterSSRBuffer()
@@ -7619,7 +7633,7 @@ void LLPipeline::filterSSRBuffer()
     if (mSSRMipTemp.empty()) return;
 
     LLGLDisable blend(GL_BLEND);
-    LLGLDepthTest depth(GL_FALSE);
+    LLGLDepthTest depth(GL_FALSE, GL_FALSE);
 
     // Identity matrices for screen-space rendering (same as probe manager)
     gGL.matrixMode(gGL.MM_MODELVIEW);
@@ -7677,6 +7691,12 @@ void LLPipeline::filterSSRBuffer()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, mipLevels - 1);
     mSSRBuffer.resetColorMipLevel();
+
+    // bindColorMipLevel bypasses the RT stack (direct glBindFramebuffer),
+    // so we must manually unbind the FBO here to avoid corrupting GL state
+    // for renderDeferredLighting.
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    LLRenderTarget::sCurFBO = 0;
 
     gGaussianProgram.unbind();
 
@@ -7751,6 +7771,11 @@ void LLPipeline::buildHiZBuffer()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, mipLevels - 1);
     mSceneMap.resetDepthMipLevel();
+
+    // bindDepthMipLevel bypasses the RT stack (direct glBindFramebuffer),
+    // so we must manually unbind the FBO here.
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    LLRenderTarget::sCurFBO = 0;
 
     gHiZReduceProgram.unbind();
 }
@@ -9906,11 +9931,18 @@ void LLPipeline::bindReflectionProbes(LLGLSLShader& shader)
     {
         // Determine if this shader is performing the SSR trace (needs previous
         // frame scene map + trace uniforms) or reading pre-computed SSR results
-        // from the SSR buffer.
+        // from the SSR buffer.  Forward alpha shaders also need trace bindings
+        // so transparent surfaces can trace their own SSR inline rather than
+        // reading incorrect opaque-surface SSR from the pre-computed buffer.
         bool inSSRTracePass = (&shader == &gScreenSpaceReflTraceProgram)
                            || (&shader == &gSSRAlphaProgram)
                            || (&shader == &gSkinnedSSRAlphaProgram)
-                           || (&shader == &gSSRWaterProgram);
+                           || (&shader == &gSSRWaterProgram)
+                           || (&shader == &gDeferredPBRAlphaProgram)
+                           || (gDeferredPBRAlphaProgram.mRiggedVariant && &shader == gDeferredPBRAlphaProgram.mRiggedVariant)
+                           || (&shader == &gDeferredAlphaProgram)
+                           || (gDeferredAlphaProgram.mRiggedVariant && &shader == gDeferredAlphaProgram.mRiggedVariant)
+                           || (&shader == &gDeferredAvatarAlphaProgram);
 
         channel = shader.enableTexture(LLShaderMgr::SCENE_MAP);
         if (channel > -1)
@@ -9920,7 +9952,7 @@ void LLPipeline::bindReflectionProbes(LLGLSLShader& shader)
                 // Trace pass: bind previous frame's lit scene for ray marching
                 gGL.getTexUnit(channel)->bind(&mSceneMap);
             }
-            else if (mSSRBuffer.isComplete())
+            else if (mSSRBuffer.isComplete() && !gCubeSnapshot)
             {
                 // Lighting pass: bind pre-computed SSR buffer with trilinear for mip sampling
                 gGL.getTexUnit(channel)->bind(&mSSRBuffer);
@@ -9932,7 +9964,8 @@ void LLPipeline::bindReflectionProbes(LLGLSLShader& shader)
             }
             else
             {
-                // Fallback: bind scene map
+                // Fallback / cube snapshot: bind scene map (probes should not
+                // see the main camera's SSR buffer)
                 gGL.getTexUnit(channel)->bind(&mSceneMap);
             }
         }
@@ -9950,10 +9983,22 @@ void LLPipeline::bindReflectionProbes(LLGLSLShader& shader)
             shader.uniform1f(LLShaderMgr::DEFERRED_SSR_MAX_THICKNESS, traceMaxThickness);
             shader.uniform1f(LLShaderMgr::DEFERRED_SSR_DEPTH_BIAS, traceDepthBias);
             shader.uniform1f(LLShaderMgr::DEFERRED_SSR_GLOSSY_SAMPLES, (GLfloat)RenderScreenSpaceReflectionGlossySamples);
-            mPoissonOffset++;
 
-            if (mPoissonOffset > 128 - RenderScreenSpaceReflectionGlossySamples)
-                mPoissonOffset = 0;
+            // Only advance the Poisson noise offset for the dedicated SSR trace
+            // programs — not for every forward alpha bind.  Otherwise the offset
+            // increments hundreds of times per frame (once per alpha draw call),
+            // with the count varying by what's visible, destabilizing the noise
+            // seed between frames and causing SSR to flicker.
+            bool isSSRTraceProgram = (&shader == &gScreenSpaceReflTraceProgram)
+                                  || (&shader == &gSSRAlphaProgram)
+                                  || (&shader == &gSkinnedSSRAlphaProgram)
+                                  || (&shader == &gSSRWaterProgram);
+            if (isSSRTraceProgram)
+            {
+                mPoissonOffset++;
+                if (mPoissonOffset > 128 - RenderScreenSpaceReflectionGlossySamples)
+                    mPoissonOffset = 0;
+            }
 
             shader.uniform1f(LLShaderMgr::DEFERRED_SSR_NOISE_SINE, (GLfloat)mPoissonOffset);
             shader.uniform1f(LLShaderMgr::DEFERRED_SSR_MAX_Z, traceMaxDepth());

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -209,10 +209,6 @@ F32 LLPipeline::CameraDoFResScale;
 F32 LLPipeline::RenderAutoHideSurfaceAreaLimit;
 bool LLPipeline::RenderScreenSpaceReflections;
 S32 LLPipeline::RenderScreenSpaceReflectionIterations;
-F32 LLPipeline::RenderScreenSpaceReflectionRayStep;
-F32 LLPipeline::RenderScreenSpaceReflectionDistanceBias;
-F32 LLPipeline::RenderScreenSpaceReflectionDepthRejectBias;
-F32 LLPipeline::RenderScreenSpaceReflectionAdaptiveStepMultiplier;
 S32 LLPipeline::RenderScreenSpaceReflectionGlossySamples;
 S32 LLPipeline::RenderBufferVisualization;
 bool LLPipeline::RenderMirrors;
@@ -287,14 +283,7 @@ static LLStaticHashedString sKern("kern");
 static LLStaticHashedString sKernScale("kern_scale");
 static LLStaticHashedString sSmaaRTMetrics("SMAA_RT_METRICS");
 
-static LLStaticHashedString sTraceIterations("iterationCount");
-static LLStaticHashedString sTraceRayStep("trayStep");
-static LLStaticHashedString sTraceDistanceBias("distanceBias");
-static LLStaticHashedString sTraceDepthRejectBias("depthRejectBias");
-static LLStaticHashedString sTraceStepMultiplier("adaptiveStepMultiplier");
 static LLStaticHashedString sSSRJitterOffset("ssrJitterOffset");
-static LLStaticHashedString sTraceSplitParamsStart("splitParamsStart");
-static LLStaticHashedString sTraceSplitParamsEnd("splitParamsEnd");
 
 //----------------------------------------
 
@@ -606,10 +595,6 @@ void LLPipeline::init()
     connectRefreshCachedSettingsSafe("RenderAutoHideSurfaceAreaLimit");
     connectRefreshCachedSettingsSafe("RenderScreenSpaceReflections");
     connectRefreshCachedSettingsSafe("RenderScreenSpaceReflectionIterations");
-    connectRefreshCachedSettingsSafe("RenderScreenSpaceReflectionRayStep");
-    connectRefreshCachedSettingsSafe("RenderScreenSpaceReflectionDistanceBias");
-    connectRefreshCachedSettingsSafe("RenderScreenSpaceReflectionDepthRejectBias");
-    connectRefreshCachedSettingsSafe("RenderScreenSpaceReflectionAdaptiveStepMultiplier");
     connectRefreshCachedSettingsSafe("RenderScreenSpaceReflectionGlossySamples");
     connectRefreshCachedSettingsSafe("RenderBufferVisualization");
     connectRefreshCachedSettingsSafe("RenderMirrors");
@@ -937,7 +922,20 @@ bool LLPipeline::allocateScreenBufferInternal(U32 resX, U32 resY)
             // At full res: no own depth, share from deferred (zero-copy).
             // At reduced res: allocate own depth, blit from deferred before alpha/water passes.
             mSSRBuffer.allocate(ssrW, ssrH, GL_RGBA16F, !fullRes, LLTexUnit::TT_TEXTURE, LLTexUnit::TMG_AUTO);
-            mSSRFilterTemp.allocate(ssrW, ssrH, GL_RGBA16F);
+
+            // Allocate per-mip temp targets for Gaussian ping-pong (one per mip level > 0)
+            U32 ssrMipLevels = mSSRBuffer.getMipLevels();
+            if (ssrMipLevels > 1 && mSSRMipTemp.empty())
+            {
+                mSSRMipTemp.resize(ssrMipLevels - 1);
+                for (U32 i = 0; i < mSSRMipTemp.size(); ++i)
+                {
+                    U32 mip = i + 1;
+                    U32 w = llmax(1U, ssrW >> mip);
+                    U32 h = llmax(1U, ssrH >> mip);
+                    mSSRMipTemp[i].allocate(w, h, GL_RGBA16F);
+                }
+            }
 
             if (fullRes)
             {
@@ -948,7 +946,7 @@ bool LLPipeline::allocateScreenBufferInternal(U32 resX, U32 resY)
         {
             mSceneMap.release();
             mSSRBuffer.release();
-            mSSRFilterTemp.release();
+            mSSRMipTemp.clear();
         }
 
         mPostPingMap.allocate(resX, resY, GL_RGBA);
@@ -1292,7 +1290,7 @@ void LLPipeline::releaseScreenBuffers()
     mHeroProbeRT.deferredLight.release();
 
     mSSRBuffer.release();
-    mSSRFilterTemp.release();
+    mSSRMipTemp.clear();
 }
 
 void LLPipeline::releaseSunShadowTarget(U32 index)
@@ -7611,81 +7609,82 @@ void LLPipeline::renderSSRWater()
 void LLPipeline::filterSSRBuffer()
 {
     if (!RenderScreenSpaceReflections || gCubeSnapshot) return;
-    if (!mSSRBuffer.isComplete() || !mSSRFilterTemp.isComplete()) return;
-    if (!gSSRFilterProgram.isComplete()) return;
+    if (!mSSRBuffer.isComplete()) return;
+    if (!gGaussianProgram.isComplete()) return;
 
-    LL_PROFILE_GPU_ZONE("SSR filter");
+    LL_PROFILE_GPU_ZONE("SSR mip chain");
 
-    LLVector3 go = RenderShadowGaussian;
-    const U32 kern_length = 4;
-    F32 x = 0.f;
-    LLVector3 gauss[32];
-    for (U32 i = 0; i < kern_length; i++)
-    {
-        gauss[i].mV[0] = llgaussian(x, go.mV[0]);
-        gauss[i].mV[1] = llgaussian(x, go.mV[1]);
-        gauss[i].mV[2] = x;
-        x += 1.f;
-    }
+    U32 mipLevels = mSSRBuffer.getMipLevels();
+    if (mipLevels <= 1) return;
+    if (mSSRMipTemp.empty()) return;
+
+    LLGLDisable blend(GL_BLEND);
+    LLGLDepthTest depth(GL_FALSE);
+
+    // Identity matrices for screen-space rendering (same as probe manager)
+    gGL.matrixMode(gGL.MM_MODELVIEW);
+    gGL.pushMatrix();
+    gGL.loadIdentity();
+
+    gGL.matrixMode(gGL.MM_PROJECTION);
+    gGL.pushMatrix();
+    gGL.loadIdentity();
+
+    gGL.flush();
+
+    static LLStaticHashedString resScale("resScale");
+    static LLStaticHashedString direction("direction");
 
     static LLCachedControl<F32> ssrFilterScale(gSavedSettings, "RenderScreenSpaceReflectionsFilterScale", 2.0f);
-    F32 blur_size = (F32)ssrFilterScale;
 
-    // --- Horizontal pass: mSSRBuffer -> mSSRFilterTemp ---
-    mSSRFilterTemp.bindTarget();
-    mSSRFilterTemp.clear(GL_COLOR_BUFFER_BIT);
+    gGaussianProgram.bind();
+    S32 diffuseChannel = gGaussianProgram.enableTexture(LLShaderMgr::DEFERRED_DIFFUSE, LLTexUnit::TT_TEXTURE);
 
-    bindDeferredShader(gSSRFilterProgram);
-
-    // Override screen_res to match SSR buffer dimensions (bindDeferredShader
-    // sets it to the full-res deferred target, but the filter operates at
-    // SSR buffer resolution).
-    gSSRFilterProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES,
-        (GLfloat)mSSRBuffer.getWidth(), (GLfloat)mSSRBuffer.getHeight());
-
-    S32 channel = gSSRFilterProgram.enableTexture(LLShaderMgr::DIFFUSE_MAP);
-    if (channel > -1)
-        gGL.getTexUnit(channel)->bind(&mSSRBuffer);
-
-    gSSRFilterProgram.uniform2f(sDelta, 1.f, 0.f);
-    gSSRFilterProgram.uniform3fv(sKern, kern_length, gauss[0].mV);
-    gSSRFilterProgram.uniform1f(sKernScale, blur_size * (kern_length / 2.f - 0.5f));
-
+    for (U32 m = 1; m < mipLevels && (m - 1) < mSSRMipTemp.size(); m++)
     {
-        LLGLDisable blend(GL_BLEND);
-        LLGLDepthTest depth(GL_FALSE);
+        LL_PROFILE_GPU_ZONE("SSR mip blur");
+
+        LLRenderTarget& temp = mSSRMipTemp[m - 1];
+        S32 srcW = llmax(1, (S32)(mSSRBuffer.getWidth() >> (m - 1)));
+        S32 srcH = llmax(1, (S32)(mSSRBuffer.getHeight() >> (m - 1)));
+
+        // Horizontal pass: read SSR mip m-1, write to temp (at mip m resolution)
+        gGaussianProgram.uniform1f(resScale, (F32)ssrFilterScale / (F32)srcW);
+        gGaussianProgram.uniform2f(direction, 1.f, 0.f);
+
+        gGL.getTexUnit(diffuseChannel)->bind(&mSSRBuffer);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, m - 1);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, m - 1);
+
+        temp.bindTarget();
+        mScreenTriangleVB->setBuffer();
+        mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+        temp.flush();
+
+        // Vertical pass: read temp, write to SSR mip m (same resolution as temp)
+        gGaussianProgram.uniform1f(resScale, (F32)ssrFilterScale / (F32)temp.getHeight());
+        gGaussianProgram.uniform2f(direction, 0.f, 1.f);
+
+        gGL.getTexUnit(diffuseChannel)->bind(&temp);
+
+        mSSRBuffer.bindColorMipLevel(m);
         mScreenTriangleVB->setBuffer();
         mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
     }
 
-    mSSRFilterTemp.flush();
-    unbindDeferredShader(gSSRFilterProgram);
+    // Restore SSR buffer state
+    gGL.getTexUnit(diffuseChannel)->bind(&mSSRBuffer);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, mipLevels - 1);
+    mSSRBuffer.resetColorMipLevel();
 
-    // --- Vertical pass: mSSRFilterTemp -> mSSRBuffer ---
-    mSSRBuffer.bindTarget();
-    mSSRBuffer.clear(GL_COLOR_BUFFER_BIT);
+    gGaussianProgram.unbind();
 
-    bindDeferredShader(gSSRFilterProgram);
-    gSSRFilterProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES,
-        (GLfloat)mSSRBuffer.getWidth(), (GLfloat)mSSRBuffer.getHeight());
+    gGL.matrixMode(gGL.MM_PROJECTION);
+    gGL.popMatrix();
 
-    channel = gSSRFilterProgram.enableTexture(LLShaderMgr::DIFFUSE_MAP);
-    if (channel > -1)
-        gGL.getTexUnit(channel)->bind(&mSSRFilterTemp);
-
-    gSSRFilterProgram.uniform2f(sDelta, 0.f, 1.f);
-    gSSRFilterProgram.uniform3fv(sKern, kern_length, gauss[0].mV);
-    gSSRFilterProgram.uniform1f(sKernScale, blur_size * (kern_length / 2.f - 0.5f));
-
-    {
-        LLGLDisable blend(GL_BLEND);
-        LLGLDepthTest depth(GL_FALSE);
-        mScreenTriangleVB->setBuffer();
-        mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
-    }
-
-    mSSRBuffer.flush();
-    unbindDeferredShader(gSSRFilterProgram);
+    gGL.matrixMode(gGL.MM_MODELVIEW);
+    gGL.popMatrix();
 }
 
 void LLPipeline::copyScreenSpaceReflections(LLRenderTarget* src, LLRenderTarget* dst)
@@ -9923,8 +9922,13 @@ void LLPipeline::bindReflectionProbes(LLGLSLShader& shader)
             }
             else if (mSSRBuffer.isComplete())
             {
-                // Lighting pass: bind pre-computed SSR buffer
+                // Lighting pass: bind pre-computed SSR buffer with trilinear for mip sampling
                 gGL.getTexUnit(channel)->bind(&mSSRBuffer);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+
+                // Pass mip scale for roughness -> mip level mapping
+                static LLStaticHashedString sSsrMipScale("ssrMipScale");
+                shader.uniform1f(sSsrMipScale, (float)(mSSRBuffer.getMipLevels() - 1));
             }
             else
             {
@@ -9936,31 +9940,22 @@ void LLPipeline::bindReflectionProbes(LLGLSLShader& shader)
         if (inSSRTracePass)
         {
             // Set all SSR trace uniforms (only needed for trace shaders)
-            static LLCachedControl<LLVector3> traceIterations(gSavedSettings, "RenderScreenSpaceReflectionIterations");
-            static LLCachedControl<LLVector3> traceSteps(gSavedSettings, "RenderScreenSpaceReflectionRayStep");
-            static LLCachedControl<LLVector3> traceDistanceBias(gSavedSettings, "RenderScreenSpaceReflectionDistanceBias");
-            static LLCachedControl<LLVector3> traceRejectBias(gSavedSettings, "RenderScreenSpaceReflectionDepthRejectBias");
-            static LLCachedControl<LLVector3> traceStepMultiplier(gSavedSettings, "RenderScreenSpaceReflectionAdaptiveStepMultiplier");
-            static LLCachedControl<LLVector3> traceSplitStart(gSavedSettings, "RenderScreenSpaceReflectionSplitStart");
-            static LLCachedControl<LLVector3> traceSplitEnd(gSavedSettings, "RenderScreenSpaceReflectionSplitEnd");
+            static LLCachedControl<S32> traceIterations(gSavedSettings, "RenderScreenSpaceReflectionIterations");
+            static LLCachedControl<F32> traceMaxThickness(gSavedSettings, "RenderScreenSpaceReflectionMaxThickness");
+            static LLCachedControl<F32> traceDepthBias(gSavedSettings, "RenderScreenSpaceReflectionDepthBias");
             static LLCachedControl<F32> traceMaxDepth(gSavedSettings, "RenderScreenSpaceReflectionMaxDepth");
             static LLCachedControl<F32> traceMaxRoughness(gSavedSettings, "RenderScreenSpaceReflectionMaxRoughness");
 
-            shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_ITR_COUNT, 1, traceIterations().mV);
-            shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_DIST_BIAS, 1, traceDistanceBias().mV);
-            shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_RAY_STEP, 1, traceSteps().mV);
+            shader.uniform1i(LLShaderMgr::DEFERRED_SSR_ITR_COUNT, traceIterations);
+            shader.uniform1f(LLShaderMgr::DEFERRED_SSR_MAX_THICKNESS, traceMaxThickness);
+            shader.uniform1f(LLShaderMgr::DEFERRED_SSR_DEPTH_BIAS, traceDepthBias);
             shader.uniform1f(LLShaderMgr::DEFERRED_SSR_GLOSSY_SAMPLES, (GLfloat)RenderScreenSpaceReflectionGlossySamples);
-            shader.uniform3fv(sTraceDepthRejectBias, 1, traceRejectBias().mV);
             mPoissonOffset++;
 
             if (mPoissonOffset > 128 - RenderScreenSpaceReflectionGlossySamples)
                 mPoissonOffset = 0;
 
             shader.uniform1f(LLShaderMgr::DEFERRED_SSR_NOISE_SINE, (GLfloat)mPoissonOffset);
-            shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_ADAPTIVE_STEP_MULT, 1, traceStepMultiplier().mV);
-            shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_SPLIT_START, 1, traceSplitStart().mV);
-            shader.uniform3fv(LLShaderMgr::DEFERRED_SSR_SPLIT_END, 1, traceSplitEnd().mV);
-
             shader.uniform1f(LLShaderMgr::DEFERRED_SSR_MAX_Z, traceMaxDepth());
             shader.uniform1f(LLShaderMgr::DEFERRED_SSR_MAX_ROUGHNESS, traceMaxRoughness());
 

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -292,6 +292,7 @@ static LLStaticHashedString sTraceRayStep("trayStep");
 static LLStaticHashedString sTraceDistanceBias("distanceBias");
 static LLStaticHashedString sTraceDepthRejectBias("depthRejectBias");
 static LLStaticHashedString sTraceStepMultiplier("adaptiveStepMultiplier");
+static LLStaticHashedString sSSRJitterOffset("ssrJitterOffset");
 static LLStaticHashedString sTraceSplitParamsStart("splitParamsStart");
 static LLStaticHashedString sTraceSplitParamsEnd("splitParamsEnd");
 
@@ -7400,12 +7401,53 @@ void LLPipeline::copyScreenSpaceReflections(LLRenderTarget* src, LLRenderTarget*
 
         gGL.getTexUnit(diff_map)->bind(src);
         gGL.getTexUnit(depth_map)->bind(&depth_src, true);
+        gGL.getTexUnit(depth_map)->setTextureFilteringOption(LLTexUnit::TFO_POINT);
 
         mScreenTriangleVB->setBuffer();
         mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
 
         dst->flush();
     }
+}
+
+void LLPipeline::buildHiZBuffer()
+{
+    if (!RenderScreenSpaceReflections || gCubeSnapshot) return;
+
+    LL_PROFILE_GPU_ZONE("build Hi-Z");
+
+    S32 mipLevels = mSceneMap.getMipLevels();
+    if (mipLevels <= 1) return;
+
+    LLGLDepthTest depth(GL_TRUE, GL_TRUE, GL_ALWAYS);
+
+    gHiZReduceProgram.bind();
+
+    static LLStaticHashedString sHiZSrcLevel("srcLevel");
+
+    // Bind mSceneMap's own depth as the read source
+    gHiZReduceProgram.bindTexture(LLShaderMgr::DEFERRED_DEPTH, &mSceneMap, true, LLTexUnit::TFO_POINT);
+
+    for (S32 level = 1; level < mipLevels; level++)
+    {
+        // Restrict readable mip range to [0, level-1] to avoid feedback
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, level - 1);
+
+        gHiZReduceProgram.uniform1i(sHiZSrcLevel, level - 1);
+
+        mSceneMap.bindDepthMipLevel(level);
+
+        mScreenTriangleVB->setBuffer();
+        mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+    }
+
+    // Restore full mip range and mip 0 binding
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, mipLevels - 1);
+    mSceneMap.resetDepthMipLevel();
+
+    gHiZReduceProgram.unbind();
 }
 
 void LLPipeline::generateGlow(LLRenderTarget* src)
@@ -9584,11 +9626,39 @@ void LLPipeline::bindReflectionProbes(LLGLSLShader& shader)
         shader.uniform1f(LLShaderMgr::DEFERRED_SSR_MAX_Z, traceMaxDepth());
         shader.uniform1f(LLShaderMgr::DEFERRED_SSR_MAX_ROUGHNESS, traceMaxRoughness());
 
+        // Compute jitter compensation for SMAA T2x.
+        // mSceneMap was rendered with the previous frame's jittered projection.
+        // SSR projects positions using the current frame's projection.
+        // Correct the UV offset so mSceneMap lookups hit the right texels.
+        float jitterOffsetX = 0.f;
+        float jitterOffsetY = 0.f;
+        if (sT2xJitterEnabled)
+        {
+            static const float jitters[2][2] = {
+                { 0.25f, -0.25f },
+                {-0.25f,  0.25f },
+            };
+            U32 curIdx  = mSMAAFrameIndex & 1;
+            U32 prevIdx = curIdx ^ 1;
+            float width  = (float)gViewerWindow->getWorldViewWidthRaw();
+            float height = (float)gViewerWindow->getWorldViewHeightRaw();
+            // Jitter is applied to proj[2][0/1] as j * 2 / dim.
+            // NDC offset from jitter = -j_ndc (perspective divide flips sign).
+            // UV = NDC * 0.5 + 0.5, so UV delta = NDC delta * 0.5.
+            // Correction = (cur_j - prev_j) / dim  (the 2 and 0.5 cancel).
+            jitterOffsetX = (jitters[curIdx][0] - jitters[prevIdx][0]) / width;
+            jitterOffsetY = (jitters[curIdx][1] - jitters[prevIdx][1]) / height;
+        }
+        shader.uniform2f(sSSRJitterOffset, jitterOffsetX, jitterOffsetY);
+
         channel = shader.enableTexture(LLShaderMgr::SCENE_DEPTH);
         if (channel > -1)
         {
             gGL.getTexUnit(channel)->bind(&mSceneMap, true);
         }
+
+        static LLStaticHashedString sHiZMipCount("hizMipCount");
+        shader.uniform1i(sHiZMipCount, (GLint)mSceneMap.getMipLevels());
     }
 }
 

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -737,7 +737,7 @@ public:
 
     // Pre-computed SSR: RGB=reflection, A=fade
     LLRenderTarget          mSSRBuffer;
-    LLRenderTarget          mSSRFilterTemp;  // Ping-pong target for SSR filter
+    std::vector<LLRenderTarget> mSSRMipTemp;  // Per-mip temp targets for SSR Gaussian ping-pong
 
     // exposure map for getting average color in scene
     LLRenderTarget          mLuminanceMap;
@@ -1097,10 +1097,6 @@ public:
     static F32 RenderAutoHideSurfaceAreaLimit;
     static bool RenderScreenSpaceReflections;
     static S32 RenderScreenSpaceReflectionIterations;
-    static F32 RenderScreenSpaceReflectionRayStep;
-    static F32 RenderScreenSpaceReflectionDistanceBias;
-    static F32 RenderScreenSpaceReflectionDepthRejectBias;
-    static F32 RenderScreenSpaceReflectionAdaptiveStepMultiplier;
     static S32 RenderScreenSpaceReflectionGlossySamples;
     static S32 RenderBufferVisualization;
     static bool RenderMirrors;

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -153,6 +153,7 @@ public:
     void bindScreenToTexture();
     void renderFinalize();
     void copyScreenSpaceReflections(LLRenderTarget* src, LLRenderTarget* dst);
+    void buildHiZBuffer();
     void generateLuminance(LLRenderTarget* src, LLRenderTarget* dst);
     void generateExposure(LLRenderTarget* src, LLRenderTarget* dst, bool use_history = true);
     void tonemap(LLRenderTarget* src, LLRenderTarget* dst, bool gamma_correct);

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -154,6 +154,10 @@ public:
     void renderFinalize();
     void copyScreenSpaceReflections(LLRenderTarget* src, LLRenderTarget* dst);
     void buildHiZBuffer();
+    void renderSSRTrace();
+    void renderSSRAlpha();
+    void renderSSRWater();
+    void filterSSRBuffer();
     void generateLuminance(LLRenderTarget* src, LLRenderTarget* dst);
     void generateExposure(LLRenderTarget* src, LLRenderTarget* dst, bool use_history = true);
     void tonemap(LLRenderTarget* src, LLRenderTarget* dst, bool gamma_correct);
@@ -730,6 +734,10 @@ public:
     // copy of the color/depth buffer just before gamma correction
     // for use by SSR
     LLRenderTarget          mSceneMap;
+
+    // Pre-computed SSR: RGB=reflection, A=fade
+    LLRenderTarget          mSSRBuffer;
+    LLRenderTarget          mSSRFilterTemp;  // Ping-pong target for SSR filter
 
     // exposure map for getting average color in scene
     LLRenderTarget          mLuminanceMap;


### PR DESCRIPTION
This will add Hi-Z tracing and separate SSR into its own pass so we can filter it.  Filtering greatly improves performance instead of niavely casting lots of rays for glossy reflections.  Also adds some reasonably sane settings to the feature table including resolution scaling.  This does, for now, remove SSR from semi-transparent objects (water excluded)