### PR TITLE
#2023 Load from a variable font

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2490,14 +2490,12 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
           <map>
             <key>archive</key>
             <map>
-              <key>creds</key>
-              <string>github</string>
               <key>hash</key>
-              <string>164a34f4bac8a886217bffb68464a883f8f14cc6</string>
+              <string>8de96fd083783b9f4df1d8d7028c8a713a7d7217</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-google-fonts/releases/assets/396854332</string>
+              <string>https://github.com/secondlife/3p-google-fonts/releases/download/v1.0.0-r6/google_fonts-1.0.0.24469773244-common-24469773244.tar.zst</string>
             </map>
             <key>name</key>
             <string>common</string>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2493,11 +2493,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>9bd007dd70635d85d716ca00484cefa700cdb6f0</string>
+              <string>164a34f4bac8a886217bffb68464a883f8f14cc6</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-google-fonts/releases/assets/365756469</string>
+              <string>https://api.github.com/repos/secondlife/3p-google-fonts/releases/assets/396854332</string>
             </map>
             <key>name</key>
             <string>common</string>

--- a/indra/llrender/llfontfreetype.cpp
+++ b/indra/llrender/llfontfreetype.cpp
@@ -389,22 +389,28 @@ F32 LLFontFreetype::getXKerning(const LLFontGlyphInfo* left_glyph_info, const LL
 
     FT_Vector  delta;
 
-    llverify(!FT_Get_Kerning(mFTFace, left_glyph, right_glyph, ft_kerning_unfitted, &delta));
+    llverify(!FT_Get_Kerning(mFTFace, left_glyph, right_glyph, FT_KERNING_UNFITTED, &delta));
 
     // Apply the FreeType auto-hinter's subpixel side-bearing correction between
     // adjacent glyphs. When the hinter has shifted the right side of the left
     // glyph or the left side of the right glyph, (rsb_delta - lsb_delta) is the
-    // sub-pixel nudge that keeps spacing visually even. It combines cleanly with
-    // the ll_round() that callers apply after kerning: sub-pixel values only
-    // affect the rounded pen when they cross a half-pixel threshold, matching
-    // the classic FT_Pos +-32 snap.
-    S32 delta_correction = 0;
-    if (left_glyph_info)
-        delta_correction += left_glyph_info->mRsbDelta;
-    if (right_glyph_info)
-        delta_correction -= right_glyph_info->mLsbDelta;
+    // sub-pixel nudge that keeps spacing visually even.
+    F32 delta_correction = 0.0f;
+    if (left_glyph_info && right_glyph_info)
+    {
+        // According to FreeType docs, these delta values should only trigger
+        // discrete ±1 pixel adjustments when they cross certain thresholds.
+        // Substructing delta_diff from delta.x doesn't work as well as treating
+        // it as a thresholds
+        S32 delta_diff = left_glyph_info->mRsbDelta - right_glyph_info->mLsbDelta;
+        if (delta_diff > 32)
+            delta_correction = -1.0f;
+        else if (delta_diff < -31)
+            delta_correction = 1.0f;
+    }
 
-    return (delta.x + delta_correction) * (1.f / 64.f);
+    // ft_kerning_unfitted mode always returns 26.6 fixed-point values
+    return (F32)(delta.x * (1.f / 64.f)) + delta_correction;
 }
 
 bool LLFontFreetype::hasGlyph(llwchar wch) const

--- a/indra/llrender/llfontfreetype.cpp
+++ b/indra/llrender/llfontfreetype.cpp
@@ -39,6 +39,7 @@
 // For some reason, this won't work if it's not wrapped in the ifdef
 #ifdef FT_FREETYPE_H
 #include FT_FREETYPE_H
+#include FT_MULTIPLE_MASTERS_H
 #endif
 
 #include "lldir.h"
@@ -165,7 +166,7 @@ LLFontFreetype::~LLFontFreetype()
     // mFallbackFonts cleaned up by LLPointer destructor
 }
 
