### PR TITLE
Send metadata for textures to get correct upload cost estimate.

### DIFF
--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -2857,9 +2857,33 @@ void LLMeshUploadThread::packModelIntance(
                     // to ensure accurate price estimation. If not included, the server will assume all
                     // textures are 1024 x 1024, which could lead to a low estimate.
                     LLSD info = LLSD::emptyMap();
-                    info["width"] = texture->getFullWidth();
-                    info["height"] = texture->getFullHeight();
+
+                    S32 texture_width = 0;
+                    S32 texture_height = 0;
+                    if (texture->hasSavedRawImage())
+                    {
+                        LLImageDataLock lock(texture->getSavedRawImage());
+
+                        LLPointer<LLImageJ2C> upload_file = LLViewerTextureList::convertToUploadFile(texture->getSavedRawImage());
+
+                        if (!upload_file.isNull() && upload_file->getDataSize() && !upload_file->isBufferInvalid())
+                        {
+                            texture_width  = upload_file->getWidth();
+                            texture_height = upload_file->getHeight();
+                        }
+                    }
+
+                    if ((texture_width <= 0) || (texture_height <= 0))
+                    {
+                        // Fall back to the texture's stored dimensions if we can't get dimensions from the raw image.
+                        texture_width = texture->getFullWidth();
+                        texture_height = texture->getFullHeight();
+                    }
+
+                    info["width"] = texture_width;
+                    info["height"] = texture_height;
                     res["texture_info"][texture_num] = info;
+                    res["texture_list"][texture_num] = LLSD::Binary(); // empty binary to indicate texture is not included, for older server compatibility
                 }
                 // store indexes for error handling;
                 texture_list_dest.push_back(material.mDiffuseMapFilename);

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -2847,8 +2847,20 @@ void LLMeshUploadThread::packModelIntance(
                 texture_index.find(texture) == texture_index.end())
             {
                 texture_index[texture] = texture_num;
-                std::string str = texture_str.str();
-                res["texture_list"][texture_num] = LLSD::Binary(str.begin(), str.end());
+                if (include_textures)
+                {
+                    std::string str = texture_str.str();
+                    res["texture_list"][texture_num] = LLSD::Binary(str.begin(), str.end());
+                }
+                else
+                {   // When not including the whole texture, we need to send some metadata about the image
+                    // to ensure accurate price estimation. If not included, the server will assume all
+                    // textures are 1024 x 1024, which could lead to a low estimate.
+                    LLSD info = LLSD::emptyMap();
+                    info["width"] = texture->getFullWidth();
+                    info["height"] = texture->getFullHeight();
+                    res["texture_info"][texture_num] = info;
+                }
                 // store indexes for error handling;
                 texture_list_dest.push_back(material.mDiffuseMapFilename);
                 texture_num++;
@@ -2881,8 +2893,8 @@ void LLMeshUploadThread::wholeModelToLLSD(LLSD& dest, std::vector<std::string>& 
     LLSD res;
     if (mDestinationFolderId.isNull())
     {
-    result["folder_id"] = gInventory.findUserDefinedCategoryUUIDForType(LLFolderType::FT_OBJECT);
-    result["texture_folder_id"] = gInventory.findUserDefinedCategoryUUIDForType(LLFolderType::FT_TEXTURE);
+        result["folder_id"] = gInventory.findUserDefinedCategoryUUIDForType(LLFolderType::FT_OBJECT);
+        result["texture_folder_id"] = gInventory.findUserDefinedCategoryUUIDForType(LLFolderType::FT_TEXTURE);
     }
     else
     {


### PR DESCRIPTION
When sending the request for a cost estimate for texture upload, include metadata about the texture size.

Issue: #5547 

## Description

During the price check phase of mesh upload, the simulator would send an array of empty textures (0 byte blobs). 

In order to apply the correct upload cost, the simulator must be provided with at least the dimensions of the expected textures.



## Related Issues

Issue: https://github.com/secondlife/server/issues/2392
Pull: https://github.com/secondlife/server/pull/2402

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

* 26.02 is the first viewer to allow 2K texture uploads as part of the mesh upload.
* The simulator requires a full "texture_list" array on the final upload.
* The simulator will still use the "texture_list" array for estimation if the "texture_info" is missing from the estimate request. In this case it assumes that the textures are 1K. The price check (expected != actual) will fail if the uploaded textures are larger and have not been scaled down by the viewer.