### PR TITLE
p#564 Remake nsis to velopack update flow

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -4237,16 +4237,16 @@
       <key>Value</key>
       <string>0.0.0</string>
     </map>
-    <key>LastInstallVersion</key>
+    <key>PreviousInstallChecked</key>
     <map>
         <key>Comment</key>
-        <string>Version number of last instance of the viewer that you installed</string>
+        <string>Whether viewer checked previous install on the same channel for NSIS</string>
         <key>Persist</key>
         <integer>1</integer>
         <key>Type</key>
-        <string>String</string>
+        <string>Boolean</string>
         <key>Value</key>
-        <string></string>
+        <string>0</string>
     </map>
     <key>LimitDragDistance</key>
     <map>

--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -443,9 +443,10 @@ int APIENTRY WINMAIN(HINSTANCE hInstance,
         LLControlGroup settings("global");
         if (settings.loadFromFile(user_settings_path))
         {
-            if (settings.controlExists("LastInstallVersion"))
+            // If user reinstalls or updates, we want to recheck for nsis leftovers.
+            if (settings.controlExists("PreviousInstallChecked"))
             {
-                settings.setString("LastInstallVersion", std::string());
+                settings.setBOOL("PreviousInstallChecked", false);
             }
             settings.saveToFile(user_settings_path, true);
         }

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -2619,14 +2619,12 @@ void release_notes_coro(const std::string url)
 void uninstall_nsis_if_required()
 {
 #if LL_VELOPACK && LL_WINDOWS
-    std::string last_install_ver = gSavedSettings.getString("LastInstallVersion");
-    if (!last_install_ver.empty())
+    bool checked_for_legacy_install = gSavedSettings.getBOOL("PreviousInstallChecked");
+    if (checked_for_legacy_install)
     {
         return;
     }
-    LLVersionInfo* ver_inst = LLVersionInfo::getInstance();
-    gSavedSettings.setString("LastInstallVersion",
-        ver_inst->getChannelAndVersion());
+    gSavedSettings.setBOOL("PreviousInstallChecked", true);
 
     LL_INFOS() << "Looking for previous NSIS installs" << LL_ENDL;
 
@@ -2639,6 +2637,8 @@ void uninstall_nsis_if_required()
     {
         return;
     }
+
+    LLVersionInfo* ver_inst = LLVersionInfo::getInstance();
 
     if (found_major > ver_inst->getMajor())
     {
@@ -2660,8 +2660,10 @@ void uninstall_nsis_if_required()
         LL_INFOS() << "Found installed nsis version that is newer" << found_major << "." << found_minor << "." << found_patch << "." << found_build << LL_ENDL;
         return;
     }
+
     // Assume that nsis is going to be something like x.x.x, while velopack is x.x.(x+1),
     // so there is no point to check build.
+    LL_INFOS() << "Found NSIS install " << found_major << "." << found_minor << "." << found_patch << "." << found_build << LL_ENDL;
 
     clear_nsis_links();
 

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -2628,66 +2628,46 @@ void uninstall_nsis_if_required()
     gSavedSettings.setString("LastInstallVersion",
         ver_inst->getChannelAndVersion());
 
-    if (LLNotifications::instance().getIgnored("PromptRemoveNsisInstallation"))
-    {
-        // By default 'ignore' returns default button, which is uninstall
-        // for PromptRemoveNsisInstallation, but while we want the button
-        // to be the default, we don't want a scary UAC without a notice
-        // as a default action, so if this notification is ignored,
-        // we will treat it as if user is going to cancel the uninstall.
-        return;
-    }
-
     LL_INFOS() << "Looking for previous NSIS installs" << LL_ENDL;
 
-    wchar_t buffer[MAX_PATH];
-    if (!get_nsis_uninstaller_path( buffer,
-                                    MAX_PATH,
-                                    ver_inst->getMajor(),
-                                    ver_inst->getMinor(),
-                                    ver_inst->getPatch(),
-                                    ver_inst->getBuild())
-        )
+    S32 found_major = 0;
+    S32 found_minor = 0;
+    S32 found_patch = 0;
+    U64 found_build = 0;
+
+    if (!get_nsis_version(found_major, found_minor, found_patch, found_build))
     {
         return;
     }
 
-    // Clean legacy links regardless of whether we will proceed with uninstall or not.
+    if (found_major > ver_inst->getMajor())
+    {
+        LL_INFOS() << "Found installed nsis version that is newer" << found_major << "." << found_minor << "." << found_patch << "." << found_build << LL_ENDL;
+        return;
+    }
+
+    if (found_major == ver_inst->getMajor()
+        && found_minor > ver_inst->getMinor())
+    {
+        LL_INFOS() << "Found installed nsis version that is newer" << found_major << "." << found_minor << "." << found_patch << "." << found_build << LL_ENDL;
+        return;
+    }
+
+    if (found_major == ver_inst->getMajor()
+        && found_minor == ver_inst->getMinor()
+        && found_patch > ver_inst->getPatch())
+    {
+        LL_INFOS() << "Found installed nsis version that is newer" << found_major << "." << found_minor << "." << found_patch << "." << found_build << LL_ENDL;
+        return;
+    }
+    // Assume that nsis is going to be something like x.x.x, while velopack is x.x.(x+1),
+    // so there is no point to check build.
+
     clear_nsis_links();
 
-    // Compose command line: "<uninstaller_path>" /S /clearreg
-    std::wstring params = L"\"";
-    params += buffer;
-    params += L"\"";
-    // params += L" /S /clearreg"; // silent uninstall and clear registry entries
-
-    LLNotificationsUtil::add("PromptRemoveNsisInstallation", LLSD(), LLSD(),
-        [params](const LLSD& notification, const LLSD& response)
-    {
-        S32 option = LLNotificationsUtil::getSelectedOption(notification, response);
-        if (option == 1) // cancel
-        {
-            return;
-        }
-
-        LL_INFOS() << "Triggering NSIS uninstall from " << ll_convert_wide_to_string(params) << LL_ENDL;
-
-        // Launch uninstaller using explorer.exe
-        SHELLEXECUTEINFOW sei = { 0 };
-        sei.cbSize = sizeof(sei);
-        sei.fMask = SEE_MASK_DEFAULT;
-        sei.hwnd = NULL;
-        sei.lpVerb = L"runas"; // Request elevation
-        sei.lpFile = L"explorer.exe";
-        sei.lpParameters = params.c_str();
-
-        sei.nShow = SW_HIDE;
-
-        if (!ShellExecuteExW(&sei))
-        {
-            LL_WARNS("AppInit") << "Failed to launch NSIS uninstaller, error code: " << GetLastError() << LL_ENDL;
-        }
-    });
+    LLSD args;
+    args["VERSION"] = llformat("%d.%d.%d", found_major, found_minor, found_patch);
+    LLNotificationsUtil::add("FoundLegacyNsisInstallation", args);
 #endif
 }
 

--- a/indra/newview/llvelopack.cpp
+++ b/indra/newview/llvelopack.cpp
@@ -458,7 +458,11 @@ static void parse_version(const wchar_t* version_str, int& major, int& minor, in
     swscanf(version_str, L"%d.%d.%d.%llu", &major, &minor, &patch, &build);
 }
 
-bool get_nsis_uninstaller_path(wchar_t* path_buffer, DWORD bufSize, S32 cur_major_ver, S32 cur_minor_ver, S32 cur_patch_ver, U64 cur_build_ver)
+bool get_nsis_version(
+    int& nsis_major,
+    int& nsis_minor,
+    int& nsis_patch,
+    uint64_t& nsis_build)
 {
     // Test for presence of NSIS viewer registration, then
     // attempt to read uninstall info
@@ -483,23 +487,12 @@ bool get_nsis_uninstaller_path(wchar_t* path_buffer, DWORD bufSize, S32 cur_majo
         return false;
     }
 
-    int nsis_major = 0, nsis_minor = 0, nsis_patch = 0;
-    uint64_t nsis_build = 0;
     parse_version(version_buf, nsis_major, nsis_minor, nsis_patch, nsis_build);
 
-    // Compare numerically
-    if ((nsis_major > cur_major_ver) ||
-        (nsis_major == cur_major_ver && nsis_minor > cur_minor_ver) ||
-        (nsis_major == cur_major_ver && nsis_minor == cur_minor_ver && nsis_patch > cur_patch_ver) ||
-         // Assume that bigger build number means newer version, which is not always true but works for our purposes
-        (nsis_major == cur_major_ver && nsis_minor == cur_minor_ver && nsis_patch == cur_patch_ver && nsis_build > cur_build_ver))
-    {
-        LL_INFOS() << "Found installed nsis version that is newer" << nsis_major << "." << nsis_minor << "." << nsis_patch << LL_ENDL;
-        RegCloseKey(hkey);
-        return false;
-    }
-
-    LONG rv = RegGetValueW(hkey, nullptr, L"UninstallString", RRF_RT_REG_SZ, &type, path_buffer, &bufSize);
+    // Make sure it actually exists and not a dead entry.
+    wchar_t path_buffer[MAX_PATH] = { 0 };
+    DWORD path_buf_size = sizeof(path_buffer);
+    LONG rv = RegGetValueW(hkey, nullptr, L"UninstallString", RRF_RT_REG_SZ, &type, path_buffer, &path_buf_size);
     RegCloseKey(hkey);
     if (rv != ERROR_SUCCESS)
     {

--- a/indra/newview/llvelopack.h
+++ b/indra/newview/llvelopack.h
@@ -47,7 +47,11 @@ void velopack_cleanup();
 
 #if LL_WINDOWS
 void clear_nsis_links();
-bool get_nsis_uninstaller_path(wchar_t* path_buffer, DWORD bufSize, S32 cur_major_ver, S32 cur_minor_ver, S32 cur_patch_ver, U64 cur_build_ver);
+bool get_nsis_version(
+    int& nsis_major,
+    int& nsis_minor,
+    int& nsis_patch,
+    uint64_t& nsis_build);
 #endif
 
 #endif // LL_VELOPACK

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -202,17 +202,12 @@ No tutorial is currently available.
 
   <notification
    icon="alertmodal.tga"
-   name="PromptRemoveNsisInstallation"
+   name="FoundLegacyNsisInstallation"
    type="alertmodal">
-[APP_NAME] found an installation from an older version. Do you want to uninstall the previous version now?
-
-The uninstaller may display additional prompts requesting permission to access or modify files on your disk.
-      <tag>confirm </tag>
-    <usetemplate
-     ignoretext="Ask to remove legacy installation"
-     name="okcancelignore"
-     notext="Cancel"
-     yestext="Uninstall"/>
+      [APP_NAME] found an installation of an older version [VERSION]. To uninstall the older version, please follow [https://community.secondlife.com/knowledgebase/english/how-to-uninstall-and-reinstall-second-life-r524 this manual].
+      <usetemplate
+       name="okbutton"
+       yestext="OK"/>
   </notification>
 
   <notification


### PR DESCRIPTION
We can't remake released nsis builds, and nsis builds have couple issues that velopack triggered uninstall can't avoid, clear links and guide user to a knowledge base page instead.

Since 'ignore' logic was removed, make message less spammy by only triggering the check after an install/update.