-bool LLFontFreetype::loadFace(const std::string& filename, F32 point_size, F32 vert_dpi, F32 horz_dpi, bool is_fallback, S32 face_n, EFontHinting hinting, S32 flags)
+bool LLFontFreetype::loadFace(const std::string& filename, F32 point_size, F32 vert_dpi, F32 horz_dpi, S32 weight, bool is_fallback, S32 face_n, EFontHinting hinting, S32 flags)
 {
     // Don't leak face objects.  This is also needed to deal with
     // changed font file names.
@@ -191,6 +192,18 @@ bool LLFontFreetype::loadFace(const std::string& filename, F32 point_size, F32 v
     mIsFallback = is_fallback;
     mHinting = hinting;
     mFontFlags = flags;
+    mWeight = weight;
+
+    bool variable_font = false;
+    if (weight >= 0)
+    {
+        variable_font = setVariationAxis("wght", static_cast<F32>(weight));
+
+        // For Inter, also set optical size based on point size
+        // This makes text look better at different sizes
+        setVariationAxis("opsz", point_size);
+    }
+
     F32 pixels_per_em = (point_size / 72.f)*vert_dpi; // Size in inches * dpi
 
     error = FT_Set_Char_Size(mFTFace,    /* handle to face object           */
@@ -250,6 +263,12 @@ bool LLFontFreetype::loadFace(const std::string& filename, F32 point_size, F32 v
     {
         // FontGL applies programmatic bolding to fonts that are a part of 'bold' descriptor but don't have the bold style set.
         // Ex: Inter SemiBold doesn't have FT_STYLE_FLAG_BOLD and without this style it would be bolded programmatically.
+        mStyle |= LLFontGL::BOLD;
+    }
+    else if (weight >= 600 && variable_font)
+    {
+        // If the font is heavy enough, consider it bold and avoid programmatic bolding
+        // even if it doesn't have the bold style set.
         mStyle |= LLFontGL::BOLD;
     }
 
@@ -359,12 +378,8 @@ F32 LLFontFreetype::getXKerning(llwchar char_left, llwchar char_right) const
 
     llverify(!FT_Get_Kerning(mFTFace, left_glyph, right_glyph, ft_kerning_unfitted, &delta));
 
-    if (mFTFace->face_flags & FT_FACE_FLAG_SCALABLE)
-    {
-        // Return the X advance
-        return (F32)(delta.x * (1.0 / 64.0));
-    }
-    return (F32)delta.x;
+    // ft_kerning_unfitted mode always returns 26.6 fixed-point values
+    return (F32)(delta.x * (1.0 / 64.0));
 }
 
 F32 LLFontFreetype::getXKerning(const LLFontGlyphInfo* left_glyph_info, const LLFontGlyphInfo* right_glyph_info) const
@@ -379,12 +394,8 @@ F32 LLFontFreetype::getXKerning(const LLFontGlyphInfo* left_glyph_info, const LL
 
     llverify(!FT_Get_Kerning(mFTFace, left_glyph, right_glyph, ft_kerning_unfitted, &delta));
 
-    if (mFTFace->face_flags & FT_FACE_FLAG_SCALABLE)
-    {
-        // Return the X advance
-        return (F32)(delta.x * (1.0 / 64.0));
-    }
-    return (F32)delta.x;
+    // ft_kerning_unfitted mode always returns 26.6 fixed-point values
+    return (F32)(delta.x * (1.0 / 64.0));
 }
 
 bool LLFontFreetype::hasGlyph(llwchar wch) const
@@ -697,7 +708,7 @@ void LLFontFreetype::renderGlyph(EFontGlyphType bitmap_type, U32 glyph_index, ll
 void LLFontFreetype::reset(F32 vert_dpi, F32 horz_dpi)
 {
     resetBitmapCache();
-    loadFace(mName, mPointSize, vert_dpi ,horz_dpi, mIsFallback, 0, mHinting, mFontFlags);
+    loadFace(mName, mPointSize, vert_dpi ,horz_dpi, mWeight, mIsFallback, 0, mHinting, mFontFlags);
     if (!mIsFallback)
     {
         // This is the head of the list - need to rebuild ourself and all fallbacks.
@@ -863,6 +874,73 @@ void LLFontFreetype::setSubImageLuminanceAlpha(U32 x, U32 y, U32 bitmap_num, U32
             from_offset++;
         }
     }
+}
+
+bool LLFontFreetype::setVariationAxis(const std::string& axis_tag, F32 value)
+{
+    if (!mFTFace)
+        return false;
+
+    // Check if this is a variable font
+    FT_MM_Var* master = nullptr;
+    if (FT_Get_MM_Var(mFTFace, &master) != 0)
+    {
+        // Not a variable font - this is not an error, just silently skip
+        return false;
+    }
+
+    // Find the axis by tag (e.g., "wght" for weight)
+    FT_UInt axis_index = 0;
+    bool found = false;
+    for (FT_UInt i = 0; i < master->num_axis; i++)
+    {
+        // Compare the 4-byte tag
+        if (master->axis[i].tag == FT_MAKE_TAG(axis_tag[0], axis_tag[1], axis_tag[2], axis_tag[3]))
+        {
+            axis_index = i;
+            found = true;
+
+            // Clamp value to valid range for this axis
+            F32 min_val = master->axis[i].minimum / 65536.0f;
+            F32 max_val = master->axis[i].maximum / 65536.0f;
+            value = llclamp(value, min_val, max_val);
+
+            break;
+        }
+    }
+
+    if (!found)
+    {
+        FT_Done_MM_Var(gFTLibrary, master);
+        LL_WARNS_ONCE("FontVariation") << "Axis '" << axis_tag << "' not found in font: " << mName << LL_ENDL;
+        return false;
+    }
+
+    FT_UInt num_coords = master->num_axis;
+    FT_Fixed* coords = new FT_Fixed[num_coords];
+
+    // Get current coordinates
+    FT_Get_Var_Design_Coordinates(mFTFace, num_coords, coords);
+
+    // Update the specific axis
+    coords[axis_index] = (FT_Fixed)(value * 65536.0f);
+
+    // Set all coordinates
+    int error = FT_Set_Var_Design_Coordinates(mFTFace, num_coords, coords);
+
+    delete[] coords;
+    FT_Done_MM_Var(gFTLibrary, master);
+
+    if (error != 0)
+    {
+        LL_WARNS() << "Failed to set variation coordinates for " << axis_tag
+            << " = " << value << " in font: " << mName << LL_ENDL;
+        return false;
+    }
+
+    LL_INFOS("FontVariation") << "Set " << axis_tag << " = " << value
+        << " for font: " << mName << LL_ENDL;
+    return true;
 }
 
 

--- a/indra/llrender/llfontfreetype.cpp
+++ b/indra/llrender/llfontfreetype.cpp
@@ -117,6 +117,8 @@ LLFontGlyphInfo::LLFontGlyphInfo(U32 index, EFontGlyphType glyph_type)
     mYBitmapOffset(0),  // Offset to the origin in the bitmap
     mXBearing(0),       // Distance from baseline to left in pixels
     mYBearing(0),       // Distance from baseline to top in pixels
+    mLsbDelta(0),
+    mRsbDelta(0),
     mBitmapEntry(std::make_pair(EFontGlyphType::Unspecified, -1)) // Which bitmap in the bitmap cache contains this glyph
 {
 }
@@ -132,6 +134,8 @@ LLFontGlyphInfo::LLFontGlyphInfo(const LLFontGlyphInfo& fgi)
     , mYBitmapOffset(fgi.mYBitmapOffset)
     , mXBearing(fgi.mXBearing)
     , mYBearing(fgi.mYBearing)
+    , mLsbDelta(fgi.mLsbDelta)
+    , mRsbDelta(fgi.mRsbDelta)
 {
     mBitmapEntry = fgi.mBitmapEntry;
 }
@@ -369,17 +373,10 @@ F32 LLFontFreetype::getXKerning(llwchar char_left, llwchar char_right) const
 
     //llassert(!mIsFallback);
     LLFontGlyphInfo* left_glyph_info = getGlyphInfo(char_left, EFontGlyphType::Unspecified);;
-    U32 left_glyph = left_glyph_info ? left_glyph_info->mGlyphIndex : 0;
     // Kern this puppy.
     LLFontGlyphInfo* right_glyph_info = getGlyphInfo(char_right, EFontGlyphType::Unspecified);
-    U32 right_glyph = right_glyph_info ? right_glyph_info->mGlyphIndex : 0;
 
-    FT_Vector  delta;
-
-    llverify(!FT_Get_Kerning(mFTFace, left_glyph, right_glyph, ft_kerning_unfitted, &delta));
-
-    // ft_kerning_unfitted mode always returns 26.6 fixed-point values
-    return (F32)(delta.x * (1.0 / 64.0));
+    return getXKerning(left_glyph_info, right_glyph_info);
 }
 
 F32 LLFontFreetype::getXKerning(const LLFontGlyphInfo* left_glyph_info, const LLFontGlyphInfo* right_glyph_info) const
@@ -394,8 +391,20 @@ F32 LLFontFreetype::getXKerning(const LLFontGlyphInfo* left_glyph_info, const LL
 
     llverify(!FT_Get_Kerning(mFTFace, left_glyph, right_glyph, ft_kerning_unfitted, &delta));
 
-    // ft_kerning_unfitted mode always returns 26.6 fixed-point values
-    return (F32)(delta.x * (1.0 / 64.0));
+    // Apply the FreeType auto-hinter's subpixel side-bearing correction between
+    // adjacent glyphs. When the hinter has shifted the right side of the left
+    // glyph or the left side of the right glyph, (rsb_delta - lsb_delta) is the
+    // sub-pixel nudge that keeps spacing visually even. It combines cleanly with
+    // the ll_round() that callers apply after kerning: sub-pixel values only
+    // affect the rounded pen when they cross a half-pixel threshold, matching
+    // the classic FT_Pos +-32 snap.
+    S32 delta_correction = 0;
+    if (left_glyph_info)
+        delta_correction += left_glyph_info->mRsbDelta;
+    if (right_glyph_info)
+        delta_correction -= right_glyph_info->mLsbDelta;
+
+    return (delta.x + delta_correction) * (1.f / 64.f);
 }
 
 bool LLFontFreetype::hasGlyph(llwchar wch) const
@@ -540,6 +549,11 @@ LLFontGlyphInfo* LLFontFreetype::addGlyphFromFont(const LLFontFreetype *fontp, l
     gi->mHeight = height;
     gi->mXBearing = fontp->mFTFace->glyph->bitmap_left;
     gi->mYBearing = fontp->mFTFace->glyph->bitmap_top;
+    // FreeType fills these when the glyph has been auto-hinted; they describe how
+    // much the hinter nudged the left/right side bearings (in 26.6 pixels). Keep
+    // them so inter-glyph spacing can be corrected in getXKerning().
+    gi->mLsbDelta = (S32)fontp->mFTFace->glyph->lsb_delta;
+    gi->mRsbDelta = (S32)fontp->mFTFace->glyph->rsb_delta;
     // Convert these from 26.6 units to float pixels.
     gi->mXAdvance = fontp->mFTFace->glyph->advance.x / 64.f;
     gi->mYAdvance = fontp->mFTFace->glyph->advance.y / 64.f;

--- a/indra/llrender/llfontfreetype.cpp
+++ b/indra/llrender/llfontfreetype.cpp
@@ -932,7 +932,7 @@ bool LLFontFreetype::setVariationAxis(const std::string& axis_tag, F32 value)
     if (!found)
     {
         FT_Done_MM_Var(gFTLibrary, master);
-        LL_WARNS_ONCE("FontVariation") << "Axis '" << axis_tag << "' not found in font: " << mName << LL_ENDL;
+        LL_WARNS_ONCE("Font") << "Axis '" << axis_tag << "' not found in font: " << mName << LL_ENDL;
         return false;
     }
 
@@ -958,7 +958,7 @@ bool LLFontFreetype::setVariationAxis(const std::string& axis_tag, F32 value)
         return false;
     }
 
-    LL_INFOS("FontVariation") << "Set " << axis_tag << " = " << value
+    LL_DEBUGS("Font") << "Set " << axis_tag << " = " << value
         << " for font: " << mName << LL_ENDL;
     return true;
 }

--- a/indra/llrender/llfontfreetype.h
+++ b/indra/llrender/llfontfreetype.h
@@ -88,6 +88,8 @@ struct LLFontGlyphInfo
     S32 mYBitmapOffset; // Offset to the origin in the bitmap
     S32 mXBearing;  // Distance from baseline to left in pixels
     S32 mYBearing;  // Distance from baseline to top in pixels
+    S32 mLsbDelta;  // FreeType subpixel left side bearing delta (26.6 units)
+    S32 mRsbDelta;  // FreeType subpixel right side bearing delta (26.6 units)
     std::pair<EFontGlyphType, S32> mBitmapEntry; // Which bitmap in the bitmap cache contains this glyph
 };
 

--- a/indra/llrender/llfontfreetype.h
+++ b/indra/llrender/llfontfreetype.h
@@ -101,7 +101,7 @@ public:
 
     // is_fallback should be true for fallback fonts that aren't used
     // to render directly (Unicode backup, primarily)
-    bool loadFace(const std::string& filename, F32 point_size, F32 vert_dpi, F32 horz_dpi, bool is_fallback, S32 face_n, EFontHinting hinting, S32 flags);
+    bool loadFace(const std::string& filename, F32 point_size, F32 vert_dpi, F32 horz_dpi, S32 weight, bool is_fallback, S32 face_n, EFontHinting hinting, S32 flags);
 
     S32 getNumFaces(const std::string& filename);
 
@@ -163,6 +163,7 @@ private:
     void resetBitmapCache();
     void setSubImageLuminanceAlpha(U32 x, U32 y, U32 bitmap_num, U32 width, U32 height, U8 *data, S32 stride = 0) const;
     bool setSubImageBGRA(U32 x, U32 y, U32 bitmap_num, U16 width, U16 height, const U8* data, U32 stride) const;
+    bool setVariationAxis(const std::string& axis_tag, F32 value);
     bool hasGlyph(llwchar wch) const;       // Has a glyph for this character
     LLFontGlyphInfo* addGlyph(llwchar wch, EFontGlyphType glyph_type) const;        // Add a new character to the font if necessary
     LLFontGlyphInfo* addGlyphFromFont(
@@ -187,6 +188,7 @@ private:
     bool mIsFallback;
     EFontHinting mHinting;
     S32 mFontFlags;
+    S32 mWeight = -1;
     typedef std::pair<LLPointer<LLFontFreetype>, char_functor_t> fallback_font_t;
     typedef std::vector<fallback_font_t> fallback_font_vector_t;
     fallback_font_vector_t mFallbackFonts; // A list of fallback fonts to look for glyphs in (for Unicode chars)

--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -90,14 +90,14 @@ void LLFontGL::destroyGL()
     mFontFreetype->destroyGL();
 }
 
-bool LLFontGL::loadFace(const std::string& filename, F32 point_size, const F32 vert_dpi, const F32 horz_dpi, bool is_fallback, S32 face_n, EFontHinting hinting, S32 flags)
+bool LLFontGL::loadFace(const std::string& filename, F32 point_size, const F32 vert_dpi, const F32 horz_dpi, S32 weight, bool is_fallback, S32 face_n, EFontHinting hinting, S32 flags)
 {
     if(mFontFreetype == reinterpret_cast<LLFontFreetype*>(NULL))
     {
         mFontFreetype = new LLFontFreetype;
     }
 
-    return mFontFreetype->loadFace(filename, point_size, vert_dpi, horz_dpi, is_fallback, face_n, hinting, flags);
+    return mFontFreetype->loadFace(filename, point_size, vert_dpi, horz_dpi, weight, is_fallback, face_n, hinting, flags);
 }
 
 S32 LLFontGL::getNumFaces(const std::string& filename)

--- a/indra/llrender/llfontgl.h
+++ b/indra/llrender/llfontgl.h
@@ -87,7 +87,7 @@ public:
 
     void destroyGL();
 
-    bool loadFace(const std::string& filename, F32 point_size, const F32 vert_dpi, const F32 horz_dpi, bool is_fallback, S32 face_n, EFontHinting hinting, S32 flags);
+    bool loadFace(const std::string& filename, F32 point_size, const F32 vert_dpi, const F32 horz_dpi, S32 weight, bool is_fallback, S32 face_n, EFontHinting hinting, S32 flags);
 
     S32 getNumFaces(const std::string& filename);
     S32 getCacheGeneration() const;

--- a/indra/llrender/llfontregistry.cpp
+++ b/indra/llrender/llfontregistry.cpp
@@ -181,16 +181,16 @@ LLFontDescriptor LLFontDescriptor::normalize() const
     return LLFontDescriptor(new_name,new_size,new_style, getFontFiles(), getFontCollectionFiles());
 }
 
