### PR TITLE
Remove SLVersionChecker from the viewer with velopack.

### DIFF
--- a/indra/newview/installers/windows/installer_template.nsi
+++ b/indra/newview/installers/windows/installer_template.nsi
@@ -939,21 +939,7 @@ Function .onInstSuccess
 
         Call CheckWindowsServPack		# Warn if not on the latest SP before asking to launch.
         StrCmp $SKIP_AUTORUN "true" +2;
-        # Assumes SetOutPath $INSTDIR
-        # Run INSTEXE (our updater), passing VIEWER_EXE plus the command-line
-        # arguments built into our shortcuts. This gives the updater a chance
-        # to verify that the viewer we just installed is appropriate for the
-        # running system -- or, if not, to download and install a different
-        # viewer. For instance, if a user running 32-bit Windows installs a
-        # 64-bit viewer, it cannot run on this system. But since the updater
-        # is a 32-bit executable even in the 64-bit viewer package, the
-        # updater can detect the problem and adapt accordingly.
-        # Once everything is in order, the updater will run the specified
-        # viewer with the specified params.
-        # Quote the updater executable and the viewer executable because each
-        # must be a distinct command-line token, but DO NOT quote the language
-        # string because it must decompose into separate command-line tokens.
-        Exec '"$INSTDIR\$INSTEXE" precheck "$INSTDIR\$VIEWER_EXE" $SHORTCUT_LANG_PARAM'
+        Exec '"$INSTDIR\$VIEWER_EXE" $SHORTCUT_LANG_PARAM'
 # 
 FunctionEnd
 

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -661,7 +661,6 @@ LLAppViewer::LLAppViewer()
     mPurgeCacheOnExit(false),
     mPurgeUserDataOnExit(false),
     mSecondInstance(false),
-    mUpdaterNotFound(false),
     mSavedFinalSnapshot(false),
     mSavePerAccountSettings(false),     // don't save settings on logout unless login succeeded.
     mQuitRequested(false),
@@ -1118,11 +1117,10 @@ bool LLAppViewer::init()
     gGLActive = false;
 
 //#if LL_RELEASE_FOR_DOWNLOAD
-    // Launch VVM update check (replaces SLVersionChecker)
+    // Launch VVM update check
     if (!gSavedSettings.getBOOL("CmdLineSkipUpdater") && !gNonInteractive)
     {
         initVVMUpdateCheck();
-        mUpdaterNotFound = false;
     }
     else
     {
@@ -3235,16 +3233,6 @@ bool LLAppViewer::initWindow()
     LL_INFOS("AppInit") << "Window initialization done." << LL_ENDL;
 
     return true;
-}
-
-bool LLAppViewer::isUpdaterMissing()
-{
-    return mUpdaterNotFound;
-}
-
-bool LLAppViewer::waitForUpdater()
-{
-    return !gSavedSettings.getBOOL("CmdLineSkipUpdater") && !mUpdaterNotFound && !gNonInteractive;
 }
 
 void LLAppViewer::writeDebugInfo(bool isStatic)

--- a/indra/newview/llappviewer.h
+++ b/indra/newview/llappviewer.h
@@ -117,9 +117,6 @@ public:
     bool quitRequested() { return mQuitRequested; }
     bool logoutRequestSent() { return mLogoutRequestSent; }
     bool isSecondInstance() { return mSecondInstance; }
-    bool isUpdaterMissing(); // In use by tests
-    bool waitForUpdater();
-
     void writeDebugInfo(bool isStatic=true);
 
     void setServerReleaseNotesURL(const std::string& url) { mServerReleaseNotesURL = url; }
@@ -327,7 +324,6 @@ private:
     static LLAppViewer* sInstance;
 
     bool mSecondInstance; // Is this a second instance of the app?
-    bool mUpdaterNotFound; // True when attempt to start updater failed
 
     std::string mMarkerFileName;
     LLAPRFile mMarkerFile; // A file created to indicate the app is running.

--- a/indra/newview/lllogininstance.cpp
+++ b/indra/newview/lllogininstance.cpp
@@ -277,11 +277,6 @@ void LLLoginInstance::constructAuthParams(LLPointer<LLCredential> user_credentia
     mRequestData["params"] = request_params;
     mRequestData["options"] = requested_options;
     mRequestData["http_params"] = http_params;
-#if LL_RELEASE_FOR_DOWNLOAD
-    mRequestData["wait_for_updater"] = LLAppViewer::instance()->waitForUpdater();
-#else
-    mRequestData["wait_for_updater"] = false;
-#endif
 }
 
 bool LLLoginInstance::handleLoginEvent(const LLSD& event)
