### PR TITLE
Support for metadata and script subtype.

### DIFF
--- a/indra/llinventory/llinventory.cpp
+++ b/indra/llinventory/llinventory.cpp
@@ -134,7 +134,7 @@ bool LLInventoryObject::getIsFavorite() const
     return mFavorite;
 }
 
-std::string LLInventoryObject::getRuntime() const
+const std::string& LLInventoryObject::getRuntime() const
 {
     return mRuntime;
 }

--- a/indra/llinventory/llinventory.cpp
+++ b/indra/llinventory/llinventory.cpp
@@ -1535,14 +1535,7 @@ bool LLInventoryCategory::importLegacyStream(std::istream& input_stream)
             {
                 setFavorite(false);
             }
-            if (metadata.has("script") && metadata["script"].has("runtime"))
-            {
-                setRuntime(metadata["script"]["runtime"].asString());
-            }
-            else
-            {
-                setRuntime(std::string());
-            }
+            setRuntime(std::string());
 
         }
         else

--- a/indra/llinventory/llinventory.cpp
+++ b/indra/llinventory/llinventory.cpp
@@ -200,19 +200,21 @@ void LLInventoryObject::setFavorite(bool favorite)
 
 void LLInventoryObject::setRuntime(std::string_view runtime)
 {
-    if (getType() == LLAssetType::AT_LSL_TEXT)
-    {
-        mRuntime = runtime;
-    }
-    else
-    {
-        mRuntime.clear();
-    }
+    // Store the runtime unconditionally; it will be validated/cleared
+    // when the final asset type is known (see setType()).
+    mRuntime = runtime;
 }
 
 void LLInventoryObject::setType(LLAssetType::EType type)
 {
     mType = type;
+
+    // Only LSL text assets are expected to have a runtime; clear any
+    // previously stored runtime for other asset types.
+    if (mType != LLAssetType::AT_LSL_TEXT)
+    {
+        mRuntime.clear();
+    }
 }
 
 
@@ -1104,6 +1106,12 @@ bool LLInventoryItem::fromLLSD(const LLSD& sd, bool is_new)
             if (script_map.has(w))
             {
                 mRuntime = script_map[w].asString();
+            }
+            else
+            {
+                // Clear any stale runtime when a script block is present
+                // but no explicit runtime value is provided.
+                mRuntime.clear();
             }
             continue;
         }

--- a/indra/llinventory/llinventory.cpp
+++ b/indra/llinventory/llinventory.cpp
@@ -61,6 +61,8 @@ static const std::string INV_SALE_INFO_LABEL("sale_info");
 static const std::string INV_FLAGS_LABEL("flags");
 static const std::string INV_CREATION_DATE_LABEL("created_at");
 static const std::string INV_TOGGLED_LABEL("toggled");
+static const std::string INV_SCRIPT_LABEL("script");
+static const std::string INV_RUNTIME_LABEL("runtime");
 
 // key used by agent-inventory-service
 static const std::string INV_ASSET_TYPE_LABEL_WS("type_default");
@@ -109,6 +111,7 @@ void LLInventoryObject::copyObject(const LLInventoryObject* other)
     mName = other->mName;
     mThumbnailUUID = other->mThumbnailUUID;
     mFavorite = other->mFavorite;
+    mRuntime = other->mRuntime;
 }
 
 const LLUUID& LLInventoryObject::getUUID() const
@@ -129,6 +132,11 @@ const LLUUID& LLInventoryObject::getThumbnailUUID() const
 bool LLInventoryObject::getIsFavorite() const
 {
     return mFavorite;
+}
+
+std::string LLInventoryObject::getRuntime() const
+{
+    return mRuntime;
 }
 
 const std::string& LLInventoryObject::getName() const
@@ -188,6 +196,18 @@ void LLInventoryObject::setThumbnailUUID(const LLUUID& thumbnail_uuid)
 void LLInventoryObject::setFavorite(bool favorite)
 {
     mFavorite = favorite;
+}
+
+void LLInventoryObject::setRuntime(std::string_view runtime)
+{
+    if (getType() == LLAssetType::AT_LSL_TEXT)
+    {
+        mRuntime = runtime;
+    }
+    else
+    {
+        mRuntime.clear();
+    }
 }
 
 void LLInventoryObject::setType(LLAssetType::EType type)
@@ -278,6 +298,15 @@ bool LLInventoryObject::importLegacyStream(std::istream& input_stream)
             else
             {
                 setFavorite(false);
+            }
+
+            if (metadata.has("script") && metadata["script"].has("runtime"))
+            {
+                setRuntime(metadata["script"]["runtime"].asString());
+            }
+            else
+            {
+                setRuntime(std::string());
             }
         }
         else if(0 == strcmp("name", keyword))