-void LLFontDescriptor::addFontFile(const std::string& file_name, EFontHinting hinting, S32 flags, F32 size_delta, const std::string& char_functor)
+void LLFontDescriptor::addFontFile(const std::string& file_name, EFontHinting hinting, S32 flags, F32 size_delta, S32 weight, const std::string& char_functor)
 {
     char_functor_map_t::const_iterator it = mCharFunctors.find(char_functor);
-    mFontFiles.push_back(LLFontFileInfo(file_name, hinting, flags, size_delta, (mCharFunctors.end() != it) ? it->second : nullptr));
+    mFontFiles.push_back(LLFontFileInfo(file_name, hinting, flags, size_delta, weight, (mCharFunctors.end() != it) ? it->second : nullptr));
 }
 
-void LLFontDescriptor::addFontCollectionFile(const std::string& file_name, EFontHinting hinting, S32 flags, F32 size_delta, const std::string& char_functor)
+void LLFontDescriptor::addFontCollectionFile(const std::string& file_name, EFontHinting hinting, S32 flags, F32 size_delta, S32 weight, const std::string& char_functor)
 {
     char_functor_map_t::const_iterator it = mCharFunctors.find(char_functor);
-    mFontCollectionFiles.push_back(LLFontFileInfo(file_name, hinting, flags, size_delta, (mCharFunctors.end() != it) ? it->second : nullptr));
+    mFontCollectionFiles.push_back(LLFontFileInfo(file_name, hinting, flags, size_delta, weight, (mCharFunctors.end() != it) ? it->second : nullptr));
 }
 
 LLFontRegistry::LLFontRegistry(bool create_gl_textures)
