### PR TITLE
Restore optional updates, only restart the viewer if it were optional.

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -1671,7 +1671,7 @@ bool LLAppViewer::cleanup()
     if (velopack_is_update_pending())
     {
         LL_INFOS("AppInit") << "Applying pending Velopack update on shutdown..." << LL_ENDL;
-        velopack_apply_pending_update(false);  // don't restart after update
+        velopack_apply_pending_update(velopack_should_restart_after_update());
     }
     velopack_cleanup();
 #endif

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -1671,7 +1671,7 @@ bool LLAppViewer::cleanup()
     if (velopack_is_update_pending())
     {
         LL_INFOS("AppInit") << "Applying pending Velopack update on shutdown..." << LL_ENDL;
-        velopack_apply_pending_update(true);  // restart=true
+        velopack_apply_pending_update(false);  // don't restart after update
     }
     velopack_cleanup();
 #endif

--- a/indra/newview/llpanellogin.cpp
+++ b/indra/newview/llpanellogin.cpp
@@ -37,6 +37,9 @@
 
 #include "llappviewer.h"
 #include "llbutton.h"
+#if LL_VELOPACK
+#include "llvelopack.h"
+#endif
 #include "llcheckboxctrl.h"
 #include "llcommandhandler.h"       // for secondlife:///app/login/
 #include "llcombobox.h"
