### PR TITLE
Fix LLTextureCacheRemoteWorker::doRead malloc size error

### DIFF
--- a/indra/newview/lltexturecache.cpp
+++ b/indra/newview/lltexturecache.cpp
@@ -341,7 +341,7 @@ bool LLTextureCacheRemoteWorker::doRead()
     if (!done && (mState == LOCAL))
     {
         llassert(local_size != 0);  // we're assuming there is a non empty local file here...
-        if (!mDataSize || mDataSize > local_size)
+        if (mDataSize <= 0 || mDataSize > local_size)
         {
             mDataSize = local_size;
         }


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/5537

Simply fixes the above issue by ensuring mDataSize can't be both 0 or less than 0, so the compiler is sure during static analyses the malloc size can't be too large (such as -1 that underflows as it wants a size_t).