@@ -291,6 +291,7 @@ bool font_desc_init_from_xml(LLXMLNodePtr node, LLFontDescriptor& desc)
             std::string char_functor;
             EFontHinting hinting = EFontHinting::FORCE_AUTOHINT;
             S32 flags = 0;
+            S32 weight = -1;
 
             if (child->hasAttribute("functor"))
             {
@@ -335,17 +336,22 @@ bool font_desc_init_from_xml(LLXMLNodePtr node, LLFontDescriptor& desc)
                 child->getAttributeF32("size_delta", size_delta);
             }
 
+            if (child->hasAttribute("font_weight"))
+            {
+                child->getAttributeS32("font_weight", weight);
+            }
+
             if (child->hasAttribute("load_collection"))
             {
                 bool col = false;
                 child->getAttributeBOOL("load_collection", col);
                 if (col)
                 {
-                    desc.addFontCollectionFile(font_file_name, hinting, flags, size_delta, char_functor);
+                    desc.addFontCollectionFile(font_file_name, hinting, flags, size_delta, weight, char_functor);
                 }
             }
 
-            desc.addFontFile(font_file_name, hinting, flags, size_delta, char_functor);
+            desc.addFontFile(font_file_name, hinting, flags, size_delta, weight, char_functor);
         }
         else if (child->hasName("os"))
         {
@@ -502,7 +508,7 @@ LLFontGL *LLFontRegistry::createFont(const LLFontDescriptor& desc)
     // Add ultimate fallback list - generated dynamically on linux,
     // null elsewhere.
     std::transform(getUltimateFallbackList().begin(), getUltimateFallbackList().end(), std::back_inserter(font_files),
-                   [](const std::string& file_name) { return LLFontFileInfo(file_name, EFontHinting::FORCE_AUTOHINT, 0, 0.f); });
+                   [](const std::string& file_name) { return LLFontFileInfo(file_name, EFontHinting::FORCE_AUTOHINT, 0, 0.f, -1); });
 
     // Load fonts based on names.
     if (font_files.empty())