@@ -936,6 +939,19 @@ void LLPanelLogin::handleMediaEvent(LLPluginClassMedia* /*self*/, EMediaEvent ev
 // static
 void LLPanelLogin::onClickConnect(bool commit_fields)
 {
+#if LL_VELOPACK
+    // In theory, you should never be able to get here.
+    // If there's a required update, try as you might you're not supposed to actually close the downloading update dialog.
+    // But just in case...
+    if (velopack_is_required_update_in_progress())
+    {
+        LLSD args;
+        args["VERSION"] = velopack_get_required_update_version();
+        LLNotificationsUtil::add("DownloadingUpdate", args);
+        return;
+    }
+#endif
+
     if (sInstance && sInstance->mCallback)
     {
         if (commit_fields)

--- a/indra/newview/llvelopack.cpp
+++ b/indra/newview/llvelopack.cpp
@@ -35,6 +35,7 @@
 #include <fstream>
 #include <unordered_map>
 #include "llnotificationsutil.h"
+#include "llviewercontrol.h"
 #include "llcoros.h"
 
 #include "Velopack.h"
@@ -762,6 +763,20 @@ static void velopack_download_update()
     }
 }
 
+static void on_required_update_response(const LLSD& notification, const LLSD& response)
+{
+    LL_INFOS("Velopack") << "Required update acknowledged, starting download" << LL_ENDL;
+    LLCoros::instance().launch("VelopackRequiredUpdate", []()
+    {
+        velopack_download_update();
+        if (velopack_is_update_pending())
+        {
+            LL_INFOS("Velopack") << "Required update downloaded, applying and restarting" << LL_ENDL;
+            velopack_apply_pending_update(true);
+        }
+    });
+}
+
 static void on_optional_update_response(const LLSD& notification, const LLSD& response)
 {
     S32 option = LLNotificationsUtil::getSelectedOption(notification, response);
@@ -788,16 +803,39 @@ void velopack_check_for_updates(bool required, const std::string& version, const
 {
     if (required)
     {
-        velopack_download_update();
-    }
-    else
-    {
-        LL_INFOS("Velopack") << "Optional update available (version " << version << "), prompting user" << LL_ENDL;
+        LL_INFOS("Velopack") << "Required update to version " << version << ", prompting user" << LL_ENDL;
         LLSD args;
         args["VERSION"] = version;
         args["URL"] = relnotes_url;
-        LLNotificationsUtil::add("PromptOptionalUpdate", args, LLSD(), on_optional_update_response);
+        LLNotificationsUtil::add("PauseForUpdate", args, LLSD(), on_required_update_response);
+        return;
     }
+
+    // Optional update — check user preference
+    U32 updater_setting = gSavedSettings.getU32("UpdaterServiceSetting");
+    if (updater_setting == 0)
+    {
+        // "Install only mandatory updates" — skip optional
+        LL_INFOS("Velopack") << "Optional update to version " << version
+                             << " skipped (UpdaterServiceSetting=0)" << LL_ENDL;
+        return;
+    }
+
+    if (updater_setting == 3)
+    {
+        // "Install each update automatically" — download silently, apply on quit
+        LL_INFOS("Velopack") << "Optional update to version " << version
+                             << ", downloading automatically (UpdaterServiceSetting=3)" << LL_ENDL;
+        velopack_download_update();
+        return;
+    }
+
+    // Default / value 1: "Ask me when an optional update is ready to install"
+    LL_INFOS("Velopack") << "Optional update available (version " << version << "), prompting user" << LL_ENDL;
+    LLSD args;
+    args["VERSION"] = version;
+    args["URL"] = relnotes_url;
+    LLNotificationsUtil::add("PromptOptionalUpdate", args, LLSD(), on_optional_update_response);
 }
 
 std::string velopack_get_current_version()

--- a/indra/newview/llvelopack.cpp
+++ b/indra/newview/llvelopack.cpp
@@ -768,7 +768,15 @@ static void on_optional_update_response(const LLSD& notification, const LLSD& re
     if (option == 0) // "Install"
     {
         LL_INFOS("Velopack") << "User accepted optional update, starting download" << LL_ENDL;
-        LLCoros::instance().launch("VelopackOptionalUpdate", [](){ velopack_download_update(); });
+        LLCoros::instance().launch("VelopackOptionalUpdate", []()
+        {
+            velopack_download_update();
+            if (velopack_is_update_pending())
+            {
+                LL_INFOS("Velopack") << "Optional update downloaded, applying and restarting" << LL_ENDL;
+                velopack_apply_pending_update(true);
+            }
+        });
     }
     else
     {

--- a/indra/newview/llvelopack.cpp
+++ b/indra/newview/llvelopack.cpp
@@ -36,6 +36,7 @@
 #include <unordered_map>
 #include "llnotificationsutil.h"
 #include "llviewercontrol.h"
+#include "llappviewer.h"
 #include "llcoros.h"
 
 #include "Velopack.h"
@@ -59,6 +60,8 @@ static std::function<void(int)> sProgressCallback;
 static vpkc_update_manager_t* sUpdateManager = nullptr;
 static vpkc_update_info_t* sPendingUpdate = nullptr;
 static vpkc_update_source_t* sUpdateSource = nullptr;
+static LLNotificationPtr sDownloadingNotification;
+static bool sRestartAfterUpdate = false;
 static std::unordered_map<std::string, std::string> sAssetUrlMap; // basename -> original absolute URL
 
 //
@@ -646,25 +649,6 @@ bool velopack_initialize()
 #endif
 
     vpkc_app_run(nullptr);
-
-    // Check if a previously downloaded update is ready to apply.
-    // This runs early in startup (WINMAIN) before any heavy initialization.
-    vpkc_update_options_t options = {};
-    options.AllowVersionDowngrade = false;
-    options.ExplicitChannel = nullptr;
-
-    vpkc_update_manager_t* mgr = nullptr;
-    if (vpkc_new_update_manager(sUpdateUrl.empty() ? "" : sUpdateUrl.c_str(), &options, nullptr, &mgr))
-    {
-        vpkc_asset_t* pending = nullptr;
-        if (vpkc_update_pending_restart(mgr, &pending) && pending)
-        {
-            LL_INFOS("Velopack") << "Pending update found, applying now..." << LL_ENDL;
-            vpkc_wait_exit_then_apply_updates(mgr, pending, false, true, nullptr, 0);
-            // If we get here, the update will be applied after we exit
-        }
-        vpkc_free_update_manager(mgr);
-    }
     return true;
 }
 
@@ -756,6 +740,7 @@ static void velopack_download_update()
             LL_WARNS("Velopack") << "Failed to download update: " << ll_safe_string((const char*)descr) <<  LL_ENDL;
             vpkc_free_update_info(update_info);
         }
+
     }
     else
     {
@@ -763,16 +748,36 @@ static void velopack_download_update()
     }
 }
 
+static void show_downloading_notification(const std::string& version)
+{
+    LLSD args;
+    args["VERSION"] = version;
+    sDownloadingNotification = LLNotificationsUtil::add("DownloadingUpdate", args);
+}
+
+static void dismiss_downloading_notification()
+{
+    if (sDownloadingNotification)
+    {
+        LLNotificationsUtil::cancel(sDownloadingNotification);
+        sDownloadingNotification = nullptr;
+    }
+}
+
 static void on_required_update_response(const LLSD& notification, const LLSD& response)
 {
+    std::string version = notification["substitutions"]["VERSION"].asString();
     LL_INFOS("Velopack") << "Required update acknowledged, starting download" << LL_ENDL;
+    show_downloading_notification(version);
     LLCoros::instance().launch("VelopackRequiredUpdate", []()
     {
         velopack_download_update();
+        dismiss_downloading_notification();
         if (velopack_is_update_pending())
         {
-            LL_INFOS("Velopack") << "Required update downloaded, applying and restarting" << LL_ENDL;
-            velopack_apply_pending_update(true);
+            LL_INFOS("Velopack") << "Required update downloaded, quitting to apply" << LL_ENDL;
+            velopack_request_restart_after_update();
+            LLAppViewer::instance()->requestQuit();
         }
     });
 }
@@ -782,14 +787,18 @@ static void on_optional_update_response(const LLSD& notification, const LLSD& re
     S32 option = LLNotificationsUtil::getSelectedOption(notification, response);
     if (option == 0) // "Install"
     {
+        std::string version = notification["substitutions"]["VERSION"].asString();
         LL_INFOS("Velopack") << "User accepted optional update, starting download" << LL_ENDL;
+        show_downloading_notification(version);
         LLCoros::instance().launch("VelopackOptionalUpdate", []()
         {
             velopack_download_update();
+            dismiss_downloading_notification();
             if (velopack_is_update_pending())
             {
-                LL_INFOS("Velopack") << "Optional update downloaded, applying and restarting" << LL_ENDL;
-                velopack_apply_pending_update(true);
+                LL_INFOS("Velopack") << "Optional update downloaded, quitting to apply" << LL_ENDL;
+                velopack_request_restart_after_update();
+                LLAppViewer::instance()->requestQuit();
             }
         });
     }
@@ -857,6 +866,16 @@ std::string velopack_get_current_version()
 bool velopack_is_update_pending()
 {
     return sPendingUpdate != nullptr;
+}
+
+bool velopack_should_restart_after_update()
+{
+    return sRestartAfterUpdate;
+}
+
+void velopack_request_restart_after_update()
+{
+    sRestartAfterUpdate = true;
 }
 
 void velopack_apply_pending_update(bool restart)

--- a/indra/newview/llvelopack.cpp
+++ b/indra/newview/llvelopack.cpp
@@ -34,6 +34,8 @@
 #include <boost/json.hpp>
 #include <fstream>
 #include <unordered_map>
+#include "llnotificationsutil.h"
+#include "llcoros.h"
 
 #include "Velopack.h"
 
@@ -665,7 +667,7 @@ bool velopack_initialize()
     return true;
 }
 
-void velopack_check_for_updates()
+static void velopack_download_update()
 {
     if (sUpdateUrl.empty())
     {
@@ -757,6 +759,36 @@ void velopack_check_for_updates()
     else
     {
         LL_DEBUGS("Velopack") << "No update available (result=" << result << ")" << LL_ENDL;
+    }
+}
+
+static void on_optional_update_response(const LLSD& notification, const LLSD& response)
+{
+    S32 option = LLNotificationsUtil::getSelectedOption(notification, response);
+    if (option == 0) // "Install"
+    {
+        LL_INFOS("Velopack") << "User accepted optional update, starting download" << LL_ENDL;
+        LLCoros::instance().launch("VelopackOptionalUpdate", [](){ velopack_download_update(); });
+    }
+    else
+    {
+        LL_INFOS("Velopack") << "User declined optional update (option=" << option << ")" << LL_ENDL;
+    }
+}
+
+void velopack_check_for_updates(bool required, const std::string& version, const std::string& relnotes_url)
+{
+    if (required)
+    {
+        velopack_download_update();
+    }
+    else
+    {
+        LL_INFOS("Velopack") << "Optional update available (version " << version << "), prompting user" << LL_ENDL;
+        LLSD args;
+        args["VERSION"] = version;
+        args["URL"] = relnotes_url;
+        LLNotificationsUtil::add("PromptOptionalUpdate", args, LLSD(), on_optional_update_response);
     }
 }
 

--- a/indra/newview/llvelopack.cpp
+++ b/indra/newview/llvelopack.cpp
@@ -62,6 +62,13 @@ static vpkc_update_info_t* sPendingUpdate = nullptr;
 static vpkc_update_source_t* sUpdateSource = nullptr;
 static LLNotificationPtr sDownloadingNotification;
 static bool sRestartAfterUpdate = false;
+
+// Forward declarations
+static void show_required_update_prompt();
+static void show_downloading_notification(const std::string& version);
+static bool sRequiredUpdateInProgress = false;
+static std::string sRequiredUpdateVersion;
+static std::string sRequiredUpdateRelnotes;
 static std::unordered_map<std::string, std::string> sAssetUrlMap; // basename -> original absolute URL
 
 //
@@ -748,11 +755,21 @@ static void velopack_download_update()
     }
 }
 
