### PR TITLE
#5454 fix not showing Friend requests during start up notification

### DIFF
--- a/indra/newview/llchannelmanager.cpp
+++ b/indra/newview/llchannelmanager.cpp
@@ -140,6 +140,7 @@ void LLChannelManager::onLoginCompleted()
         }
         else
         {
+            mStartUpToastInited = true;
             gViewerWindow->getRootView()->addChild(mStartUpChannel);
 
             // init channel's position and size

--- a/indra/newview/llchannelmanager.h
+++ b/indra/newview/llchannelmanager.h
@@ -104,12 +104,15 @@ public:
      */
     static LLNotificationsUI::LLScreenChannel* getNotificationScreenChannel();
 
+    bool getStartUpToastInited() const { return mStartUpToastInited; }
+
     std::vector<ChannelElem>& getChannelList() { return mChannelList;}
 private:
 
     LLScreenChannel* createChannel(LLScreenChannelBase::Params& p);
 
     LLScreenChannel*            mStartUpChannel;
+    bool                        mStartUpToastInited{false};
     std::vector<ChannelElem>    mChannelList;
 };
 

--- a/indra/newview/llimprocessing.cpp
+++ b/indra/newview/llimprocessing.cpp
@@ -1485,6 +1485,7 @@ void LLIMProcessing::processNewMessage(LLUUID from_id,
                         LLNotification::Params params("OfferFriendship");
                         params.substitutions = args;
                         params.payload = payload;
+                        params.offer_from_agent = true;
                         LLPostponedNotification::add<LLPostponedOfferNotification>(params, from_id, false);
                     }
                 }

--- a/indra/newview/llnotificationofferhandler.cpp
+++ b/indra/newview/llnotificationofferhandler.cpp
@@ -36,6 +36,7 @@
 #include "llscriptfloater.h"
 #include "llimview.h"
 #include "llnotificationsutil.h"
+#include "llchannelmanager.h"
 
 #include <boost/regex.hpp>
 
@@ -135,7 +136,13 @@ bool LLOfferHandler::processNotification(const LLNotificationPtr& notification, 
 
             LLScreenChannel* channel = dynamic_cast<LLScreenChannel*>(mChannel.get());
             if(channel)
+            {
+                if (LLChannelManager::getInstance()->getStartUpToastInited() && notification->getOfferFromAgent())
+                {
+                    LLChannelManager::getInstance()->onStartUpToastClose();
+                }
                 channel->addToast(p);
+            }
 
         }
 


### PR DESCRIPTION
Hide startup channel and show agent offers that arrive while startup toast is still displayed.