### PR TITLE
Restore alpha object SSR.

### DIFF
--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -9492,7 +9492,9 @@ void LLPipeline::renderDeferredLighting()
                           LLPipeline::RENDER_TYPE_WATEREXCLUSION,
                           END_RENDER_TYPES);
 
+        mInForwardAlphaPass = true;
         renderGeomPostDeferred(*LLViewerCamera::getInstance());
+        mInForwardAlphaPass = false;
         popRenderTypeMask();
     }
 
@@ -9941,11 +9943,7 @@ void LLPipeline::bindReflectionProbes(LLGLSLShader& shader)
                            || (&shader == &gSSRAlphaProgram)
                            || (&shader == &gSkinnedSSRAlphaProgram)
                            || (&shader == &gSSRWaterProgram)
-                           || (&shader == &gDeferredPBRAlphaProgram)
-                           || (gDeferredPBRAlphaProgram.mRiggedVariant && &shader == gDeferredPBRAlphaProgram.mRiggedVariant)
-                           || (&shader == &gDeferredAlphaProgram)
-                           || (gDeferredAlphaProgram.mRiggedVariant && &shader == gDeferredAlphaProgram.mRiggedVariant)
-                           || (&shader == &gDeferredAvatarAlphaProgram);
+                           || mInForwardAlphaPass;
 
         channel = shader.enableTexture(LLShaderMgr::SCENE_MAP);
         if (channel > -1)

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -739,6 +739,8 @@ public:
     LLRenderTarget          mSSRBuffer;
     std::vector<LLRenderTarget> mSSRMipTemp;  // Per-mip temp targets for SSR Gaussian ping-pong
 
+    bool mInForwardAlphaPass = false;
+
     // exposure map for getting average color in scene
     LLRenderTarget          mLuminanceMap;
     LLRenderTarget          mExposureMap;


### PR DESCRIPTION
Re-adds transparent SSR with the caveat that they do these traces at full resolution.