@@ -316,13 +311,6 @@ void LLLoginInstance::handleLoginFailure(const LLSD& event)
     // Login has failed.
     // Figure out why and respond...
     LLSD response = event["data"];
-    LLSD updater  = response["updater"];
-
-    // Always provide a response to the updater, if in fact the updater
-    // contacted us, if in fact the ping contains a 'reply' key. Most code
-    // paths tell it not to proceed with updating.
-    ResponsePtr resp(std::make_shared<LLEventAPI::Response>
-                         (LLSDMap("update", false), updater));
 
     std::string reason_response = response["reason"].asString();
     std::string message_response = response["message"].asString();
@@ -385,26 +373,15 @@ void LLLoginInstance::handleLoginFailure(const LLSD& event)
     }
     else if(reason_response == "update")
     {
-        // This can happen if the user clicked Login quickly, before we heard
-        // back from the Viewer Version Manager, but login failed because
-        // login.cgi is insisting on a required update. We were called with an
-        // event that bundles both the login.cgi 'response' and the
-        // synchronization event from the 'updater'.
+        // login.cgi rejected login and requires an update. Since Velopack
+        // handles updates now, the best we can do here is tell the user
+        // to download the update manually via the release notes URL.
         std::string login_version = response["message_args"]["VERSION"];
-        std::string vvm_version   = updater["VERSION"];
-        std::string relnotes      = updater["URL"];
         LL_WARNS("LLLogin") << "Login failed because an update to version " << login_version << " is required." << LL_ENDL;
-        // vvm_version might be empty because we might not have gotten
-        // SLVersionChecker's LoginSync handshake. But if it IS populated, it
-        // should (!) be the same as the version we got from login.cgi.
-        if ((! vvm_version.empty()) && vvm_version != login_version)
-        {
-            LL_WARNS("LLLogin") << "VVM update version " << vvm_version
-                                << " differs from login version " << login_version
-                                << "; presenting VVM version to match release notes URL"
-                                << LL_ENDL;
-            login_version = vvm_version;
-        }
+
+        // Try to use the release notes URL from the VVM query if available,
+        // otherwise fall back to constructing one from the version.
+        std::string relnotes = LLVersionInfo::instance().getReleaseNotes();
         if (relnotes.empty() || relnotes.find("://") == std::string::npos)
         {
             relnotes = LLTrans::getString("RELEASE_NOTES_BASE_URL");
@@ -420,32 +397,11 @@ void LLLoginInstance::handleLoginFailure(const LLSD& event)
         args["VERSION"] = login_version;
         args["URL"] = relnotes;
 
-        if (updater.isUndefined())
-        {
-            // If the updater failed to shake hands, better advise the user to
-            // download the update him/herself.
-            LLNotificationsUtil::add(
-                "RequiredUpdate",
-                args,
-                updater,
-                boost::bind(&LLLoginInstance::handleLoginDisallowed, this, _1, _2));
-        }
-        else
-        {
-            // If we've heard from the updater that an update is required,
-            // then display the prompt that assures the user we'll take care
-            // of it. This is the one case in which we bind 'resp':
-            // instead of destroying our Response object (and thus sending a
-            // negative reply to the updater) as soon as we exit this
-            // function, bind our shared_ptr so it gets passed into
-            // syncWithUpdater. That ensures that the response is delayed
-            // until the user has responded to the notification.
-            LLNotificationsUtil::add(
-                "PauseForUpdate",
-                args,
-                updater,
-                boost::bind(&LLLoginInstance::syncWithUpdater, this, resp, _1, _2));
-        }
+        LLNotificationsUtil::add(
+            "RequiredUpdate",
+            args,
+            LLSD(),
+            boost::bind(&LLLoginInstance::handleLoginDisallowed, this, _1, _2));
     }
     else if(reason_response == "mfa_challenge")
     {
@@ -477,19 +433,6 @@ void LLLoginInstance::handleLoginFailure(const LLSD& event)
 
         LLNotificationsUtil::add("LoginFailedUnknown", LLSD::emptyMap(), LLSD::emptyMap(), boost::bind(&LLLoginInstance::handleLoginDisallowed, this, _1, _2));
     }
-}
-
-void LLLoginInstance::syncWithUpdater(ResponsePtr resp, const LLSD& notification, const LLSD& response)
-{
-    LL_INFOS("LLLogin") << "LLLoginInstance::syncWithUpdater" << LL_ENDL;
-    // 'resp' points to an instance of LLEventAPI::Response that will be
-    // destroyed as soon as we return and the notification response functor is
-    // unregistered. Modify it so that it tells the updater to go ahead and
-    // perform the update. Naturally, if we allowed the user a choice as to
-    // whether to proceed or not, this assignment would reflect the user's
-    // selection.
-    (*resp)["update"] = true;
-    attemptComplete();
 }
 
 void LLLoginInstance::handleLoginDisallowed(const LLSD& notification, const LLSD& response)

