### PR TITLE
Fix glTF collision volume bind reconstruction

### DIFF
--- a/indra/llappearance/llavatarappearance.cpp
+++ b/indra/llappearance/llavatarappearance.cpp
@@ -1647,10 +1647,10 @@ glm::mat4 LLAvatarBoneInfo::getJointMatrix()
     glm::mat4 mat(1.0f);
     // 1. Scaling
     mat = glm::scale(mat, glm::vec3(mScale[0], mScale[1], mScale[2]));
-    // 2. Rotation (Euler angles rad)
-    mat = glm::rotate(mat, mRot[0], glm::vec3(1, 0, 0));
-    mat = glm::rotate(mat, mRot[1], glm::vec3(0, 1, 0));
-    mat = glm::rotate(mat, mRot[2], glm::vec3(0, 0, 1));
+    // 2. Rotation (avatar_skeleton.xml stores Euler angles in degrees)
+    mat = glm::rotate(mat, glm::radians(mRot[0]), glm::vec3(1, 0, 0));
+    mat = glm::rotate(mat, glm::radians(mRot[1]), glm::vec3(0, 1, 0));
+    mat = glm::rotate(mat, glm::radians(mRot[2]), glm::vec3(0, 0, 1));
     // 3. Position
     mat = glm::translate(mat, glm::vec3(mPos[0], mPos[1], mPos[2]));
     return mat;

--- a/indra/newview/gltf/llgltfloader.cpp
+++ b/indra/newview/gltf/llgltfloader.cpp
@@ -1551,6 +1551,12 @@ void LLGLTFLoader::buildOverrideMatrix(LLJointData& viewer_data, joints_data_map
         glm::quat rotation;
         glm::decompose(translated_joint, scale, rotation, translation_override, skew, perspective);
 
+        glm::mat4 viewer_rotation_scale(1.0f);
+        viewer_rotation_scale = glm::rotate(viewer_rotation_scale, glm::radians(viewer_data.mRotation[0]), glm::vec3(1, 0, 0));
+        viewer_rotation_scale = glm::rotate(viewer_rotation_scale, glm::radians(viewer_data.mRotation[1]), glm::vec3(0, 1, 0));
+        viewer_rotation_scale = glm::rotate(viewer_rotation_scale, glm::radians(viewer_data.mRotation[2]), glm::vec3(0, 0, 1));
+        viewer_rotation_scale = glm::scale(viewer_rotation_scale, viewer_data.mScale);
+
         // Viewer allows overrides, which are base joint with applied translation override.
         // fortunately normal bones use only translation, without rotation or scale
         node.mOverrideMatrix = glm::recompose(glm::vec3(1, 1, 1), glm::identity<glm::quat>(), translation_override, glm::vec3(0, 0, 0), glm::vec4(0, 0, 0, 1));
@@ -1566,13 +1572,14 @@ void LLGLTFLoader::buildOverrideMatrix(LLJointData& viewer_data, joints_data_map
         }
         else
         {
-            // This is likely incomplete or even wrong.
-            // Viewer Collision bones specify rotation and scale.
-            // Importer should apply rotation and scale to this matrix and save as needed
-            // then subsctruct them from bind matrix
-            // Todo: get models that use collision bones, made by different programs
-
-            overriden_joint = glm::scale(overriden_joint, viewer_data.mScale);
+            // Collision volumes need the imported translation override, but
+            // their local rotation-scale basis must come from the raw viewer
+            // skeleton XML values. For non-uniform torso volumes, matching DAE
+            // requires viewer rotation followed by viewer scale.
+            overriden_joint = viewer_rotation_scale;
+            overriden_joint[3][0] = translation_override.x;
+            overriden_joint[3][1] = translation_override.y;
+            overriden_joint[3][2] = translation_override.z;
             node.mOverrideRestMatrix = parent_support_rest * overriden_joint;
         }
     }


### PR DESCRIPTION
## Description

The glTF importer rebuilt collision-volume override-rest matrices from the imported translation override and viewer-side scale only. That dropped the collision-volume rotation defined in `avatar_skeleton.xml` and produced incorrect inverse bind matrices for rotated collision volumes, especially torso volumes that use non-uniform scale.

The visible result was a mismatch between rigged mesh imported from `.glb` and the equivalent `.dae` upload.

This change fixes that in two places:

- `LLAvatarBoneInfo::getJointMatrix()` now interprets `avatar_skeleton.xml` Euler joint rotations as degrees.
- `LLGLTFLoader::buildOverrideMatrix()` now rebuilds collision-volume local rotation/scale directly from the raw viewer skeleton rotation and scale values, then applies the imported local translation override.

Regular joints stay on the existing translation-only override path, and alternate-bind translation handling is unchanged.

Why this is scoped this way:
- the issue is specific to collision volumes
- normal avatar joints were already importing correctly
- torso collision volumes use non-uniform scale, so the rotation/scale composition needs to match the viewer skeleton definition instead of being reduced to translation plus scale only

With the collision-volume basis restored, the final glTF import matches the working DAE path in local validation.

## Related Issues

Issue Link: relates to the glTF collision volume import issue discussed in the associated Second Life Feedback/Jira report at https://feedback.secondlife.com/bug-reports/p/differences-between-collada-and-glb-imports

## Checklist

- [x] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the contributing guidelines.

## Additional Notes

Local validation compared `.glb` and `.dae` imports of the same rigged mesh with deforming collision volumes. Before this change, glTF imports showed visible torso/chest deviations. After this change, the glTF import matched the DAE import in those cases.
