### PR TITLE
#5516 Increase default width for Inventory floater

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_my_inventory.xml
+++ b/indra/newview/skins/default/xui/en/floater_my_inventory.xml
@@ -12,7 +12,7 @@
  save_visibility="true"
  reuse_instance="true"
  title="INVENTORY"
- width="418" >
+ width="424" >
    <panel
     class="sidepanel_inventory"
     name="main_panel"


### PR DESCRIPTION
The 4 Inventory tabs should fit so default, so let's adjust the floater width.