--- a/indra/newview/lllogininstance.h
+++ b/indra/newview/lllogininstance.h
@@ -28,8 +28,6 @@
 #define LL_LLLOGININSTANCE_H
 
 #include "lleventdispatcher.h"
-#include "lleventapi.h"
-#include <memory>                   // std::shared_ptr
 #include "llsecapi.h"
 class LLLogin;
 class LLEventStream;
@@ -72,10 +70,7 @@ public:
     void saveMFAHash(LLSD const& response);
 
 private:
-    typedef std::shared_ptr<LLEventAPI::Response> ResponsePtr;
     void constructAuthParams(LLPointer<LLCredential> user_credentials);
-    void updateApp(bool mandatory, const std::string& message);
-    bool updateDialogCallback(const LLSD& notification, const LLSD& response);
 
     bool handleLoginEvent(const LLSD& event);
     void handleLoginFailure(const LLSD& event);
@@ -83,7 +78,6 @@ private:
     void handleDisconnect(const LLSD& event);
     void handleIndeterminate(const LLSD& event);
     void handleLoginDisallowed(const LLSD& notification, const LLSD& response);
-    void syncWithUpdater(ResponsePtr resp, const LLSD& notification, const LLSD& response);
 
     bool handleTOSResponse(bool v, const std::string& key);
     void showMFAChallange(const std::string& message);

--- a/indra/newview/llversioninfo.cpp
+++ b/indra/newview/llversioninfo.cpp
@@ -54,7 +54,7 @@ LLVersionInfo::LLVersionInfo():
     mWorkingChannelName(LL_TO_STRING(LL_VIEWER_CHANNEL)),
     build_configuration(LLBUILD_CONFIG), // set in indra/cmake/BuildVersion.cmake
     // instantiate an LLEventMailDrop with canonical name to listen for news
-    // from SLVersionChecker
+    // from the Viewer Version Manager
     mPump{new LLEventMailDrop("relnotes")},
     // immediately listen on mPump, store arriving URL into mReleaseNotes
     mStore{new LLStoreListener<std::string>(*mPump, mReleaseNotes)}

--- a/indra/newview/llversioninfo.h
+++ b/indra/newview/llversioninfo.h
@@ -112,8 +112,8 @@ private:
     std::string mReleaseNotes;
     // Store unique_ptrs to the next couple things so we don't have to explain
     // to every consumer of this header file all the details of each.
-    // mPump is the LLEventMailDrop on which we listen for SLVersionChecker to
-    // post the release-notes URL from the Viewer Version Manager.
+    // mPump is the LLEventMailDrop on which we listen for the
+    // release-notes URL from the Viewer Version Manager.
     std::unique_ptr<LLEventMailDrop> mPump;
     // mStore is an adapter that stores the release-notes URL in mReleaseNotes.
     std::unique_ptr<LLStoreListener<std::string>> mStore;

--- a/indra/newview/llviewerstats.cpp
+++ b/indra/newview/llviewerstats.cpp
@@ -783,7 +783,11 @@ void send_viewer_stats(bool include_preferences)
     fail["failed_resends"] = (S32) gMessageSystem->mFailedResendPackets;
     fail["off_circuit"] = (S32) gMessageSystem->mOffCircuitPackets;
     fail["invalid"] = (S32) gMessageSystem->mInvalidOnCircuitPackets;
-    fail["missing_updater"] = (S32) LLAppViewer::instance()->isUpdaterMissing();
+#if LL_VELOPACK
+    fail["missing_updater"] = false;
+#else
+    fail["missing_updater"] = true;
+#endif
 
     LLSD &inventory = body["inventory"];
     inventory["usable"] = gInventory.isInventoryUsable();

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -767,9 +767,11 @@ class Windows_x86_64_Manifest(ViewerManifest):
         # packId determines install folder: %LocalAppData%\{packId}
         # Uses same naming as NSIS INSTNAME for channel separation
         pack_id = self.app_name_oneword()  # "SecondLife", "SecondLifeBeta", etc.
