### PR TITLE
#5541 Add safety checks for inventory save during shutdown

### DIFF
--- a/indra/newview/llinventorymodel.cpp
+++ b/indra/newview/llinventorymodel.cpp
@@ -2383,10 +2383,22 @@ void LLInventoryModel::cache(
         items,
         INCLUDE_TRASH,
         can_cache);
+
+    if (categories.empty() && items.empty())
+    {
+        LL_WARNS(LOG_INV) << "Nothing to cache for " << parent_folder_id << LL_ENDL;
+        return;
+    }
+
     // Use temporary file to avoid potential conflicts with other
     // instances (even a 'read only' instance unzips into a file)
     std::string temp_file = gDirUtilp->getTempFilename();
-    saveToFile(temp_file, categories, items);
+    if (!saveToFile(temp_file, categories, items))
+    {
+        LL_WARNS(LOG_INV) << "Failed to save inventory cache for " << parent_folder_id << LL_ENDL;
+        LLFile::remove(temp_file);
+        return;
+    }
     std::string gzip_filename = getInvCacheAddres(agent_id);
     gzip_filename.append(".gz");
     if(gzip_file(temp_file, gzip_filename))
@@ -3537,6 +3549,11 @@ bool LLInventoryModel::saveToFile(const std::string& filename,
         S32 cat_count = 0;
         for (auto& cat : categories)
         {
+            if (cat.isNull())
+            {
+                LL_WARNS(LOG_INV) << "Skipping null category during inventory save" << LL_ENDL;
+                continue;
+            }
             if (cat->getVersion() != LLViewerInventoryCategory::VERSION_UNKNOWN)
             {
                 LLSD sd;
@@ -3551,6 +3568,11 @@ bool LLInventoryModel::saveToFile(const std::string& filename,
         auto it_count = items.size();
         for (auto& item : items)
         {
+            if (item.isNull())
+            {
+                LL_WARNS(LOG_INV) << "Skipping null item during inventory save" << LL_ENDL;
+                continue;
+            }
             LLSD sd;
             item->asLLSD(sd);
             item_array.append(sd);


### PR DESCRIPTION
## Description

Likely cause is a use-after-free that corrupts std::map internals; the map insertion only exposes the failure (not the origin).

Defensive checks reduce the likelihood of a fatal exit, but root cause may need heap diagnostics to find the original corruption. However, given that this is a shutdown crash, it should be fine as is.

## Related Issues

#5541 