+static void on_downloading_closed(const LLSD& notification, const LLSD& response)
+{
+    sDownloadingNotification = nullptr;
+    if (sRequiredUpdateInProgress)
+    {
+        // User closed the downloading dialog during a required update — re-show it
+        show_downloading_notification(sRequiredUpdateVersion);
+    }
+}
+
 static void show_downloading_notification(const std::string& version)
 {
     LLSD args;
     args["VERSION"] = version;
-    sDownloadingNotification = LLNotificationsUtil::add("DownloadingUpdate", args);
+    sDownloadingNotification = LLNotificationsUtil::add("DownloadingUpdate", args, LLSD(), on_downloading_closed);
 }
 
 static void dismiss_downloading_notification()
@@ -808,15 +825,23 @@ static void on_optional_update_response(const LLSD& notification, const LLSD& re
     }
 }
 
+static void show_required_update_prompt()
+{
+    LLSD args;
+    args["VERSION"] = sRequiredUpdateVersion;
+    args["URL"] = sRequiredUpdateRelnotes;
+    LLNotificationsUtil::add("PauseForUpdate", args, LLSD(), on_required_update_response);
+}
+
 void velopack_check_for_updates(bool required, const std::string& version, const std::string& relnotes_url)
 {
     if (required)
     {
         LL_INFOS("Velopack") << "Required update to version " << version << ", prompting user" << LL_ENDL;
-        LLSD args;
-        args["VERSION"] = version;
-        args["URL"] = relnotes_url;
-        LLNotificationsUtil::add("PauseForUpdate", args, LLSD(), on_required_update_response);
+        sRequiredUpdateInProgress = true;
+        sRequiredUpdateVersion = version;
+        sRequiredUpdateRelnotes = relnotes_url;
+        show_required_update_prompt();
         return;
     }
 
@@ -866,6 +891,16 @@ std::string velopack_get_current_version()
 bool velopack_is_update_pending()
 {
     return sPendingUpdate != nullptr;
+}
+
+bool velopack_is_required_update_in_progress()
+{
+    return sRequiredUpdateInProgress;
+}
+
+std::string velopack_get_required_update_version()
+{
+    return sRequiredUpdateVersion;
 }
 
 bool velopack_should_restart_after_update()

--- a/indra/newview/llvelopack.h
+++ b/indra/newview/llvelopack.h
@@ -33,7 +33,7 @@
 #include <functional>
 
 bool velopack_initialize();
-void velopack_check_for_updates();
+void velopack_check_for_updates(bool required = true, const std::string& version = std::string(), const std::string& relnotes_url = std::string());
 std::string velopack_get_current_version();
 bool velopack_is_update_pending();
 void velopack_apply_pending_update(bool restart = true);

--- a/indra/newview/llvelopack.h
+++ b/indra/newview/llvelopack.h
@@ -36,6 +36,8 @@ bool velopack_initialize();
 void velopack_check_for_updates(bool required = true, const std::string& version = std::string(), const std::string& relnotes_url = std::string());
 std::string velopack_get_current_version();
 bool velopack_is_update_pending();
+bool velopack_is_required_update_in_progress();
+std::string velopack_get_required_update_version();
 bool velopack_should_restart_after_update();
 void velopack_request_restart_after_update();
 void velopack_apply_pending_update(bool restart = true);

--- a/indra/newview/llvelopack.h
+++ b/indra/newview/llvelopack.h
@@ -36,6 +36,8 @@ bool velopack_initialize();
 void velopack_check_for_updates(bool required = true, const std::string& version = std::string(), const std::string& relnotes_url = std::string());
 std::string velopack_get_current_version();
 bool velopack_is_update_pending();
+bool velopack_should_restart_after_update();
+void velopack_request_restart_after_update();
 void velopack_apply_pending_update(bool restart = true);
 void velopack_set_update_url(const std::string& url);
 void velopack_set_progress_callback(std::function<void(int)> callback);

--- a/indra/newview/llvvmquery.cpp
+++ b/indra/newview/llvvmquery.cpp
@@ -75,6 +75,10 @@ namespace
     {
         // Get base URL from grid manager
         std::string base_url = LLGridManager::getInstance()->getUpdateServiceURL();
+
+        // We use this for dev testing when working with VVM and working on the updater.  Not advisable to uncomment it.
+        //std::string base_url = "https://update.qa.secondlife.io/update";
+
         if (base_url.empty())
         {
             LL_WARNS("VVM") << "No update service URL configured" << LL_ENDL;
@@ -82,8 +86,11 @@ namespace
         }
 
         // Gather parameters for VVM query
-        //std::string channel = LLVersionInfo::instance().getChannel();
-        std::string channel = "QA Target for Velopack";
+        std::string channel = LLVersionInfo::instance().getChannel();
+
+        // We use this for dev testing when working with VVM and working on the updater.  Not advisable to uncomment it.
+        // std::string channel = "QA Target for Velopack";
+
         std::string version = LLVersionInfo::instance().getVersion();
         std::string platform = get_platform_string();
         std::string platform_version = get_platform_version();

--- a/indra/newview/llvvmquery.cpp
+++ b/indra/newview/llvvmquery.cpp
@@ -82,8 +82,8 @@ namespace
         }
 
         // Gather parameters for VVM query
-        std::string channel = LLVersionInfo::instance().getChannel();
-        // std::string channel = "QA Target for Velopack";
+        //std::string channel = LLVersionInfo::instance().getChannel();
+        std::string channel = "QA Target for Velopack";
         std::string version = LLVersionInfo::instance().getVersion();
         std::string platform = get_platform_string();
         std::string platform_version = get_platform_version();
@@ -124,6 +124,10 @@ namespace
             return;
         }
 