@@ -421,6 +450,7 @@ void LLInventoryItem::copyItem(const LLInventoryItem* other)
     mInventoryType = other->mInventoryType;
     mFlags = other->mFlags;
     mCreationDate = other->mCreationDate;
+    mRuntime = other->mRuntime;
 }
 
 // If this is a linked item, then the UUID of the base object is
@@ -784,6 +814,16 @@ bool LLInventoryItem::importLegacyStream(std::istream& input_stream)
             {
                 setFavorite(false);
             }
+
+            if (metadata.has("script") && metadata["script"].has("runtime"))
+            {
+                setRuntime(metadata["script"]["runtime"].asString());
+            }
+            else
+            {
+                setRuntime(std::string());
+            }
+
         }
         else if(0 == strcmp("inv_type", keyword))
         {
@@ -949,6 +989,11 @@ void LLInventoryItem::asLLSD( LLSD& sd ) const
         sd[INV_FAVORITE_LABEL] = LLSD().with(INV_TOGGLED_LABEL, mFavorite);
     }
 
+    if (!mRuntime.empty())
+    {
+        sd[INV_SCRIPT_LABEL] = LLSD().with(INV_RUNTIME_LABEL, mRuntime);
+    }
+
     U32 mask = mPermissions.getMaskBase();
     if(((mask & PERM_ITEM_UNRESTRICTED) == PERM_ITEM_UNRESTRICTED)
         || (mAssetUUID.isNull()))
@@ -1048,6 +1093,17 @@ bool LLInventoryItem::fromLLSD(const LLSD& sd, bool is_new)
             if (favorite_map.has(w))
             {
                 mFavorite = favorite_map[w].asBoolean();
+            }
+            continue;
+        }
+
+        if (i->first == INV_SCRIPT_LABEL)
+        {
+            const LLSD& script_map = i->second;
+            const std::string w = INV_RUNTIME_LABEL;
+            if (script_map.has(w))
+            {
+                mRuntime = script_map[w].asString();
             }
             continue;
         }
@@ -1471,6 +1527,15 @@ bool LLInventoryCategory::importLegacyStream(std::istream& input_stream)
             {
                 setFavorite(false);
             }
+            if (metadata.has("script") && metadata["script"].has("runtime"))
+            {
+                setRuntime(metadata["script"]["runtime"].asString());
+            }
+            else
+            {
+                setRuntime(std::string());
+            }
+
         }
         else
         {

--- a/indra/llinventory/llinventory.h
+++ b/indra/llinventory/llinventory.h
@@ -72,6 +72,7 @@ public:
     const LLUUID& getParentUUID() const;
     virtual const LLUUID& getThumbnailUUID() const;
     virtual bool getIsFavorite() const;
+    virtual std::string getRuntime() const;
     virtual const std::string& getName() const;
     virtual LLAssetType::EType getType() const;
     LLAssetType::EType getActualType() const; // bypasses indirection for linked items
@@ -88,6 +89,7 @@ public:
     void setParent(const LLUUID& new_parent);
     virtual void setThumbnailUUID(const LLUUID& thumbnail_uuid);
     virtual void setFavorite(bool favorite);
+    virtual void setRuntime(std::string_view runtime);
     void setType(LLAssetType::EType type);
     virtual void setCreationDate(time_t creation_date_utc); // only stored for items
 
@@ -114,6 +116,7 @@ protected:
     LLUUID mParentUUID; // Parent category.  Root categories have LLUUID::NULL.
     LLUUID mThumbnailUUID;
     bool mFavorite;
+    std::string mRuntime;
     LLAssetType::EType mType;
     std::string mName;
     time_t mCreationDate; // seconds from 1/1/1970, UTC

--- a/indra/llinventory/llinventory.h
+++ b/indra/llinventory/llinventory.h
@@ -72,7 +72,7 @@ public:
     const LLUUID& getParentUUID() const;
     virtual const LLUUID& getThumbnailUUID() const;
     virtual bool getIsFavorite() const;
-    virtual std::string getRuntime() const;
+    virtual const std::string& getRuntime() const;
     virtual const std::string& getName() const;
     virtual LLAssetType::EType getType() const;
     LLAssetType::EType getActualType() const; // bypasses indirection for linked items

--- a/indra/newview/llpreviewscript.cpp
+++ b/indra/newview/llpreviewscript.cpp
@@ -521,7 +521,6 @@ bool LLScriptEdCore::postBuild()
         "menu_lsl_font_size.xml", gMenuHolder, LLViewerMenuHolderGL::child_registry_t::instance());
     getChild<LLMenuButton>("font_btn")->setMenu(context_menu, LLMenuButton::MP_BOTTOM_LEFT, true);
 