-        # Velopack requires SemVer2 (3-part: major.minor.patch), viewer has 4 parts
-        # TODO: Treat patch as build number.
+        # Velopack requires SemVer2. Use major.minor.patch-buildnumber so that
+        # Velopack can distinguish builds and order them correctly.
         pack_version = '.'.join(self.args['version'][:3])
+        if len(self.args['version']) > 3 and self.args['version'][3]:
+            pack_version += '-' + self.args['version'][3]
         pack_title = self.app_name()  # Display name with spaces
         pack_dir = self.get_dst_prefix()
         main_exe = self.final_exe()
@@ -824,12 +826,19 @@ class Windows_x86_64_Manifest(ViewerManifest):
         # which are rebuilt during signing, but Velopack installers are created here.
         # Velopack creates: {packId}-win-Setup.exe
         velopack_setup = os.path.join(releases_dir, '%s-win-Setup.exe' % pack_id)
-        # Use versioned name with hyphen: Second_Life_26_1_0_53294_x86_64-Setup.exe
         self.package_file = self.installer_base_name() + '-Setup.exe'
         our_setup = os.path.join(pack_dir, self.package_file)
         if os.path.exists(velopack_setup):
             shutil.move(velopack_setup, our_setup)
             print("Moved %s to %s" % (velopack_setup, our_setup))
+
+        # Rename the portable zip to include the version number
+        # Velopack creates: {packId}-win-Portable.zip
+        velopack_portable = os.path.join(releases_dir, '%s-win-Portable.zip' % pack_id)
+        if os.path.exists(velopack_portable):
+            our_portable = os.path.join(releases_dir, self.installer_base_name() + '-Portable.zip')
+            shutil.move(velopack_portable, our_portable)
+            print("Moved %s to %s" % (velopack_portable, our_portable))
 
         # Output the Releases directory path for artifact upload (contains nupkg, RELEASES for updates)
         self.set_github_output('velopack_releases', releases_dir)
@@ -1203,8 +1212,11 @@ class Darwin_x86_64_Manifest(ViewerManifest):
         """
         # packId determines install identification - same as Windows for consistency
         pack_id = self.app_name_oneword()  # "SecondLife", "SecondLifeBeta", etc.
-        # Velopack requires SemVer2 (3-part: major.minor.patch), viewer has 4 parts
+        # Velopack requires SemVer2. Use major.minor.patch-buildnumber so that
+        # Velopack can distinguish builds and order them correctly.
         pack_version = '.'.join(self.args['version'][:3])
+        if len(self.args['version']) > 3 and self.args['version'][3]:
+            pack_version += '-' + self.args['version'][3]
         pack_title = self.app_name()  # Display name with spaces
 
         # The .app bundle path (e.g., "/path/to/Second Life Release.app")

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -540,18 +540,6 @@ class Windows_x86_64_Manifest(ViewerManifest):
                                                 '*.bat',
                                                 '*.tar.xz')))
 
-            with self.prefix(src=os.path.join(pkgdir, "VMP")):
-                # include the compiled launcher scripts so that it gets included in the file_list
-                self.path('SLVersionChecker.exe')
-
-            with self.prefix(dst="vmp_icons"):
-                with self.prefix(src=self.icon_path()):
-                    self.path("secondlife.ico")
-                #VMP  Tkinter icons
-                with self.prefix(src="vmp_icons"):
-                    self.path("*.png")
-                    self.path("*.gif")
-
         # Plugin host application
         self.path2basename(os.path.join(os.pardir,
                                         'llplugin', 'slplugin', self.args['configuration']),
@@ -864,7 +852,7 @@ class Windows_x86_64_Manifest(ViewerManifest):
         substitution_strings['installer_file'] = installer_file
 
         version_vars = """
-        !define INSTEXE "SLVersionChecker.exe"
+        !define INSTEXE "%(final_exe)s"
         !define VERSION "%(version_short)s"
         !define VERSION_LONG "%(version)s"
         !define VERSION_DASHES "%(version_dashes)s"
@@ -1049,15 +1037,6 @@ class Darwin_x86_64_Manifest(ViewerManifest):
                 # need .icns file referenced by Info.plist
                 with self.prefix(src=self.icon_path(), dst="") :
                     self.path("secondlife.icns")
