### PR TITLE
secondlife/viewer#5634: Apply version string from janus server if available. Also display the type of connection the version is applicable to.

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -343,6 +343,39 @@ const LLVoiceVersionInfo& LLWebRTCVoiceClient::getVersion()
     return mVoiceVersion;
 }
 
+// --------------------------------------------------
+
+void LLWebRTCVoiceClient::updateVersion()
+{
+    sessionStatePtr_t session = mNextSession.get() ? mNextSession : mSession;
+
+    if (session)
+    {
+        // A WebRTC session can be connected to multiple servers at once. To more easily disambiguate which server version is being printed, show the connection type. In most cases, this shouldn't matter and the Janus version should be the same for all connections. Janus versions are also logged for each connection.
+        mVoiceVersion.serverVersion = session->getVersion();
+        if (session->isCallbackPossible())
+        {
+            mVoiceVersion.mBuildVersion = "ad-hoc";
+        }
+        else if (session->isEstate())
+        {
+            mVoiceVersion.mBuildVersion = "estate";
+        }
+        else if (session->isSpatial())
+        {
+            mVoiceVersion.mBuildVersion = "parcel";
+        }
+        else
+        {
+            mVoiceVersion.mBuildVersion = mVoiceVersion.serverVersion;
+        }
+    }
+    else
+    {
+        mVoiceVersion.serverVersion = mVoiceVersion.mBuildVersion = "";
+    }
+}
+
 //---------------------------------------------------
 
 void LLWebRTCVoiceClient::updateSettings()
@@ -2054,6 +2087,22 @@ void LLWebRTCVoiceClient::sessionState::revive()
     mShuttingDown = false;
 }
 
+const std::string LLWebRTCVoiceClient::sessionState::getVersion() const
+{
+    // Prefer the version of a primary connection which has already received a version string over the data channel. If that does not make sense, fall back to any non-empty version string we can find.
+    bool primary = true;
+    do
+    {
+        for (auto& connection : mWebRTCConnections) {
+            if (connection->isPrimary() == primary && connection->getVersion().length()) {
+                return connection->getVersion();
+            }
+        }
+        primary = !primary;
+    } while (!primary);
+    return "";
+}
+
 //=========================================================================
 // the following are methods to support the coroutine implementation of the
 // voice connection and processing.  They should only be called in the context
@@ -2249,6 +2298,11 @@ void LLWebRTCVoiceClient::deleteSession(const sessionStatePtr_t &session)
     if (deleteNextAudioSession)
     {
         mNextSession.reset();
+    }
+
+    if (!sShuttingDown)
+    {
+        updateVersion();
     }
 }
 
@@ -2623,6 +2677,10 @@ void LLVoiceWebRTCConnection::sendData(const std::string &data)
     {
         mWebRTCDataInterface->sendData(data, false);
     }
+}
+
+const std::string& LLVoiceWebRTCConnection::getVersion() {
+    return mServerVersion;
 }
 
 // Tell the simulator that we're shutting down a voice connection.
@@ -3048,6 +3106,7 @@ bool LLVoiceWebRTCConnection::connectionStateMachine()
 // An object where each key is an agent id.  (in the future, we may allow
 // integer indices into an agentid list, populated on join commands.  For size.
 // Each key will point to a json object with keys identifying what's updated.
+// 'V'  - voice server version (string)
 // 'p'  - audio source power (level/volume) (int8 as int)
 // 'j'  - object of join data (currently only a boolean 'p' marking a primary participant)
 // 'l'  - boolean, always true if exists.
@@ -3107,6 +3166,16 @@ void LLVoiceWebRTCConnection::OnDataReceivedImpl(const std::string &data, bool b
             }
 
             boost::json::object participant_obj = participant_elem.value().as_object();
+
+            if (participant_obj.contains("V") && participant_obj["V"].is_string() && agent_id == gAgentID)
+            {
+                // sendJoin was called on the connection. The voice server has responded with the new version string. Set it here.
+                mServerVersion = participant_obj["V"].as_string().c_str();
+                LLWebRTCVoiceClient::getInstance()->updateVersion();
+                LL_DEBUGS("Voice") << "Received version string \"" << participant_obj["V"].as_string().c_str()
+                                   << "\" for connection: primary=" << mPrimary << ", spatial=" << isSpatial()
+                                   << ", region=" << mRegionID << ", mChannelID=" << mChannelID << LL_ENDL;
+            }
 
             LLWebRTCVoiceClient::participantStatePtr_t participant =
                 LLWebRTCVoiceClient::getInstance()->findParticipantByID(mChannelID, agent_id);

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -80,6 +80,7 @@ public:
     static bool isShuttingDown() { return sShuttingDown; }
 
     const LLVoiceVersionInfo& getVersion() override;
+    void                      updateVersion();
 
     void updateSettings() override; // call after loading settings and whenever they change
 
@@ -285,6 +286,7 @@ public:
 
         void shutdownAllConnections();
         void revive();
+        const std::string getVersion() const;
 
         static void processSessionStates();
 
@@ -609,6 +611,7 @@ class LLVoiceWebRTCConnection :
 
     void sendJoin();
     void sendData(const std::string &data);
+    const std::string& getVersion();
 
     void processIceUpdates();
 
@@ -623,6 +626,7 @@ class LLVoiceWebRTCConnection :
     bool connectionStateMachine();
 
     virtual bool isSpatial() { return false; }
+    bool         isPrimary() const { return mPrimary; }
 
     LLUUID getRegionID() { return mRegionID; }
 
@@ -694,6 +698,7 @@ class LLVoiceWebRTCConnection :
     bool   mPrimary;
     LLUUID mViewerSession;
     std::string mChannelID;
+    std::string mServerVersion;
 
     std::string mChannelSDP;
     std::string mRemoteChannelSDP;


### PR DESCRIPTION
## Description

This adds the janus version string to About > Secondlife if available from the janus server, otherwise it will fall back to the old display. If a version is available, the connection type will also be displayed (estate, parcel, ad-hoc). Since the viewer can have multiple WebRTC connections, the version/connection type displayed does a best-effort attempt to get the version of the most important connection, otherwise it will attempt to guess the version from other connections of the same type.

Without janus server version: "Voice Server Version: Secondlife WebRTC Gateway"

With janus server version (examples):
  - Voice Server Version: Secondlife WebRTC Gateway [version string]/estate
  - Voice Server Version: Secondlife WebRTC Gateway [version string]/parcel
  - Voice Server Version: Secondlife WebRTC Gateway [version string]/ad-hoc

## Related Issues

- https://github.com/secondlife/3p-janus-gateway/issues/97
- https://github.com/secondlife/viewer/issues/5634

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

Requires janus server changes to see the version number