### PR TITLE
Fix up velopack downloading updates.  Handle updates internally then hand them off to velopack.

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -1673,6 +1673,7 @@ bool LLAppViewer::cleanup()
         LL_INFOS("AppInit") << "Applying pending Velopack update on shutdown..." << LL_ENDL;
         velopack_apply_pending_update(true);  // restart=true
     }
+    velopack_cleanup();
 #endif
 
     //ditch LLVOAvatarSelf instance

--- a/indra/newview/llvelopack.cpp
+++ b/indra/newview/llvelopack.cpp
@@ -121,6 +121,7 @@ static std::string download_url_raw(const std::string& url)
     auto httpAdapter = std::make_shared<LLCoreHttpUtil::HttpCoroutineAdapter>("VelopackSource", httpPolicy);
     auto httpRequest = std::make_shared<LLCore::HttpRequest>();
     auto httpOpts = std::make_shared<LLCore::HttpOptions>();
+    httpOpts->setFollowRedirects(true);
 
     LLSD result = httpAdapter->getRawAndSuspend(httpRequest, url, httpOpts);
     LLSD httpResults = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS];
@@ -141,6 +142,8 @@ static bool download_url_to_file(const std::string& url, const std::string& loca
     auto httpAdapter = std::make_shared<LLCoreHttpUtil::HttpCoroutineAdapter>("VelopackDownload", httpPolicy);
     auto httpRequest = std::make_shared<LLCore::HttpRequest>();
     auto httpOpts = std::make_shared<LLCore::HttpOptions>();
+    httpOpts->setFollowRedirects(true);
+    httpOpts->setTransferTimeout(1200);
 
     LLSD result = httpAdapter->getRawAndSuspend(httpRequest, url, httpOpts);
     LLSD httpResults = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS];
