### PR TITLE
#5346 Resolve duplicated window class name

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -387,17 +387,6 @@ const std::string ERROR_MARKER_FILE_NAME("SecondLife.error_marker");
 const std::string LOGOUT_MARKER_FILE_NAME("SecondLife.logout_marker");
 static std::string gLaunchFileOnQuit;
 
-// Used on Win32 for other apps to identify our window (eg, win_setup)
-#if LL_VELOPACK
-// Velopack is deliberately different fron NSIS to not prevent nsis uninstall
-const char* const VIEWER_WINDOW_CLASSNAME = "Second\u00A0Life"; // no break space
-#else
-// NSIS relies on this to detect if viewer is up.
-// NSIS's method is somewhat unreliable since window
-// can close long before cleanup is done
-const char* const VIEWER_WINDOW_CLASSNAME = "Second Life";
-#endif
-
 //----------------------------------------------------------------------------
 
 // List of entries from strings.xml to always replace
@@ -3118,7 +3107,7 @@ bool LLAppViewer::initWindow()
     LLViewerWindow::Params window_params;
     window_params
         .title(gWindowTitle)
-        .name(VIEWER_WINDOW_CLASSNAME)
+        .name(sWindowClass)
         .x(gSavedSettings.getS32("WindowX"))
         .y(gSavedSettings.getS32("WindowY"))
         .width(gSavedSettings.getU32("WindowWidth"))

--- a/indra/newview/llappviewer.h
+++ b/indra/newview/llappviewer.h
@@ -284,6 +284,14 @@ protected:
 
     virtual void sendOutOfDiskSpaceNotification();
 
+protected:
+
+    // NSIS relies on this to detect if viewer is up.
+    // NSIS's method is somewhat unreliable since window
+    // can close long before cleanup is done.
+    // sendURLToOtherInstance also relies on this to detect if viewer is up.
+    static constexpr const char* sWindowClass = "Second Life";
+
 private:
 
     bool doFrame();

--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -225,7 +225,6 @@ LONG WINAPI catchallCrashHandler(EXCEPTION_POINTERS * /*ExceptionInfo*/)
     return 0;
 }
 
-const std::string LLAppViewerWin32::sWindowClass = "Second Life";
 
 /*
     This function is used to print to the command line a text message
@@ -963,7 +962,7 @@ bool LLAppViewerWin32::restoreErrorTrap()
 bool LLAppViewerWin32::sendURLToOtherInstance(const std::string& url)
 {
     wchar_t window_class[256]; /* Flawfinder: ignore */   // Assume max length < 255 chars.
-    mbstowcs(window_class, sWindowClass.c_str(), 255);
+    mbstowcs(window_class, sWindowClass, 255);
     window_class[255] = 0;
     // Use the class instead of the window name.
     HWND other_window = FindWindow(window_class, NULL);

--- a/indra/newview/llappviewerwin32.h
+++ b/indra/newview/llappviewerwin32.h
@@ -59,8 +59,6 @@ protected:
 
     std::string generateSerialNumber();
 
-    static const std::string sWindowClass;
-
 private:
     void disableWinErrorReporting();
 


### PR DESCRIPTION
Mismatch in class names was causing issues for sendURLToOtherInstance.

Separate class name is no longer needed for velopack since we are no longer expected to triggger uninstall of nsis from velopack.