### PR TITLE
#3420 CreateLandmarkForPosition floater fails to save descriptions

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_create_landmark.xml
+++ b/indra/newview/skins/default/xui/en/floater_create_landmark.xml
@@ -87,7 +87,7 @@
      name="notes_editor"
      spellcheck="true"
      text_readonly_color="white"
-     prevalidator="ascii_with_newline"
+     prevalidator="ascii"
      commit_on_focus_lost="true"
      top_pad="5"
      width="290"


### PR DESCRIPTION
Description field isn't supposed to hold newline.