### PR TITLE
Update viewer copyright year in About licenses

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -3416,7 +3416,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
       <key>license_file</key>
       <string>docs/LICENSE-source.txt</string>
       <key>copyright</key>
-      <string>Copyright (c) 2020, Linden Research, Inc.</string>
+      <string>Copyright (c) 2026, Linden Research, Inc.</string>
       <key>version_file</key>
       <string>newview/viewer_version.txt</string>
       <key>name</key>


### PR DESCRIPTION
This updates the viewer copyright notice shown under Help > About Second Life > Licenses from 2020 to 2026.

Built locally and verified that the generated packages-info.txt now carries the updated year.