@@ -169,7 +172,10 @@ static bool download_url_to_file(const std::string& url, const std::string& loca
 
 static char* custom_get_release_feed(void* user_data, const char* releases_name)
 {
-    std::string url = sUpdateUrl + "/" + releases_name;
+    std::string base = sUpdateUrl;
+    if (!base.empty() && base.back() == '/')
+        base.pop_back();
+    std::string url = base + "/" + releases_name;
     LL_INFOS("Velopack") << "Fetching release feed: " << url << LL_ENDL;
 
     std::string json_str = download_url_raw(url);
@@ -206,35 +212,43 @@ static void custom_free_release_feed(void* user_data, char* feed)
     free(feed);
 }
 
+static std::string sPreDownloadedAssetPath;
+
 static bool custom_download_asset(void* user_data,
                                    const vpkc_asset_t* asset,
                                    const char* local_path,
                                    size_t progress_callback_id)
 {
+    // The asset has already been downloaded at the coroutine level (before vpkc_download_updates).
+    // This callback just copies the pre-downloaded file to where Velopack expects it.
+    // We cannot use getRawAndSuspend here — coroutine context is lost through the Rust FFI boundary.
+    if (sPreDownloadedAssetPath.empty())
+    {
+        LL_WARNS("Velopack") << "No pre-downloaded asset available" << LL_ENDL;
+        return false;
+    }
+
     std::string filename = asset->FileName ? asset->FileName : "";
-    std::string url;
-
-    auto it = sAssetUrlMap.find(filename);
-    if (it != sAssetUrlMap.end())
-    {
-        url = it->second;
-    }
-    else
-    {
-        url = sUpdateUrl + "/" + filename;
-    }
-
-    LL_INFOS("Velopack") << "Downloading asset: " << filename << " from " << url << LL_ENDL;
+    LL_INFOS("Velopack") << "Download asset callback: filename=" << filename
+        << " local_path=" << local_path
+        << " size=" << asset->Size << LL_ENDL;
     vpkc_source_report_progress(progress_callback_id, 0);
 
-    bool success = download_url_to_file(url, local_path);
-
-    if (success)
+    std::ifstream src(sPreDownloadedAssetPath, std::ios::binary);
+    llofstream dst(local_path, std::ios::binary | std::ios::trunc);
+    if (!src.is_open() || !dst.is_open())
     {
-        vpkc_source_report_progress(progress_callback_id, 100);
-        LL_INFOS("Velopack") << "Asset download complete: " << filename << LL_ENDL;
+        LL_WARNS("Velopack") << "Failed to open files for copy" << LL_ENDL;
+        return false;
     }
-    return success;
+
+    dst << src.rdbuf();
+    dst.close();
+    src.close();
+
+    vpkc_source_report_progress(progress_callback_id, 100);
+    LL_INFOS("Velopack") << "Asset copy complete" << LL_ENDL;
+    return true;
 }
 
 //
@@ -621,6 +635,7 @@ static void on_vpk_log(void* p_user_data,
 bool velopack_initialize()
 {
     vpkc_set_logger(on_log_message, nullptr);
+    vpkc_app_set_auto_apply_on_startup(false);
 
 #if LL_WINDOWS || LL_DARWIN
     vpkc_app_set_hook_after_install(on_after_install);
@@ -628,6 +643,25 @@ bool velopack_initialize()
 #endif
 
     vpkc_app_run(nullptr);
+
+    // Check if a previously downloaded update is ready to apply.
+    // This runs early in startup (WINMAIN) before any heavy initialization.
+    vpkc_update_options_t options = {};
+    options.AllowVersionDowngrade = false;
+    options.ExplicitChannel = nullptr;
+
+    vpkc_update_manager_t* mgr = nullptr;
+    if (vpkc_new_update_manager(sUpdateUrl.empty() ? "" : sUpdateUrl.c_str(), &options, nullptr, &mgr))
+    {
+        vpkc_asset_t* pending = nullptr;
+        if (vpkc_update_pending_restart(mgr, &pending) && pending)
+        {
+            LL_INFOS("Velopack") << "Pending update found, applying now..." << LL_ENDL;
+            vpkc_wait_exit_then_apply_updates(mgr, pending, false, true, nullptr, 0);
+            // If we get here, the update will be applied after we exit
+        }
+        vpkc_free_update_manager(mgr);
+    }
     return true;
 }
 
@@ -671,6 +705,38 @@ void velopack_check_for_updates()
         vpkc_set_logger(on_vpk_log, nullptr);
         LL_CONT << LL_ENDL;
         LL_INFOS("Velopack") << "Update available, downloading..." << LL_ENDL;
+
+        // Pre-download the nupkg at the coroutine level where getRawAndSuspend works.
+        // The download callback inside the Rust FFI cannot use coroutine HTTP.
+        std::string asset_filename = update_info->TargetFullRelease->FileName
+            ? update_info->TargetFullRelease->FileName : "";
+        std::string asset_url;
+        auto url_it = sAssetUrlMap.find(asset_filename);
+        if (url_it != sAssetUrlMap.end())
+        {
+            asset_url = url_it->second;
+        }
+        else
+        {
+            std::string base = sUpdateUrl;
+            if (!base.empty() && base.back() == '/')
+                base.pop_back();
+            asset_url = base + "/" + asset_filename;
+        }
+
+        sPreDownloadedAssetPath = gDirUtilp->getExpandedFilename(LL_PATH_TEMP, asset_filename);
+        LL_INFOS("Velopack") << "Pre-downloading " << asset_url
+            << " to " << sPreDownloadedAssetPath << LL_ENDL;
+
+        if (!download_url_to_file(asset_url, sPreDownloadedAssetPath))
+        {
+            LL_WARNS("Velopack") << "Failed to pre-download update asset" << LL_ENDL;
+            sPreDownloadedAssetPath.clear();
+            vpkc_free_update_info(update_info);
+            return;
+        }
+
+        LL_INFOS("Velopack") << "Pre-download complete, handing to Velopack" << LL_ENDL;
         if (vpkc_download_updates(sUpdateManager, update_info, on_progress, nullptr))
         {
             if (sPendingUpdate)
@@ -729,6 +795,26 @@ void velopack_apply_pending_update(bool restart)
                                        false,
                                        restart,
                                        nullptr, 0);
+}
+
+void velopack_cleanup()
+{
+    if (sUpdateManager)
+    {
+        vpkc_free_update_manager(sUpdateManager);
+        sUpdateManager = nullptr;
+    }
+    if (sUpdateSource)
+    {
+        vpkc_free_source(sUpdateSource);
+        sUpdateSource = nullptr;
+    }
+    if (sPendingUpdate)
+    {
+        vpkc_free_update_info(sPendingUpdate);
+        sPendingUpdate = nullptr;
+    }
+    sAssetUrlMap.clear();
 }
 
 void velopack_set_update_url(const std::string& url)

--- a/indra/newview/llvelopack.cpp
+++ b/indra/newview/llvelopack.cpp
@@ -29,6 +29,11 @@
 #include "llviewerprecompiledheaders.h"
 #include "llvelopack.h"
 #include "llstring.h"
+#include "llcorehttputil.h"
+
+#include <boost/json.hpp>
+#include <fstream>
+#include <unordered_map>
 
 #include "Velopack.h"
 
@@ -50,6 +55,187 @@ static std::string sUpdateUrl;
 static std::function<void(int)> sProgressCallback;
 static vpkc_update_manager_t* sUpdateManager = nullptr;
 static vpkc_update_info_t* sPendingUpdate = nullptr;
+static vpkc_update_source_t* sUpdateSource = nullptr;
+static std::unordered_map<std::string, std::string> sAssetUrlMap; // basename -> original absolute URL
+
+//
+// Custom update source helpers
+//
+
+static std::string extract_basename(const std::string& url)
+{
+    // Strip query params / fragment
+    std::string path = url;
+    auto qpos = path.find('?');
+    if (qpos != std::string::npos) path = path.substr(0, qpos);
+    auto fpos = path.find('#');
+    if (fpos != std::string::npos) path = path.substr(0, fpos);
+
+    auto spos = path.rfind('/');
+    if (spos != std::string::npos && spos + 1 < path.size())
+        return path.substr(spos + 1);
+    return path;
+}
+
+static void rewrite_asset_urls(boost::json::value& jv)
+{
+    if (jv.is_object())
+    {
+        auto& obj = jv.as_object();
+        auto it = obj.find("FileName");
+        if (it != obj.end() && it->value().is_string())
+        {
+            std::string filename(it->value().as_string());
+            if (filename.find("://") != std::string::npos)
+            {
+                std::string basename = extract_basename(filename);
+                sAssetUrlMap[basename] = filename;
+                it->value() = basename;
+                LL_DEBUGS("Velopack") << "Rewrote FileName: " << basename << LL_ENDL;
+            }
+        }
+        for (auto& kv : obj)
+        {
+            rewrite_asset_urls(kv.value());
+        }
+    }
+    else if (jv.is_array())
+    {
+        for (auto& elem : jv.as_array())
+        {
+            rewrite_asset_urls(elem);
+        }
+    }
+}
+
+static std::string rewrite_release_feed(const std::string& json_str)
+{
+    boost::json::value jv = boost::json::parse(json_str);
+    rewrite_asset_urls(jv);
+    return boost::json::serialize(jv);
+}
+
+static std::string download_url_raw(const std::string& url)
+{
+    LLCore::HttpRequest::policy_t httpPolicy(LLCore::HttpRequest::DEFAULT_POLICY_ID);
+    auto httpAdapter = std::make_shared<LLCoreHttpUtil::HttpCoroutineAdapter>("VelopackSource", httpPolicy);
+    auto httpRequest = std::make_shared<LLCore::HttpRequest>();
+    auto httpOpts = std::make_shared<LLCore::HttpOptions>();
+
+    LLSD result = httpAdapter->getRawAndSuspend(httpRequest, url, httpOpts);
+    LLSD httpResults = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS];
+    LLCore::HttpStatus status = LLCoreHttpUtil::HttpCoroutineAdapter::getStatusFromLLSD(httpResults);
+    if (!status)
+    {
+        LL_WARNS("Velopack") << "HTTP request failed for " << url << ": " << status.toString() << LL_ENDL;
+        return {};
+    }
+
+    const LLSD::Binary& rawBody = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS_RAW].asBinary();
+    return std::string(rawBody.begin(), rawBody.end());
+}
+
+static bool download_url_to_file(const std::string& url, const std::string& local_path)
+{
+    LLCore::HttpRequest::policy_t httpPolicy(LLCore::HttpRequest::DEFAULT_POLICY_ID);
+    auto httpAdapter = std::make_shared<LLCoreHttpUtil::HttpCoroutineAdapter>("VelopackDownload", httpPolicy);
+    auto httpRequest = std::make_shared<LLCore::HttpRequest>();
+    auto httpOpts = std::make_shared<LLCore::HttpOptions>();
+
+    LLSD result = httpAdapter->getRawAndSuspend(httpRequest, url, httpOpts);
+    LLSD httpResults = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS];
+    LLCore::HttpStatus status = LLCoreHttpUtil::HttpCoroutineAdapter::getStatusFromLLSD(httpResults);
+    if (!status)
+    {
+        LL_WARNS("Velopack") << "Download failed for " << url << ": " << status.toString() << LL_ENDL;
+        return false;
+    }
+
+    const LLSD::Binary& rawBody = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS_RAW].asBinary();
+    llofstream outFile(local_path, std::ios::binary | std::ios::trunc);
+    if (!outFile.is_open())
+    {
+        LL_WARNS("Velopack") << "Failed to open file for writing: " << local_path << LL_ENDL;
+        return false;
+    }
+    outFile.write(reinterpret_cast<const char*>(rawBody.data()), rawBody.size());
+    outFile.close();
+    return true;
+}
+
+//
+// Custom source callbacks
+//
+
+static char* custom_get_release_feed(void* user_data, const char* releases_name)
+{
+    std::string url = sUpdateUrl + "/" + releases_name;
+    LL_INFOS("Velopack") << "Fetching release feed: " << url << LL_ENDL;
+
+    std::string json_str = download_url_raw(url);
+    if (json_str.empty())
+    {
+        return nullptr;
+    }
+
+    try
+    {
+        std::string rewritten = rewrite_release_feed(json_str);
+        char* result = static_cast<char*>(malloc(rewritten.size() + 1));
+        if (result)
+        {
+            memcpy(result, rewritten.c_str(), rewritten.size() + 1);
+        }
+        return result;
+    }
+    catch (const std::exception& e)
+    {
+        LL_WARNS("Velopack") << "Failed to parse/rewrite release feed: " << e.what() << LL_ENDL;
+        // Return original unmodified feed as fallback
+        char* result = static_cast<char*>(malloc(json_str.size() + 1));
+        if (result)
+        {
+            memcpy(result, json_str.c_str(), json_str.size() + 1);
+        }
+        return result;
+    }
+}
+
+static void custom_free_release_feed(void* user_data, char* feed)
+{
+    free(feed);
+}
+
+static bool custom_download_asset(void* user_data,
+                                   const vpkc_asset_t* asset,
+                                   const char* local_path,
+                                   size_t progress_callback_id)
+{
+    std::string filename = asset->FileName ? asset->FileName : "";
+    std::string url;
+
+    auto it = sAssetUrlMap.find(filename);
+    if (it != sAssetUrlMap.end())
+    {
+        url = it->second;
+    }
+    else
+    {
+        url = sUpdateUrl + "/" + filename;
+    }
+
+    LL_INFOS("Velopack") << "Downloading asset: " << filename << " from " << url << LL_ENDL;
+    vpkc_source_report_progress(progress_callback_id, 0);
+
+    bool success = download_url_to_file(url, local_path);
+
+    if (success)
+    {
+        vpkc_source_report_progress(progress_callback_id, 100);
+        LL_INFOS("Velopack") << "Asset download complete: " << filename << LL_ENDL;
+    }
+    return success;
+}
 
 //
 // Platform-specific helpers and hooks