+        // Read whether this update is required or optional
+        bool update_required = result["required"].asBoolean();
+        std::string relnotes = result["more_info"].asString();
+
         // Extract update URL for current platform
         LLSD platforms = result["platforms"];
         if (platforms.has(platform))
@@ -133,9 +137,16 @@ namespace
             std::string velopack_url = platforms[platform]["velopack_url"].asString();
             if (!velopack_url.empty())
             {
-                LL_INFOS("VVM") << "Velopack update URL: " << velopack_url << LL_ENDL;
+                LL_INFOS("VVM") << "Velopack update URL: " << velopack_url
+                                << " required: " << update_required << LL_ENDL;
                 velopack_set_update_url(velopack_url);
-                LLCoros::instance().launch("VelopackUpdateCheck", &velopack_check_for_updates);
+
+                std::string update_version = result["version"].asString();
+                LLCoros::instance().launch("VelopackUpdateCheck",
+                    [update_required, update_version, relnotes]()
+                    {
+                        velopack_check_for_updates(update_required, update_version, relnotes);
+                    });
             }
             else
 #endif
@@ -150,7 +161,6 @@ namespace
         }
 
         // Post release notes URL to the relnotes event pump
-        std::string relnotes = result["more_info"].asString();
         if (!relnotes.empty())
         {
             LL_INFOS("VVM") << "Release notes URL: " << relnotes << LL_ENDL;

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -4437,6 +4437,14 @@ Click OK to download and install.
 
   <notification
    icon="alertmodal.tga"
+   name="DownloadingUpdate"
+   type="alertmodal">
+Downloading update [VERSION]...
+The viewer will restart once the download is complete.
+  </notification>
+
+  <notification
+   icon="alertmodal.tga"
    name="OptionalUpdateReady"
    type="alertmodal">
 Version [VERSION] has been downloaded and is ready to install.


### PR DESCRIPTION
This restores optional updates, and will only restart the viewer if it's an optional update upon completion.