### PR TITLE
viewer-private#540 Fix freeze when opening large profiles #1

### DIFF
--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -1091,13 +1091,12 @@ S32 LLTextBase::insertStringNoUndo(S32 pos, const LLWString &wstr, LLTextBase::s
 
     getViewModel()->getEditableDisplay().insert(pos, wstr);
 
-    if ( truncate() )
-    {
-        insert_len = getLength() - old_len;
-    }
-
     if (mTrackValueChange)
     {
+        if (truncate())
+        {
+            insert_len = getLength() - old_len;
+        }
         onValueChange(pos, pos + insert_len);
     }
     needsReflow(pos);
@@ -2373,6 +2372,7 @@ void LLTextBase::setText(const LLStringExplicit &utf8str, const LLStyle::Params&
         startOfDoc();
     }
 
+    truncate(); // was postponed to avoid micro truncations and expensive checks
     mTrackValueChange = true;
     onValueChange(0, getLength());
 }
@@ -2403,6 +2403,10 @@ void LLTextBase::appendTextImpl(const std::string& new_text, const LLStyle::Para
     LL_PROFILE_ZONE_SCOPED_CATEGORY_UI;
     LLStyle::Params style_params(getStyleParams());
     style_params.overwriteFrom(input_params);
+
+    // todo: this does not check for maximum size, might
+    // want to stop once maximum size was reached to avoid
+    // expensive findUrl, replaceUrl calls.
 
     S32 part = (S32)LLTextParser::WHOLE;
     if ((mParseHTML || force_slurl) && !style_params.is_link) // Don't search for URLs inside a link segment (STORM-358).
@@ -2595,6 +2599,7 @@ void LLTextBase::copyContents(const LLTextBase* source)
 
     getViewModel()->setDisplay(source->getViewModel()->getDisplay());
 
+    truncate(); // was postponed to avoid micro truncations and expensive checks
     mTrackValueChange = true;
     onValueChange(0, getLength());
     needsReflow();

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -222,6 +222,7 @@ LLTextBase::LLTextBase(const LLTextBase::Params &p)
     mTrustedContent(p.trusted_content),
     mAlwaysShowIcons(p.always_show_icons),
     mTrackEnd( p.track_end ),
+    mTrackValueChange(true),
     mScrollIndex(-1),
     mSelectionStart( 0 ),
     mSelectionEnd( 0 ),
@@ -964,7 +965,10 @@ void LLTextBase::drawText()
 
 S32 LLTextBase::insertStringNoUndo(S32 pos, const LLWString &wstr, LLTextBase::segment_vec_t* segments )
 {
-    beforeValueChange();
+    if (mTrackValueChange)
+    {
+        beforeValueChange();
+    }
 
     S32 old_len = getLength();      // length() returns character length
     S32 insert_len = static_cast<S32>(wstr.length());
@@ -1092,7 +1096,10 @@ S32 LLTextBase::insertStringNoUndo(S32 pos, const LLWString &wstr, LLTextBase::s
         insert_len = getLength() - old_len;
     }
 
-    onValueChange(pos, pos + insert_len);
+    if (mTrackValueChange)
+    {
+        onValueChange(pos, pos + insert_len);
+    }
     needsReflow(pos);
 
     return insert_len;
@@ -1108,7 +1115,10 @@ S32 LLTextBase::removeStringNoUndo(S32 pos, S32 length)
     // Clamp length to not go past the end of the text
     length = std::min(length, text_length - pos);
 
-    beforeValueChange();
+    if (mTrackValueChange)
+    {
+        beforeValueChange();
+    }
     segment_set_t::iterator seg_iter = getSegIterContaining(pos);
     while(seg_iter != mSegments.end())
     {
@@ -1159,7 +1169,10 @@ S32 LLTextBase::removeStringNoUndo(S32 pos, S32 length)
     // recreate default segment in case we erased everything
     createDefaultSegment();
 
-    onValueChange(pos, pos);
+    if (mTrackValueChange)
+    {
+        onValueChange(pos, pos);
+    }
     needsReflow(pos);
 
     return -length; // This will be wrong if someone calls removeStringNoUndo with an excessive length
@@ -1167,7 +1180,10 @@ S32 LLTextBase::removeStringNoUndo(S32 pos, S32 length)
 
 S32 LLTextBase::overwriteCharNoUndo(S32 pos, llwchar wc)
 {
-    beforeValueChange();
+    if (mTrackValueChange)
+    {
+        beforeValueChange();
+    }
 
     if (pos > (S32)getLength())
     {
@@ -1175,7 +1191,10 @@ S32 LLTextBase::overwriteCharNoUndo(S32 pos, llwchar wc)
     }
     getViewModel()->getEditableDisplay()[pos] = wc;
 
-    onValueChange(pos, pos + 1);
+    if (mTrackValueChange)
+    {
+        onValueChange(pos, pos + 1);
+    }
     needsReflow(pos);
 
     return 1;
@@ -2330,6 +2349,10 @@ void LLTextBase::createUrlContextMenu(S32 x, S32 y, const std::string &in_url)
 
 void LLTextBase::setText(const LLStringExplicit &utf8str, const LLStyle::Params& input_params)
 {
+    beforeValueChange();
+    // Can insert a lot of different segments, don't want to spam events.
+    mTrackValueChange = false;
+
     // clear out the existing text and segments
     getViewModel()->setDisplay(LLWStringUtil::null);
 
@@ -2350,6 +2373,7 @@ void LLTextBase::setText(const LLStringExplicit &utf8str, const LLStyle::Params&
         startOfDoc();
     }
 
+    mTrackValueChange = true;
     onValueChange(0, getLength());
 }
 
@@ -2553,6 +2577,10 @@ void LLTextBase::copyContents(const LLTextBase* source)
     beforeValueChange();
     deselect();
 
+    // Can insert a lot of different segments, don't want to spam events.
+    // Do one full length onValueChange() at the end of this function.
+    mTrackValueChange = false;
+
     mSegments.clear();
     for (const LLTextSegmentPtr& segp : source->mSegments)
     {
@@ -2567,6 +2595,7 @@ void LLTextBase::copyContents(const LLTextBase* source)
 
     getViewModel()->setDisplay(source->getViewModel()->getDisplay());
 
+    mTrackValueChange = true;
     onValueChange(0, getLength());
     needsReflow();
 }

--- a/indra/llui/lltextbase.h
+++ b/indra/llui/lltextbase.h
@@ -761,6 +761,7 @@ protected:
     bool                        mUseEmoji;
     bool                        mUseColor;
     bool                        mTrackEnd;          // if true, keeps scroll position at end of document during resize
+    bool                        mTrackValueChange;  // if true, send out onValueChange() from low level text modification methods
     bool                        mReadOnly;
     bool                        mBGVisible;         // render background?
     bool                        mClip;              // clip text to widget rect

--- a/indra/llui/llurlregistry.cpp
+++ b/indra/llui/llurlregistry.cpp
@@ -149,12 +149,77 @@ static bool stringHasUrl(const std::string &text)
     // fast heuristic test for a URL in a string. This is used
     // to avoid lots of costly regex calls, BUT it needs to be
     // kept in sync with the LLUrlEntry regexes we support.
-    return (text.find("://") != std::string::npos ||
-            text.find("www.") != std::string::npos ||
-            text.find(".com") != std::string::npos ||
-            text.find("<nolink>") != std::string::npos ||
-            text.find("<icon") != std::string::npos ||
-            text.find("@") != std::string::npos);
+
+    // Early exit for empty or very short strings
+    // Smallest url is 5 characters
+    if (text.length() < 3)
+    {
+        return false;
+    }
+
+    // Single pass search for common URL indicators
+    for (size_t i = 0; i < text.length(); ++i)
+    {
+        char c = text[i];
+
+        // Check for @ (email or mention)
+        if (c == '@')
+        {
+            return true;
+        }
+
+        if (i + 3 >= text.length())
+        {
+            // Nothing else is going to match or fit if we don't
+            // have at least 4 characters left
+            // Ex: expectation is that there is something after protocol delimiter
+            // and .com takes 4 characters.
+            return false;
+        }
+
+        // Check for protocol delimiter
+        if (c == ':' && text[i + 1] == '/' && text[i + 2] == '/')
+        {
+            return true;
+        }
+
+        // Check for www. at start of word
+        if (c == 'w'
+            && text[i + 1] == 'w'
+            && text[i + 2] == 'w'
+            && text[i + 3] == '.')
+        {
+            return true;
+        }
+
+        // Check for .com (and similar)
+        if (c == '.')
+        {
+            const char* suffix = text.c_str() + i + 1;
+            if ((suffix[0] == 'c' && suffix[1] == 'o' && suffix[2] == 'm') ||
+                (suffix[0] == 'n' && suffix[1] == 'e' && suffix[2] == 't') ||
+                (suffix[0] == 'o' && suffix[1] == 'r' && suffix[2] == 'g') ||
+                (suffix[0] == 'e' && suffix[1] == 'd' && suffix[2] == 'u'))
+            {
+                return true;
+            }
+        }
+
+        // Check for <nolink> or <icon
+        if (c == '<')
+        {
+            if (i + 7 < text.length() && text.compare(i + 1, 6, "nolink") == 0)
+            {
+                return true;
+            }
+            if (i + 4 < text.length() && text.compare(i + 1, 4, "icon") == 0)
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 bool LLUrlRegistry::findUrl(const std::string &text, LLUrlMatch &match, const LLUrlLabelCallback &cb, bool is_content_trusted, bool skip_non_mentions)


### PR DESCRIPTION
A small freeze for large profiles and other text fields due to:
- Some 'on change' updates happening too often.
- Micro truncations
- Expensive regex checks