### PR TITLE
#5447 update Dialog buttons to correctly display emoji

### DIFF
--- a/indra/newview/lltoastnotifypanel.cpp
+++ b/indra/newview/lltoastnotifypanel.cpp
@@ -38,6 +38,7 @@
 #include "llnotifications.h"
 #include "lluiconstants.h"
 #include "llrect.h"
+#include "llstring.h"
 #include "lltrans.h"
 #include "llnotificationsutil.h"
 #include "llviewermessage.h"
@@ -90,8 +91,24 @@ LLButton* LLToastNotifyPanel::createButton(const LLSD& form_element, bool is_opt
     std::string name = form_element["name"].asString();
     std::string text = form_element["text"].asString();
     bool make_small_btn = index == -1 || index == -2; // for block and ignore buttons in script dialog
+
+    // Use Emoji font as exception if text contains red heart emoji (10084 U+2764) to ensure proper rendering
+    std::string font_name = mIsScriptDialog ? sFontScript : sFontDefault;
+    if (mIsScriptDialog)
+    {
+        LLWString wtext = utf8str_to_wstring(text);
+        for (llwchar ch : wtext)
+        {
+            if (ch == 0x2764)
+            {
+                font_name = "Emoji";
+                break;
+            }
+        }
+    }
+
     const LLFontGL* font = LLFontGL::getFont(LLFontDescriptor(
-        mIsScriptDialog ? sFontScript : sFontDefault, make_small_btn ? "Small" : "Medium", 0));
+        font_name, make_small_btn ? "Small" : "Medium", 0));
     p.name = name;
     p.label = text;
     p.tool_tip = text;


### PR DESCRIPTION
According to discussions in https://github.com/secondlife/viewer/issues/944 we don't want to turn all special UTF-8 characters (pseudo-emojis) into emojis in this dialog for consistency. 
So let's make exception just for red heart emoji(10084).