-
     bool lua_scripts_enabled = have_lua_enabled(LLUUID::null);
     mCompileTarget = getChild<LLComboBox>("compile_target");
     if (LLScrollListItem* luau_item = mCompileTarget->findItemByValue("luau"))
@@ -2058,7 +2057,9 @@ void LLPreviewLSL::saveIfNeeded(bool sync /*= true*/)
 
 void LLPreviewLSL::onCompileTargetChanged()
 {
-    mScriptEd->processKeywords(mScriptEd->mCompileTarget->getValue().asString() == "luau");
+    bool is_lua = (mScriptEd->mCompileTarget->getValue().asString() == "luau");
+    mScriptEd->mEditor->setLuauLanguage(is_lua);
+    mScriptEd->processKeywords(is_lua);
 }
 
 // static
@@ -2087,6 +2088,8 @@ void LLPreviewLSL::onLoadComplete(const LLUUID& asset_uuid, LLAssetType::EType t
             std::string script_name = DEFAULT_SCRIPT_NAME;
             LLInventoryItem* item = gInventory.getItem(*item_uuid);
             bool is_modifiable = false;
+            std::string compile_target;
+            bool is_lua = false;
             if (item)
             {
                 if (!item->getName().empty())
@@ -2097,16 +2100,38 @@ void LLPreviewLSL::onLoadComplete(const LLUUID& asset_uuid, LLAssetType::EType t
                 {
                     is_modifiable = true;
                 }
+
+                // subtype is the language that the script is written in,
+                // runtime is the VM that the script is running on.
+                // LSL scripts have 3 possible runtimes: "lsl2", "mono", and "luau".
+                // Lua scripts have 1 runtime: "luau".
+                U8          subtype = item->getInventorySubType();
+                std::string runtime = item->getRuntime();
+
+                is_lua = (subtype == SST_LUA);
+                if (!is_lua && (runtime == "luau"))
+                {   // an lsl script executing on the luau runtime
+                    compile_target = "lsl-luau";
+                }
+                else
+                {   // otherwise, use the runtime as the compile target
+                    // (this may be blank if the script has never been compiled)
+                    compile_target = runtime;
+                }
             }
+
+            if (compile_target.empty())
+            {
+                compile_target = is_lua ? "luau" : "mono";
+            }
+
             preview->mScriptEd->setScriptName(script_name);
             preview->mScriptEd->setEnableEditing(is_modifiable);
             preview->mScriptEd->setAssetID(asset_uuid);
             preview->mAssetStatus = PREVIEW_ASSET_LOADED;
 
-            // Temporary hack to determine if the script is LSL or SLua when loaded from the inventory.
-            bool is_lua = is_lua_script(std::string(buffer.begin(), buffer.end()));
+            preview->mScriptEd->mCompileTarget->setValue(compile_target);
             preview->mScriptEd->mEditor->setLuauLanguage(is_lua);
-            preview->mScriptEd->mCompileTarget->setValue(is_lua ? "luau" : "lsl-luau");
             preview->mScriptEd->processKeywords(is_lua);
         }
         else

--- a/indra/newview/llpreviewscript.cpp
+++ b/indra/newview/llpreviewscript.cpp
@@ -2739,8 +2739,9 @@ void LLLiveLSLEditor::onCompileTargetChanged()
 {
     mScriptEd->mCompileTarget->setEnabled(have_script_upload_cap(mObjectUUID));
     mScriptEd->enableSave(getIsModifiable());
-
-    mScriptEd->processKeywords(mScriptEd->mCompileTarget->getValue().asString() == "luau");
+    bool is_lua = mScriptEd->mCompileTarget->getValue().asString() == "luau";
+    mScriptEd->mEditor->setLuauLanguage(is_lua);
+    mScriptEd->processKeywords(is_lua);
 }
 
 void LLLiveLSLEditor::setAssociatedExperience( LLHandle<LLLiveLSLEditor> editor, const LLSD& experience )


### PR DESCRIPTION
## Description

Uses script subtype (LSL/lua) and new script.runtime metadata to select correct language parser and default compile target in editor. 

Issue #4840 

## Depends On
https://github.com/secondlife/agent-inventory-service/pull/77
https://github.com/secondlife/server/pull/2414
