### PR TITLE
Initialize LLJointData support category from avatar skeleton

### DIFF
--- a/indra/llappearance/llavatarappearance.cpp
+++ b/indra/llappearance/llavatarappearance.cpp
@@ -1698,6 +1698,7 @@ void LLAvatarSkeletonInfo::getJointMatricesAndHierarhy(
     data.mRestMatrix = parent_mat * data.mJointMatrix;
     data.mIsJoint = bone_info->mIsJoint;
     data.mGroup = bone_info->mGroup;
+    data.setSupport(bone_info->mSupport);
     for (LLAvatarBoneInfo* child_info : bone_info->mChildren)
     {
         LLJointData& child_data = data.mChildren.emplace_back();


### PR DESCRIPTION
## Description

The glTF importer branches on `LLJointData::mSupport` when it decides whether a collision volume should inherit the regular parent rest matrix or the support-rest matrix.

That support category was parsed from the avatar skeleton XML, but it was not copied into `LLJointData` when the viewer skeleton metadata was expanded for importer use. As a result, the glTF importer could make that decision on undefined state.

This change initializes `LLJointData::mSupport` from `bone_info->mSupport` in `getJointMatricesAndHierarhy()`.

Why this change is scoped this way:
- it does not alter the skeleton definition itself
- it does not introduce new importer behavior
- it makes the existing support-chain logic operate on defined data

## Related Issues

Issue Link: relates to the glTF collision volume import issue discussed in the associated Second Life Feedback/Jira report at https://feedback.secondlife.com/bug-reports/p/differences-between-collada-and-glb-imports

## Checklist

- [x] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the contributing guidelines.

## Additional Notes

This is intentionally a narrow correctness fix. The goal is to remove one source of undefined behavior from the glTF collision-volume import path before larger behavioral fixes are considered.