@@ -459,7 +645,16 @@ void velopack_check_for_updates()
         options.AllowVersionDowngrade = false;
         options.ExplicitChannel = nullptr;
 
-        if (!vpkc_new_update_manager(sUpdateUrl.c_str(), &options, nullptr, &sUpdateManager))
+        if (!sUpdateSource)
+        {
+            sUpdateSource = vpkc_new_source_custom_callback(
+                custom_get_release_feed,
+                custom_free_release_feed,
+                custom_download_asset,
+                nullptr);
+        }
+
+        if (!vpkc_new_update_manager_with_source(sUpdateSource, &options, nullptr, &sUpdateManager))
         {
             LL_WARNS("Velopack") << "Failed to create update manager" << LL_ENDL;
             return;

--- a/indra/newview/llvelopack.h
+++ b/indra/newview/llvelopack.h
@@ -39,6 +39,7 @@ bool velopack_is_update_pending();
 void velopack_apply_pending_update(bool restart = true);
 void velopack_set_update_url(const std::string& url);
 void velopack_set_progress_callback(std::function<void(int)> callback);
+void velopack_cleanup();
 
 #if LL_WINDOWS
 bool get_nsis_uninstaller_path(wchar_t* path_buffer, DWORD bufSize, S32 cur_major_ver, S32 cur_minor_ver, S32 cur_patch_ver, U64 cur_build_ver);

--- a/indra/newview/llvvmquery.cpp
+++ b/indra/newview/llvvmquery.cpp
@@ -82,7 +82,7 @@ namespace
         }
 
         // Gather parameters for VVM query
