### PR TITLE
#5569 Potential fix for frequent disconnects

### DIFF
--- a/indra/newview/lleventpoll.cpp
+++ b/indra/newview/lleventpoll.cpp
@@ -73,9 +73,9 @@ namespace Details
     // We will wait RETRY_SECONDS + (errorCount * RETRY_SECONDS_INC) before retrying after an error.
     // This means we attempt to recover relatively quickly but back off giving more time to recover
     // until we finally give up after MAX_EVENT_POLL_HTTP_ERRORS attempts.
-    constexpr F32 EVENT_POLL_ERROR_RETRY_SECONDS = 15.f; // ~ half of a normal timeout.
-    constexpr F32 EVENT_POLL_ERROR_RETRY_SECONDS_INC = 5.f; // ~ half of a normal timeout.
-    constexpr S32 MAX_EVENT_POLL_HTTP_ERRORS = 10; // ~5 minutes, by the above rules.
+    constexpr F32 EVENT_POLL_ERROR_RETRY_SECONDS = 1.f;
+    constexpr F32 EVENT_POLL_ERROR_RETRY_SECONDS_INC = 3.f;
+    constexpr S32 MAX_EVENT_POLL_HTTP_ERRORS = 15; // ~5 minutes, by the above rules.
     constexpr F64 MIN_SECONDS_PASSED = 10.0; // Minimum time we expect the server to hold the request.
 
     int LLEventPollImpl::sNextCounter = 1;
@@ -248,12 +248,13 @@ namespace Details
                 if (errorCount < MAX_EVENT_POLL_HTTP_ERRORS)
                 {   // An unanticipated error has been received from our poll
                     // request. Calculate a timeout and wait for it to expire(sleep)
-                    // before trying again.  The sleep time is increased by 5 seconds
+                    // before trying again.  The sleep time is increased by 3 seconds
                     // for each consecutive error.
-                    ++errorCount;
 
                     F32 waitToRetry = EVENT_POLL_ERROR_RETRY_SECONDS
                         + errorCount * EVENT_POLL_ERROR_RETRY_SECONDS_INC;
+
+                    ++errorCount;
 
                     LL_WARNS("LLEventPollImpl") << "<" << counter << "> Retrying in " << waitToRetry <<
                         " seconds, error count is now " << errorCount << LL_ENDL;


### PR DESCRIPTION
According to firestorm's investigation #4685's removal of http level retries negatively affects disconnects.

Removal is still nessesary to not cause increasing wait time for legal timeout 'errors'. To compensate for the removal, increase retry count and decrease delay for unexpected errors.