@@ -558,7 +564,7 @@ LLFontGL *LLFontRegistry::createFont(const LLFontDescriptor& desc)
                     fontp = new LLFontGL;
                 }
                 if (fontp->loadFace(font_path, point_size_scale + font_file_it->mSizeDelta,
-                                 LLFontGL::sVertDPI, LLFontGL::sHorizDPI, is_fallback, i, font_file_it->mHinting, font_file_it->mFlags))
+                                 LLFontGL::sVertDPI, LLFontGL::sHorizDPI, font_file_it->mWeight, is_fallback, i, font_file_it->mHinting, font_file_it->mFlags))
                 {
                     is_font_loaded = true;
                     if (is_first_found)

--- a/indra/llrender/llfontregistry.h
+++ b/indra/llrender/llfontregistry.h
@@ -43,21 +43,23 @@ enum class EFontHinting : S32
 
 struct LLFontFileInfo
 {
-    LLFontFileInfo(const std::string& file_name, EFontHinting hinting, S32 flags, F32 size_delta, const std::function<bool(llwchar)>& char_functor = nullptr)
+    LLFontFileInfo(const std::string& file_name, EFontHinting hinting, S32 flags, F32 size_delta, S32 weight, const std::function<bool(llwchar)>& char_functor = nullptr)
         : FileName(file_name)
         , CharFunctor(char_functor)
         , mHinting(hinting)
         , mFlags(flags)
         , mSizeDelta(size_delta)
+        , mWeight(weight)
     {
     }
 
-    LLFontFileInfo(const LLFontFileInfo& ffi, EFontHinting hinting, S32 flags, F32 size_delta)
+    LLFontFileInfo(const LLFontFileInfo& ffi, EFontHinting hinting, S32 flags, F32 size_delta, S32 weight)
         : FileName(ffi.FileName)
         , CharFunctor(ffi.CharFunctor)
         , mHinting(hinting)
         , mFlags(flags)
         , mSizeDelta(size_delta)
+        , mWeight(weight)
     {
     }
 
@@ -65,6 +67,7 @@ struct LLFontFileInfo
     std::function<bool(llwchar)> CharFunctor;
     EFontHinting mHinting;
     S32 mFlags;
+    S32 mWeight; // -1 - default, whatever is in the file.
 
     // Not all fonts are the same size, Ex: dejavu is bigger than inter,
     // so in some cases we want to adjust relative sizes to make characters
@@ -91,10 +94,10 @@ public:
     const std::string& getSize() const { return mSize; }
     void setSize(const std::string& size) { mSize = size; }
 
-    void addFontFile(const std::string& file_name, EFontHinting hinting, S32 flags, F32 size_delta, const std::string& char_functor = LLStringUtil::null);
+    void addFontFile(const std::string& file_name, EFontHinting hinting, S32 flags, F32 size_delta, S32 weight, const std::string& char_functor = LLStringUtil::null);
     const font_file_info_vec_t & getFontFiles() const { return mFontFiles; }
     void setFontFiles(const font_file_info_vec_t& font_files) { mFontFiles = font_files; }
-    void addFontCollectionFile(const std::string& file_name, EFontHinting hinting, S32 flags, F32 size_delta, const std::string& char_functor = LLStringUtil::null);
+    void addFontCollectionFile(const std::string& file_name, EFontHinting hinting, S32 flags, F32 size_delta, S32 weight, const std::string& char_functor = LLStringUtil::null);
     const font_file_info_vec_t& getFontCollectionFiles() const { return mFontCollectionFiles; }
     void setFontCollectionFiles(const font_file_info_vec_t& font_collection_files) { mFontCollectionFiles = font_collection_files; }
 

--- a/indra/newview/skins/default/xui/en/fonts.xml
+++ b/indra/newview/skins/default/xui/en/fonts.xml
@@ -4,7 +4,7 @@
   <font
       name="default"
       comment="default font files (global fallbacks)">
-    <file load_collection="true" font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
+    <file load_collection="true" font_weight="400">InterVariableFont.ttf</file>
     <file size_delta="-0.5">DejaVuSans.ttf</file>
     <file functor="is_emoji">TwemojiSVG.ttf</file>
     <os name="Windows">
@@ -37,7 +37,7 @@
   <font
       name="SansSerifBold"
       comment="Name of bold sans-serif font">
-      <file load_collection="true" flags="bold" font_weight="600">Inter-VariableFont_opsz,wght.ttf</file>
+      <file load_collection="true" flags="bold" font_weight="600">InterVariableFont.ttf</file>
       <file size_delta="-0.5">DejaVuSans-Bold.ttf</file>
     <os name="Windows">
       <file>arialbd.ttf</file>
@@ -50,7 +50,7 @@
   <font
       name="SansSerif"
       comment="Name of san-serif font (Truetype file name)">
-    <file load_collection="true" font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
+    <file load_collection="true" font_weight="400">InterVariableFont.ttf</file>
     <file size_delta="-0.5">DejaVuSans.ttf</file>
     <os name="Windows">
       <file>arial.ttf</file>
@@ -64,7 +64,7 @@
       name="SansSerif"
       comment="Name of bold sans-serif font"
       font_style="BOLD">
-    <file load_collection="true" flags="bold" font_weight="600">Inter-VariableFont_opsz,wght.ttf</file>
+    <file load_collection="true" flags="bold" font_weight="600">InterVariableFont.ttf</file>
     <file size_delta="-0.5">DejaVuSans-Bold.ttf</file>
   </font>
 
@@ -72,7 +72,7 @@
       name="SansSerif"
       comment="Name of italic sans-serif font"
       font_style="ITALIC">
-    <file load_collection="true" font_weight="400">Inter-Italic-VariableFont_opsz,wght.ttf</file>
+    <file load_collection="true" font_weight="400">InterItalicVariableFont.ttf</file>
     <file size_delta="-0.5">DejaVuSans-Oblique.ttf</file>
   </font>
 
@@ -80,7 +80,7 @@
       name="SansSerif"
       comment="Name of bold italic sans-serif font"
       font_style="BOLD|ITALIC">
-    <file load_collection="true" font_weight="800">Inter-Italic-VariableFont_opsz,wght.ttf</file>
+    <file load_collection="true" font_weight="800">InterItalicVariableFont.ttf</file>
     <file size_delta="-0.5">DejaVuSans-BoldOblique.ttf</file>
   </font>
 
@@ -121,7 +121,7 @@
   <font
       name="Helvetica"
       comment="Name of Helvetica font">
-    <file font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
+    <file font_weight="400">InterVariableFont.ttf</file>
     <file size_delta="-0.5">DejaVuSans.ttf</file>
     <os name="Windows">
       <file>arial.ttf</file>
@@ -135,7 +135,7 @@
       name="Helvetica"
       comment="Name of Helvetica font (bold)"
       font_style="BOLD">
-    <file flags="bold" font_weight="800">Inter-VariableFont_opsz,wght.ttf</file>
+    <file flags="bold" font_weight="800">InterVariableFont.ttf</file>
     <file size_delta="-0.5">DejaVuSans-Bold.ttf</file>
     <os name="Windows">
       <file>arialbd.ttf</file>
@@ -149,7 +149,7 @@
       name="Helvetica"
       comment="Name of Helvetica font (italic)"
       font_style="ITALIC">
-    <file font_weight="400">Inter-Italic-VariableFont_opsz,wght.ttf</file>
+    <file font_weight="400">InterItalicVariableFont.ttf</file>
     <file size_delta="-0.5">DejaVuSans-Oblique.ttf</file>
     <os name="Windows">
       <file>ariali.ttf</file>
@@ -163,7 +163,7 @@
       name="Helvetica"
       comment="Name of Helvetica font (bold italic)"
       font_style="BOLD|ITALIC">
-    <file font_weight="800">Inter-Italic-VariableFont_opsz,wght.ttf</file>
+    <file font_weight="800">InterItalicVariableFont.ttf</file>
     <file size_delta="-0.5">DejaVuSans-BoldOblique.ttf</file>
     <os name="Windows">
       <file>arialbi.ttf</file>
@@ -177,7 +177,7 @@
       name="OverrideTest"
       comment="Name of font to test overriding">
     <file>times.ttf</file>
-    <file font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
+    <file font_weight="400">InterVariableFont.ttf</file>
   </font>
 
   <font_size name="Monospace"

--- a/indra/newview/skins/default/xui/en/fonts.xml
+++ b/indra/newview/skins/default/xui/en/fonts.xml
@@ -4,7 +4,7 @@
   <font
       name="default"
       comment="default font files (global fallbacks)">
-    <file load_collection="true" font_hinting="default">Inter_18pt-Regular.ttf</file>
+    <file load_collection="true" font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
     <file size_delta="-0.5">DejaVuSans.ttf</file>
     <file functor="is_emoji">TwemojiSVG.ttf</file>
     <os name="Windows">
@@ -37,7 +37,7 @@
   <font
       name="SansSerifBold"
       comment="Name of bold sans-serif font">
-      <file load_collection="true" font_hinting="default" flags="bold">Inter_18pt-ExtraBold.ttf</file>
+      <file load_collection="true" flags="bold" font_weight="600">Inter-VariableFont_opsz,wght.ttf</file>
       <file size_delta="-0.5">DejaVuSans-Bold.ttf</file>
     <os name="Windows">
       <file>arialbd.ttf</file>
@@ -50,7 +50,7 @@
   <font
       name="SansSerif"
       comment="Name of san-serif font (Truetype file name)">
-    <file load_collection="true" font_hinting="default">Inter_18pt-Regular.ttf</file>
+    <file load_collection="true" font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
     <file size_delta="-0.5">DejaVuSans.ttf</file>
     <os name="Windows">
       <file>arial.ttf</file>
@@ -64,7 +64,7 @@
       name="SansSerif"
       comment="Name of bold sans-serif font"
       font_style="BOLD">
-    <file load_collection="true" font_hinting="default" flags="bold">Inter_18pt-Bold.ttf</file>
+    <file load_collection="true" flags="bold" font_weight="600">Inter-VariableFont_opsz,wght.ttf</file>
     <file size_delta="-0.5">DejaVuSans-Bold.ttf</file>
   </font>
 
@@ -72,7 +72,7 @@
       name="SansSerif"
       comment="Name of italic sans-serif font"
       font_style="ITALIC">
-    <file load_collection="true">Inter_18pt-Italic.ttf</file>
+    <file load_collection="true" font_weight="400">Inter-Italic-VariableFont_opsz,wght.ttf</file>
     <file size_delta="-0.5">DejaVuSans-Oblique.ttf</file>
   </font>
 
@@ -80,7 +80,7 @@
       name="SansSerif"
       comment="Name of bold italic sans-serif font"
       font_style="BOLD|ITALIC">
-    <file load_collection="true">Inter_18pt-BoldItalic.ttf</file>
+    <file load_collection="true" font_weight="800">Inter-Italic-VariableFont_opsz,wght.ttf</file>
     <file size_delta="-0.5">DejaVuSans-BoldOblique.ttf</file>
   </font>
 
@@ -121,7 +121,7 @@
   <font
       name="Helvetica"
       comment="Name of Helvetica font">
-    <file font_hinting="default">Inter_18pt-Regular.ttf</file>
+    <file font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
     <file size_delta="-0.5">DejaVuSans.ttf</file>
     <os name="Windows">
       <file>arial.ttf</file>
@@ -135,7 +135,7 @@
       name="Helvetica"
       comment="Name of Helvetica font (bold)"
       font_style="BOLD">
-    <file font_hinting="default" flags="bold">Inter_18pt-ExtraBold.ttf</file>
+    <file flags="bold" font_weight="800">Inter-VariableFont_opsz,wght.ttf</file>
     <file size_delta="-0.5">DejaVuSans-Bold.ttf</file>
     <os name="Windows">
       <file>arialbd.ttf</file>
@@ -149,7 +149,7 @@
       name="Helvetica"
       comment="Name of Helvetica font (italic)"
       font_style="ITALIC">
-    <file>Inter_18pt-Italic.ttf</file>
+    <file font_weight="400">Inter-Italic-VariableFont_opsz,wght.ttf</file>
     <file size_delta="-0.5">DejaVuSans-Oblique.ttf</file>
     <os name="Windows">
       <file>ariali.ttf</file>
@@ -163,7 +163,7 @@
       name="Helvetica"
       comment="Name of Helvetica font (bold italic)"
       font_style="BOLD|ITALIC">
-    <file>Inter_18pt-BoldItalic.ttf</file>
+    <file font_weight="800">Inter-Italic-VariableFont_opsz,wght.ttf</file>
     <file size_delta="-0.5">DejaVuSans-BoldOblique.ttf</file>
     <os name="Windows">
       <file>arialbi.ttf</file>
@@ -177,7 +177,7 @@
       name="OverrideTest"
       comment="Name of font to test overriding">
     <file>times.ttf</file>
-    <file font_hinting="default">Inter_18pt-Regular.ttf</file>
+    <file font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
   </font>
 
   <font_size name="Monospace"

--- a/indra/newview/skins/default/xui/ja/fonts.xml
+++ b/indra/newview/skins/default/xui/ja/fonts.xml
@@ -4,9 +4,7 @@
 		<file>
 			NotoSansCJKjp-SemiBold.otf
 		</file>
-        <file load_collection="true" font_hinting="default">
-            Inter_18pt-Regular.ttf
-        </file>
+        <file load_collection="true" font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
 		<os name="Windows">
 			<file load_collection="true">
 				YuGothM.ttc
@@ -82,9 +80,7 @@
 		<file>
 			NotoSansCJKjp-Bold.otf
 		</file>
-        <file load_collection="true" font_hinting="default" flags="bold">
-            Inter_18pt-SemiBold.ttf
-        </file>
+        <file load_collection="true" font_weight="800" flags="bold">Inter-VariableFont_opsz,wght.ttf</file>
 		<os name="Windows">
 			<file load_collection="true">
 				YuGothB.ttc
@@ -104,11 +100,9 @@
 	</font>
 	<font name="SansSerif" comment="Name of san-serif font (Truetype file name)">
 		<file>
-			NotoSansCJKjp-Bold.otf
+			NotoSansCJKjp-SemiBold.otf
 		</file>
-        <file load_collection="true" font_hinting="default">
-            Inter_18pt-Regular.ttf
-        </file>
+        <file load_collection="true" font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
 		<os name="Windows">
 			<file>
 				arial.ttf
@@ -121,19 +115,13 @@
 		</os>
 	</font>
 	<font name="SansSerif" comment="Name of bold sans-serif font" font_style="BOLD">
-        <file load_collection="true" font_hinting="default" flags="bold">
-            Inter_18pt-SemiBold.ttf
-        </file>
+        <file load_collection="true" font_weight="800" flags="bold">Inter-VariableFont_opsz,wght.ttf</file>
 	</font>
 	<font name="SansSerif" comment="Name of italic sans-serif font" font_style="ITALIC">
-        <file load_collection="true">
-            Inter_18pt-Italic.ttf
-        </file>
+        <file load_collection="true" font_weight="400">Inter-Italic-VariableFont_opsz,wght.ttf</file>
 	</font>
 	<font name="SansSerif" comment="Name of bold italic sans-serif font" font_style="BOLD|ITALIC">
-        <file load_collection="true" font_hinting="default" flags="bold">
-            Inter_18pt-SemiBoldItalic.ttf
-        </file>
+        <file load_collection="true" flags="bold" font_weight="800">Inter-Italic-VariableFont_opsz,wght.ttf</file>
 	</font>
 	<font name="Monospace" comment="Name of monospace font">
 		<file>
@@ -144,29 +132,25 @@
 		</file>
 	</font>
 	<font name="DejaVu" comment="Name of DejaVu font">
-        <file load_collection="true" font_hinting="default">
-            Inter_18pt-Regular.ttf
-        </file>
+        <file>DejaVuSans.ttf</file>
 	</font>
 	<font name="DejaVu" comment="Name of DejaVu font (bold)" font_style="BOLD">
-        <file load_collection="true" font_hinting="force_auto" flags="bold">
-            Inter_18pt-SemiBold.ttf
+        <file>
+            DejaVuSans-Bold.ttf
         </file>
 	</font>
 	<font name="DejaVu" comment="Name of DejaVu font (italic)" font_style="ITALIC">
-        <file load_collection="true">
-            Inter_18pt-Italic.ttf
+        <file>
+            DejaVuSans-Oblique.ttf
         </file>
 	</font>
 	<font name="DejaVu" comment="Name of DejaVu font (bold italic)" font_style="BOLD|ITALIC">
-        <file load_collection="true" font_hinting="default" flags="bold">
-            Inter_18pt-SemiBoldItalic.ttf
+        <file>
+            DejaVuSans-BoldOblique.ttf
         </file>
 	</font>
 	<font name="Helvetica" comment="Name of Helvetica font">
-        <file load_collection="true" font_hinting="default">
-            Inter_18pt-Regular.ttf
-        </file>
+        <file load_collection="true" font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
 		<os name="Windows">
 			<file>
 				arial.ttf
@@ -179,9 +163,7 @@
 		</os>
 	</font>
 	<font name="Helvetica" comment="Name of Helvetica font (bold)" font_style="BOLD">
-        <file load_collection="true" font_hinting="default" flags="bold">
-            Inter_18pt-SemiBold.ttf
-        </file>
+        <file load_collection="true" font_weight="800" flags="bold">Inter-VariableFont_opsz,wght.ttf</file>
 		<os name="Windows">
 			<file>
 				arialbd.ttf
@@ -194,9 +176,7 @@
 		</os>
 	</font>
 	<font name="Helvetica" comment="Name of Helvetica font (italic)" font_style="ITALIC">
-        <file load_collection="true">
-            Inter_18pt-Italic.ttf
-        </file>
+        <file load_collection="true" font_weight="400">Inter-Italic-VariableFont_opsz,wght.ttf</file>
 		<os name="Windows">
 			<file>
 				ariali.ttf
@@ -209,9 +189,7 @@
 		</os>
 	</font>
 	<font name="Helvetica" comment="Name of Helvetica font (bold italic)" font_style="BOLD|ITALIC">
-        <file load_collection="true" font_hinting="default" flags="bold">
-            Inter_18pt-SemiBoldItalic.ttf
-        </file>
+        <file load_collection="true" flags="bold" font_weight="800">Inter-Italic-VariableFont_opsz,wght.ttf</file>
 		<os name="Windows">
 			<file>
 				arialbi.ttf
@@ -227,9 +205,7 @@
 		<file>
 			times.ttf
 		</file>
-        <file load_collection="true" font_hinting="default">
-            Inter_18pt-Regular.ttf
-        </file>
+        <file font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
 	</font>
 	<font_size name="Monospace" comment="Size for monospaced font (points, or 1/72 of an inch)" size="8.0"/>
 	<font_size name="Huge" comment="Size of huge font (points, or 1/72 of an inch)" size="16.0"/>

--- a/indra/newview/skins/default/xui/ja/fonts.xml
+++ b/indra/newview/skins/default/xui/ja/fonts.xml
@@ -4,7 +4,7 @@
 		<file>
 			NotoSansCJKjp-SemiBold.otf
 		</file>
-        <file load_collection="true" font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
+        <file load_collection="true" font_weight="400">InterVariableFont.ttf</file>
 		<os name="Windows">
 			<file load_collection="true">
 				YuGothM.ttc
@@ -80,7 +80,7 @@
 		<file>
 			NotoSansCJKjp-Bold.otf
 		</file>
-        <file load_collection="true" font_weight="800" flags="bold">Inter-VariableFont_opsz,wght.ttf</file>
+        <file load_collection="true" font_weight="800" flags="bold">InterVariableFont.ttf</file>
 		<os name="Windows">
 			<file load_collection="true">
 				YuGothB.ttc
@@ -102,7 +102,7 @@
 		<file>
 			NotoSansCJKjp-SemiBold.otf
 		</file>
-        <file load_collection="true" font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
+        <file load_collection="true" font_weight="400">InterVariableFont.ttf</file>
 		<os name="Windows">
 			<file>
 				arial.ttf
@@ -115,13 +115,13 @@
 		</os>
 	</font>
 	<font name="SansSerif" comment="Name of bold sans-serif font" font_style="BOLD">
-        <file load_collection="true" font_weight="800" flags="bold">Inter-VariableFont_opsz,wght.ttf</file>
+        <file load_collection="true" font_weight="800" flags="bold">InterVariableFont.ttf</file>
 	</font>
 	<font name="SansSerif" comment="Name of italic sans-serif font" font_style="ITALIC">
-        <file load_collection="true" font_weight="400">Inter-Italic-VariableFont_opsz,wght.ttf</file>
+        <file load_collection="true" font_weight="400">InterItalicVariableFont.ttf</file>
 	</font>
 	<font name="SansSerif" comment="Name of bold italic sans-serif font" font_style="BOLD|ITALIC">
-        <file load_collection="true" flags="bold" font_weight="800">Inter-Italic-VariableFont_opsz,wght.ttf</file>
+        <file load_collection="true" flags="bold" font_weight="800">InterItalicVariableFont.ttf</file>
 	</font>
 	<font name="Monospace" comment="Name of monospace font">
 		<file>
@@ -150,7 +150,7 @@
         </file>
 	</font>
 	<font name="Helvetica" comment="Name of Helvetica font">
-        <file load_collection="true" font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
+        <file load_collection="true" font_weight="400">InterVariableFont.ttf</file>
 		<os name="Windows">
 			<file>
 				arial.ttf
@@ -163,7 +163,7 @@
 		</os>
 	</font>
 	<font name="Helvetica" comment="Name of Helvetica font (bold)" font_style="BOLD">
-        <file load_collection="true" font_weight="800" flags="bold">Inter-VariableFont_opsz,wght.ttf</file>
+        <file load_collection="true" font_weight="800" flags="bold">InterVariableFont.ttf</file>
 		<os name="Windows">
 			<file>
 				arialbd.ttf
@@ -176,7 +176,7 @@
 		</os>
 	</font>
 	<font name="Helvetica" comment="Name of Helvetica font (italic)" font_style="ITALIC">
-        <file load_collection="true" font_weight="400">Inter-Italic-VariableFont_opsz,wght.ttf</file>
+        <file load_collection="true" font_weight="400">InterItalicVariableFont.ttf</file>
 		<os name="Windows">
 			<file>
 				ariali.ttf
@@ -189,7 +189,7 @@
 		</os>
 	</font>
 	<font name="Helvetica" comment="Name of Helvetica font (bold italic)" font_style="BOLD|ITALIC">
-        <file load_collection="true" flags="bold" font_weight="800">Inter-Italic-VariableFont_opsz,wght.ttf</file>
+        <file load_collection="true" flags="bold" font_weight="800">InterItalicVariableFont.ttf</file>
 		<os name="Windows">
 			<file>
 				arialbi.ttf
@@ -205,7 +205,7 @@
 		<file>
 			times.ttf
 		</file>
-        <file font_weight="400">Inter-VariableFont_opsz,wght.ttf</file>
+        <file font_weight="400">InterVariableFont.ttf</file>
 	</font>
 	<font_size name="Monospace" comment="Size for monospaced font (points, or 1/72 of an inch)" size="8.0"/>
 	<font_size name="Huge" comment="Size of huge font (points, or 1/72 of an inch)" size="16.0"/>


### PR DESCRIPTION
- Variable fonts support
- Font cleanup (removed ~30MB of unused files from the package)
- Clarity adjustent (hinting)
- lsb_delta and rsb_delta support by Rye