-
-                # Copy in the updater script and helper modules
-                self.path(src=os.path.join(pkgdir, 'VMP'), dst="updater")
-
-                with self.prefix(src="", dst=os.path.join("updater", "icons")):
-                    self.path2basename(self.icon_path(), "secondlife.ico")
-                    with self.prefix(src="vmp_icons", dst=""):
-                        self.path("*.png")
-                        self.path("*.gif")
 
                 with self.prefix(src_dst="cursors_mac"):
                     self.path("*.tif")

--- a/indra/viewer_components/login/lllogin.cpp
+++ b/indra/viewer_components/login/lllogin.cpp
@@ -34,7 +34,6 @@
 
 #include "llcoros.h"
 #include "llevents.h"
-#include "lleventfilter.h"
 #include "lleventcoro.h"
 #include "llexception.h"
 #include "stringize.h"
@@ -133,16 +132,6 @@ void LLLogin::Impl::connect(const std::string& uri, const LLSD& login_params)
     LL_DEBUGS("LLLogin") << " connected with uri '" << uri << "', login_params " << login_params << LL_ENDL;
 }
 
-namespace
-{
-// Instantiate this rendezvous point at namespace scope so it's already
-// present no matter how early the updater might post to it.
-// Use an LLEventMailDrop, which has future-like semantics: regardless of the
-// relative order in which post() or listen() are called, it delivers each
-// post() event to its listener(s) until one of them consumes that event.
-static LLEventMailDrop sSyncPoint("LoginSync");
-}
-
 void LLLogin::Impl::loginCoro(std::string uri, LLSD login_params)
 {
     LLSD printable_params = hidePasswd(login_params);
@@ -225,58 +214,7 @@ void LLLogin::Impl::loginCoro(std::string uri, LLSD login_params)
             }
             else
             {
-                // Synchronize here with the updater. We synchronize here rather
-                // than in the fail.login handler, which actually examines the
-                // response from login.cgi, because here we are definitely in a
-                // coroutine and can definitely use suspendUntilBlah(). Whoever's
-                // listening for fail.login might not be.
-
-                // If the reason for login failure is that we must install a
-                // required update, we definitely want to pass control to the
-                // updater to manage that for us. We'll handle any other login
-                // failure ourselves, as usual. We figure that no matter where you
-                // are in the world, or what kind of network you're on, we can
-                // reasonably expect the Viewer Version Manager to respond more or
-                // less as quickly as login.cgi. This synchronization is only
-                // intended to smooth out minor races between the two services.
-                // But what if the updater crashes? Use a timeout so that
-                // eventually we'll tire of waiting for it and carry on as usual.
-                // Given the above, it can be a fairly short timeout, at least
-                // from a human point of view.
-
-                // Since sSyncPoint is an LLEventMailDrop, we DEFINITELY want to
-                // consume the posted event.
-                LLCoros::OverrideConsuming oc(true);
                 LLSD responses(mAuthResponse["responses"]);
-                LLSD updater;
-
-                if (printable_params["wait_for_updater"].asBoolean())
-                {
-                    std::string reason_response = responses["data"]["reason"].asString();
-                    // Timeout should produce the isUndefined() object passed here.
-                    if (reason_response == "update")
-                    {
-                        LL_INFOS("LLLogin") << "Login failure, waiting for sync from updater" << LL_ENDL;
-                        updater = llcoro::suspendUntilEventOnWithTimeout(sSyncPoint, 10, LLSD());
-                    }
-                    else
-                    {
-                        LL_DEBUGS("LLLogin") << "Login failure, waiting for sync from updater" << LL_ENDL;
-                        updater = llcoro::suspendUntilEventOnWithTimeout(sSyncPoint, 3, LLSD());
-                    }
-                    if (updater.isUndefined())
-                    {
-                        LL_WARNS("LLLogin") << "Failed to hear from updater, proceeding with fail.login"
-                                            << LL_ENDL;
-                    }
-                    else
-                    {
-                        LL_DEBUGS("LLLogin") << "Got responses from updater and login.cgi" << LL_ENDL;
-                    }
-                }
-
-                // Let the fail.login handler deal with empty updater response.
-                responses["updater"] = updater;
                 sendProgressEvent("offline", "fail.login", responses);
             }
             return;             // Done!


### PR DESCRIPTION
This removes the version checker from velopack built viewers.  It also removes it from NSIS - not that it ever really mattered for downstream viewers.