-        std::string channel = LLVersionInfo::instance().getChannel();
+        std::string channel = "QA Target for Velopack";
         std::string version = LLVersionInfo::instance().getVersion();
         std::string platform = get_platform_string();
         std::string platform_version = get_platform_version();
@@ -134,7 +134,7 @@ namespace
             {
                 LL_INFOS("VVM") << "Velopack update URL: " << velopack_url << LL_ENDL;
                 velopack_set_update_url(velopack_url);
-                velopack_check_for_updates();
+                LLCoros::instance().launch("VelopackUpdateCheck", &velopack_check_for_updates);
             }
             else
 #endif

--- a/indra/newview/llvvmquery.cpp
+++ b/indra/newview/llvvmquery.cpp
@@ -82,7 +82,8 @@ namespace
         }
 
         // Gather parameters for VVM query
-        std::string channel = "QA Target for Velopack";
+        std::string channel = LLVersionInfo::instance().getChannel();
+        // std::string channel = "QA Target for Velopack";
         std::string version = LLVersionInfo::instance().getVersion();
         std::string platform = get_platform_string();
         std::string platform_version = get_platform_version();

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -801,6 +801,10 @@ class Windows_x86_64_Manifest(ViewerManifest):
             '--packDir', pack_dir,
             '--mainExe', main_exe,
             '--packTitle', pack_title,
