### PR TITLE
#5558 Adjust map request size dynamically

### DIFF
--- a/indra/newview/llworldmap.cpp
+++ b/indra/newview/llworldmap.cpp
@@ -623,7 +623,7 @@ void LLWorldMap::updateRegions(S32 x0, S32 y0, S32 x1, S32 y1)
     block_y0 = llmax(block_y0, 0);
     block_y1 = llmin(block_y1, MAP_BLOCK_RES - 1);
 
-    // Process blocks, grouping unloaded blocks into larger requests up to MAX_BLOCKS
+    // Process blocks, grouping unloaded blocks into larger requests up to MAX_TOTAL_BLOCKS
     for (S32 block_y = block_y0; block_y <= block_y1; )
     {
         for (S32 block_x = block_x0; block_x <= block_x1; )
@@ -651,7 +651,7 @@ void LLWorldMap::updateRegions(S32 x0, S32 y0, S32 x1, S32 y1)
                 // Expand height (check vertical contiguous unloaded blocks)
                 while (request_height < MAX_BLOCKS_PER_SIDE &&
                     (block_y + request_height) <= block_y1 &&
-                    (request_width * request_height < MAX_TOTAL_BLOCKS)) // Don't exceed 64 total regions
+                    (request_width * (request_height + 1) <= MAX_TOTAL_BLOCKS)) // Don't exceed 64 total regions
                 {
                     bool can_expand = true;
                     // Width can be >1, loop over blocks in the line

--- a/indra/newview/llworldmap.cpp
+++ b/indra/newview/llworldmap.cpp
@@ -603,25 +603,103 @@ void LLWorldMap::dropImagePriorities()
 // Load all regions in a given rectangle (in region grid coordinates, i.e. world / 256 meters)
 void LLWorldMap::updateRegions(S32 x0, S32 y0, S32 x1, S32 y1)
 {
-    // Convert those boundaries to the corresponding (MAP_BLOCK_SIZE x MAP_BLOCK_SIZE) block coordinates
-    x0 = x0 / MAP_BLOCK_SIZE;
-    x1 = x1 / MAP_BLOCK_SIZE;
-    y0 = y0 / MAP_BLOCK_SIZE;
-    y1 = y1 / MAP_BLOCK_SIZE;
+    constexpr S32 MAX_REQUEST_REGIONS = 64; // Server side enforced limit.
+    constexpr S32 REGIONS_PER_BLOCK = MAP_BLOCK_SIZE * MAP_BLOCK_SIZE; // 4 x 4 = 16 regions per block
+    constexpr S32 MAX_TOTAL_BLOCKS = MAX_REQUEST_REGIONS / REGIONS_PER_BLOCK; // 64 / 16 = 4 blocks total
+    constexpr S32 MAX_BLOCKS_PER_SIDE = MAX_TOTAL_BLOCKS; // Can have up to 4 blocks in one dimension (e.g., 4x1, 1x4, 2x2)
 
-    // Load the region info those blocks
-    for (S32 block_x = llmax(x0, 0); block_x <= llmin(x1, MAP_BLOCK_RES-1); ++block_x)
+    // Convert region coordinates to block coordinates
+    // We use fixed sized blocks for ease of storage and lookup,
+    // but the requests can be of variable size of up to
+    // MAX_REQUEST_REGIONS.
+    S32 block_x0 = x0 / MAP_BLOCK_SIZE;
+    S32 block_x1 = x1 / MAP_BLOCK_SIZE;
+    S32 block_y0 = y0 / MAP_BLOCK_SIZE;
+    S32 block_y1 = y1 / MAP_BLOCK_SIZE;
+
+    // Clamp to valid range
+    block_x0 = llmax(block_x0, 0);
+    block_x1 = llmin(block_x1, MAP_BLOCK_RES - 1);
+    block_y0 = llmax(block_y0, 0);
+    block_y1 = llmin(block_y1, MAP_BLOCK_RES - 1);
+
+    // Process blocks, grouping unloaded blocks into larger requests up to MAX_BLOCKS
+    for (S32 block_y = block_y0; block_y <= block_y1; )
     {
-        for (S32 block_y = llmax(y0, 0); block_y <= llmin(y1, MAP_BLOCK_RES-1); ++block_y)
+        for (S32 block_x = block_x0; block_x <= block_x1; )
         {
             S32 offset = block_x | (block_y * MAP_BLOCK_RES);
             if (!mMapBlockLoaded[offset])
             {
-                //LL_INFOS("WorldMap") << "Loading Block (" << block_x << "," << block_y << ")" << LL_ENDL;
-                LLWorldMapMessage::getInstance()->sendMapBlockRequest(block_x * MAP_BLOCK_SIZE, block_y * MAP_BLOCK_SIZE, (block_x * MAP_BLOCK_SIZE) + MAP_BLOCK_SIZE - 1, (block_y * MAP_BLOCK_SIZE) + MAP_BLOCK_SIZE - 1);
-                mMapBlockLoaded[offset] = true;
+                // Find the maximum contiguous unloaded rectangle starting at this block
+                S32 request_width = 1;
+                S32 request_height = 1;
+
+                // Expand width (check horizontal contiguous unloaded blocks)
+                while (request_width < MAX_BLOCKS_PER_SIDE &&
+                    (block_x + request_width) <= block_x1)
+                {
+                    // request_height is 1, can add blocks one by one.
+                    S32 check_offset = (block_x + request_width) | (block_y * MAP_BLOCK_RES);
+                    if (mMapBlockLoaded[check_offset])
+                    {
+                        break;
+                    }
+                    ++request_width;
+                }
+
+                // Expand height (check vertical contiguous unloaded blocks)
+                while (request_height < MAX_BLOCKS_PER_SIDE &&
+                    (block_y + request_height) <= block_y1 &&
+                    (request_width * request_height < MAX_TOTAL_BLOCKS)) // Don't exceed 64 total regions
+                {
+                    bool can_expand = true;
+                    // Width can be >1, loop over blocks in the line
+                    for (S32 x = 0; x < request_width; ++x)
+                    {
+                        S32 check_offset = (block_x + x) | ((block_y + request_height) * MAP_BLOCK_RES);
+                        if (mMapBlockLoaded[check_offset])
+                        {
+                            can_expand = false;
+                            break;
+                        }
+                    }
+                    if (!can_expand) break;
+                    ++request_height;
+                }
+
+                // Send request for the contiguous rectangle
+                S32 min_x = block_x * MAP_BLOCK_SIZE;
+                S32 min_y = block_y * MAP_BLOCK_SIZE;
+                S32 max_x = (block_x + request_width) * MAP_BLOCK_SIZE - 1;
+                S32 max_y = (block_y + request_height) * MAP_BLOCK_SIZE - 1;
+
+                LL_DEBUGS("WorldMap") << "Loading Block rectangle (" << block_x << "," << block_y
+                    << ") to (" << (block_x + request_width - 1) << "," << (block_y + request_height - 1)
+                    << ") [" << (request_width * request_height * MAP_BLOCK_SIZE * MAP_BLOCK_SIZE) << " regions]" << LL_ENDL;
+
+                LLWorldMapMessage::getInstance()->sendMapBlockRequest(min_x, min_y, max_x, max_y);
+
+                // Mark all blocks in the requested rectangle as loaded
+                for (S32 y = 0; y < request_height; ++y)
+                {
+                    for (S32 x = 0; x < request_width; ++x)
+                    {
+                        S32 mark_offset = (block_x + x) | ((block_y + y) * MAP_BLOCK_RES);
+                        mMapBlockLoaded[mark_offset] = true;
+                    }
+                }
+
+                // Skip over the width of blocks we just requested
+                block_x += request_width;
+            }
+            else
+            {
+                // This block is already loaded, move to next
+                ++block_x;
             }
         }
+        ++block_y;
     }
 }
 

--- a/indra/newview/llworldmapview.cpp
+++ b/indra/newview/llworldmapview.cpp
@@ -1737,8 +1737,11 @@ void LLWorldMapView::updateVisibleBlocks()
     const F32 half_height = F32(height) / 2.0f;
 
     // Compute center into sim grid coordinates
-    S32 world_center_x = S32((-mPanX / mMapScale) + (camera_global.mdV[0] / REGION_WIDTH_METERS));
-    S32 world_center_y = S32((-mPanY / mMapScale) + (camera_global.mdV[1] / REGION_WIDTH_METERS));
+    // mPanX and mPanY values can be obsolete as they are used for
+    // animation and there is no point loading regions we will see
+    // so briefly, they won't have time to load. Use target directly.
+    S32 world_center_x = S32((-mTargetPanX / mMapScale) + (camera_global.mdV[0] / REGION_WIDTH_METERS));
+    S32 world_center_y = S32((-mTargetPanY / mMapScale) + (camera_global.mdV[1] / REGION_WIDTH_METERS));
 
     // Compute the boundaries into sim grid coordinates
     S32 world_left   = world_center_x - S32(half_width  / mMapScale) - 1;

--- a/indra/newview/tests/llworldmap_test.cpp
+++ b/indra/newview/tests/llworldmap_test.cpp
@@ -54,10 +54,22 @@ LLViewerFetchedTexture* LLViewerTextureManager::getFetchedTexture(const LLUUID&,
                                                                   LLGLint, LLGLenum, LLHost ) { return NULL; }
 
 // Stub related map calls
+
+// Records each sendMapBlockRequest call for inspection in tests
+struct MapBlockRequest
+{
+    U16 min_x, min_y, max_x, max_y;
+};
+static std::vector<MapBlockRequest> gMapBlockRequests;
+
 LLWorldMapMessage::LLWorldMapMessage() { }
 LLWorldMapMessage::~LLWorldMapMessage() { }
 void LLWorldMapMessage::sendItemRequest(U32 type, U64 handle) { }
-void LLWorldMapMessage::sendMapBlockRequest(U16 min_x, U16 min_y, U16 max_x, U16 max_y, bool return_nonexistent) { }
+void LLWorldMapMessage::sendMapBlockRequest(U16 min_x, U16 min_y, U16 max_x, U16 max_y, bool return_nonexistent)
+{
+    MapBlockRequest req = { min_x, min_y, max_x, max_y };
+    gMapBlockRequests.push_back(req);
+}
 
 LLWorldMipmap::LLWorldMipmap() { }
 LLWorldMipmap::~LLWorldMipmap() { }
@@ -517,5 +529,64 @@ namespace tut
         // Test 26 : reset tracking
         mWorld->cancelTracking();
         ensure("LLWorldMap::cancelTracking() at end test failed", mWorld->isTracking() == false);
+    }
+    // Test updateRegions() request grouping, size limits, and bounds
+    template<> template<>
+    void worldmap_object_t::test<4>()
+    {
+        // Test 27 : 1x1 block (4x4 = 16 regions) - single small request within bounds
+        mWorld->reset();
+        gMapBlockRequests.clear();
+        mWorld->updateRegions(0, 0, 3, 3);
+        ensure("updateRegions 1x1 block: expected 1 request", gMapBlockRequests.size() == 1);
+        {
+            const MapBlockRequest& req = gMapBlockRequests[0];
+            ensure("updateRegions 1x1 block: min_x", req.min_x == 0);
+            ensure("updateRegions 1x1 block: min_y", req.min_y == 0);
+            ensure("updateRegions 1x1 block: max_x", req.max_x == 3);
+            ensure("updateRegions 1x1 block: max_y", req.max_y == 3);
+            S32 regions = (req.max_x - req.min_x + 1) * (req.max_y - req.min_y + 1);
+            ensure("updateRegions 1x1 block: must not exceed 64 regions", regions <= 64);
+        }
+
+        // Test 28 : 2x2 blocks (8x8 = 64 regions) - single request at the 64-region limit
+        mWorld->reset();
+        gMapBlockRequests.clear();
+        mWorld->updateRegions(0, 0, 7, 7);
+        ensure("updateRegions 2x2 blocks: expected 1 request", gMapBlockRequests.size() == 1);
+        {
+            const MapBlockRequest& req = gMapBlockRequests[0];
+            ensure("updateRegions 2x2 blocks: min_x", req.min_x == 0);
+            ensure("updateRegions 2x2 blocks: min_y", req.min_y == 0);
+            ensure("updateRegions 2x2 blocks: max_x", req.max_x == 7);
+            ensure("updateRegions 2x2 blocks: max_y", req.max_y == 7);
+            S32 regions = (req.max_x - req.min_x + 1) * (req.max_y - req.min_y + 1);
+            ensure("updateRegions 2x2 blocks: must not exceed 64 regions", regions <= 64);
+        }
+
+        // Test 29 : 4x4 blocks (16x16 = 256 total regions) - must split into multiple requests
+        //           each spanning a 4x1 strip (64 regions), none exceeding the server limit
+        mWorld->reset();
+        gMapBlockRequests.clear();
+        mWorld->updateRegions(0, 0, 15, 15);
+        ensure("updateRegions 4x4 blocks: expected 4 requests", gMapBlockRequests.size() == 4);
+        for (size_t i = 0; i < gMapBlockRequests.size(); ++i)
+        {
+            const MapBlockRequest& req = gMapBlockRequests[i];
+            S32 regions = (req.max_x - req.min_x + 1) * (req.max_y - req.min_y + 1);
+            ensure("updateRegions 4x4 blocks: each request must not exceed 64 regions", regions <= 64);
+            // Requests must stay within the requested area (0..15)
+            ensure("updateRegions 4x4 blocks: max_x in bounds", req.max_x <= 15);
+            ensure("updateRegions 4x4 blocks: max_y in bounds", req.max_y <= 15);
+        }
+        // Each request covers one horizontal strip of 4 blocks (rows 0..3, 4..7, 8..11, 12..15)
+        ensure("updateRegions 4x4 blocks: request[0] min_y", gMapBlockRequests[0].min_y == 0);
+        ensure("updateRegions 4x4 blocks: request[0] max_y", gMapBlockRequests[0].max_y == 3);
+        ensure("updateRegions 4x4 blocks: request[1] min_y", gMapBlockRequests[1].min_y == 4);
+        ensure("updateRegions 4x4 blocks: request[1] max_y", gMapBlockRequests[1].max_y == 7);
+        ensure("updateRegions 4x4 blocks: request[2] min_y", gMapBlockRequests[2].min_y == 8);
+        ensure("updateRegions 4x4 blocks: request[2] max_y", gMapBlockRequests[2].max_y == 11);
+        ensure("updateRegions 4x4 blocks: request[3] min_y", gMapBlockRequests[3].min_y == 12);
+        ensure("updateRegions 4x4 blocks: request[3] max_y", gMapBlockRequests[3].max_y == 15);
     }
 }


### PR DESCRIPTION
- Instead of always requesting 4x4 regions in a single block, adjust request to get up to 64 regions per message (4 blocks)
- Don't request 'animated' regions, they won't arrive in time.