+            # Exclude build artifacts that end up in packDir but aren't part of the viewer.
+            # Default --exclude already covers *.pdb; this adds .map, .bat, .exp, .lib,
+            # .tar.xz (symbol tarballs), and the NSIS/Velopack setup exes.
+            '--exclude', r'.*\.pdb|.*\.map|.*\.bat|.*\.exp|.*\.lib|.*\.tar\.xz|secondlife-bin\..*|.*_Setup\.exe|.*-Setup\.exe',
         ]
 
         # Add icon if exists

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -804,7 +804,7 @@ class Windows_x86_64_Manifest(ViewerManifest):
             # Exclude build artifacts that end up in packDir but aren't part of the viewer.
             # Default --exclude already covers *.pdb; this adds .map, .bat, .exp, .lib,
             # .tar.xz (symbol tarballs), and the NSIS/Velopack setup exes.
-            '--exclude', r'.*\.pdb|.*\.map|.*\.bat|.*\.exp|.*\.lib|.*\.tar\.xz|secondlife-bin\..*|.*_Setup\.exe|.*-Setup\.exe',
+            '--exclude', r'.*\.pdb|.*\.map|.*\.bat|.*\.exp|.*\.lib|.*\.nsi|.*\.tar\.xz|secondlife-bin\..*|.*_Setup\.exe|.*-Setup\.exe',
         ]
 
         # Add icon if exists


### PR DESCRIPTION
This:
- Moves the update download to the viewer
- Copies the update to the packages directory for velopack to discovery
- Gets things updating once the viewer exits

Probably needs a couple of behavioral tweaks.