### PR TITLE
#4893 Async inventory review fixes

### DIFF
--- a/indra/llcommon/llsingleton.h
+++ b/indra/llcommon/llsingleton.h
@@ -524,14 +524,11 @@ public:
             case INITIALIZING:
                 // here if DERIVED_TYPE::initSingleton() (directly or indirectly)
                 // calls DERIVED_TYPE::getInstance(): go ahead and allow it
-                // record the dependency: check if we got here from another
+            case INITIALIZED:
+                // normal subsequent calls
+                // record the dependency, if any: check if we got here from another
                 // LLSingleton's constructor or initSingleton() method
                 capture_dependency(lk->mInstance);
-                return lk->mInstance;
-
-            case INITIALIZED:
-                // normal subsequent calls - skip capture_dependency() for performance
-                // dependencies are only tracked during initialization
                 return lk->mInstance;
 
             case DELETED:
@@ -733,12 +730,10 @@ public:
 
         case super::INITIALIZING:
             // As with LLSingleton, explicitly permit circular calls from
-            // within initSingleton() and capture dependencies
-            super::capture_dependency(lk->mInstance);
-            return lk->mInstance;
-
+            // within initSingleton()
         case super::INITIALIZED:
-            // normal subsequent calls - skip capture_dependency() for performance
+            // for any valid call, capture dependencies
+            super::capture_dependency(lk->mInstance);
             return lk->mInstance;
 
         case super::DELETED:

--- a/indra/llui/llview.cpp
+++ b/indra/llui/llview.cpp
@@ -264,7 +264,11 @@ void LLView::setName(const std::string& name)
 
     if (parent && !mName.empty())
     {
-        parent->mChildNameCache.erase(mName);
+        auto it = parent->mChildNameCache.find(mName);
+        if (it != parent->mChildNameCache.end() && it->second == this)
+        {
+            parent->mChildNameCache.erase(it);
+        }
     }
 
     mName = name;
@@ -373,10 +377,14 @@ void LLView::removeChild(LLView* child)
         llassert(!child->mInDraw);
         mChildList.remove( child );
 
-        // Remove from name cache
+        // Remove from name cache - verify pointer to handle duplicate names
         if (child->hasName())
         {
-            mChildNameCache.erase(child->getName());
+            auto it = mChildNameCache.find(child->getName());
+            if (it != mChildNameCache.end() && it->second == child)
+            {
+                mChildNameCache.erase(it);
+            }
         }
 
         child->mParentView = NULL;

--- a/indra/newview/llasyncinventoryskeletonloader.cpp
+++ b/indra/newview/llasyncinventoryskeletonloader.cpp
@@ -77,6 +77,7 @@ void LLAsyncInventorySkeletonLoader::reset()
     mEssentialTimeoutSec = gSavedSettings.getF32("AsyncInventoryEssentialTimeout");
 
     mSawCurrentOutfitFolder = false;
+    mCurrentOutfitFolderId.setNull();
 }
 
 bool LLAsyncInventorySkeletonLoader::isRunning() const
@@ -213,8 +214,7 @@ void LLAsyncInventorySkeletonLoader::scheduleInitialFetches()
     const LLUUID library_root = gInventory.getLibraryRootFolderID();
     if (library_root.notNull())
     {
-        enqueueFetch(library_root, true, true, gInventory.getCachedCategoryVersion(library_root));
-        mEssentialPending.insert(library_root);
+        enqueueFetch(library_root, true, false, gInventory.getCachedCategoryVersion(library_root));
     }
 
     mEssentialTimer.reset();
@@ -361,6 +361,7 @@ void LLAsyncInventorySkeletonLoader::evaluateChildren(const FetchRequest& reques
         if (child->getPreferredType() == LLFolderType::FT_CURRENT_OUTFIT)
         {
             mSawCurrentOutfitFolder = true;
+            mCurrentOutfitFolderId = child_id;
         }
 
         bool child_essential = false;
@@ -376,7 +377,7 @@ void LLAsyncInventorySkeletonLoader::evaluateChildren(const FetchRequest& reques
         bool should_fetch = child_changed || force_changed_scan;
         if (child_essential)
         {
-            if (!should_fetch && child_cache_valid)
+            if (!child_changed && child_cache_valid)
             {
                 LL_INFOS("AsyncInventory") << "Async skeleton loader trusting cached essential folder"
                                   << " cat_id=" << child_id
@@ -488,6 +489,7 @@ void LLAsyncInventorySkeletonLoader::discoverEssentialFolders()
         && mActiveFetches.count(cof_id) == 0)
     {
         mSawCurrentOutfitFolder = true;
+        mCurrentOutfitFolderId = cof_id;
         LLViewerInventoryCategory* cof = gInventory.getCategory(cof_id);
         const S32 cached_version = gInventory.getCachedCategoryVersion(cof_id);
         if (isCategoryUpToDate(cof, cached_version))
@@ -533,7 +535,14 @@ void LLAsyncInventorySkeletonLoader::enqueueFetch(const LLUUID& category_id,
     request.mEssential = essential;
     request.mCachedVersion = cached_version;
 
-    mFetchQueue.push_back(request);
+    if (essential)
+    {
+        mFetchQueue.push_front(request);
+    }
+    else
+    {
+        mFetchQueue.push_back(request);
+    }
     mQueuedCategories.insert(category_id);
 }
 
@@ -595,7 +604,11 @@ bool LLAsyncInventorySkeletonLoader::hasFetchedCurrentOutfit() const
         return true;
     }
 
-    LLUUID cof_id = gInventory.findCategoryUUIDForType(LLFolderType::FT_CURRENT_OUTFIT);
+    LLUUID cof_id = mCurrentOutfitFolderId;
+    if (cof_id.isNull())
+    {
+        cof_id = gInventory.findCategoryUUIDForType(LLFolderType::FT_CURRENT_OUTFIT);
+    }
     if (cof_id.isNull())
     {
         return false;

--- a/indra/newview/llasyncinventoryskeletonloader.cpp
+++ b/indra/newview/llasyncinventoryskeletonloader.cpp
@@ -268,7 +268,6 @@ void LLAsyncInventorySkeletonLoader::handleFetchComplete(const LLUUID& request_i
     FetchRequest request = active_it->second;
     mActiveFetches.erase(active_it);
     mQueuedCategories.erase(request_id);
-    mFetchedCategories.insert(request_id);
 
     if (request.mEssential)
     {
@@ -287,6 +286,8 @@ void LLAsyncInventorySkeletonLoader::handleFetchComplete(const LLUUID& request_i
         processQueue();
         return;
     }
+
+    mFetchedCategories.insert(request_id);
 
     LLViewerInventoryCategory* category = gInventory.getCategory(request_id);
     S32 server_version = LLViewerInventoryCategory::VERSION_UNKNOWN;

--- a/indra/newview/llasyncinventoryskeletonloader.cpp
+++ b/indra/newview/llasyncinventoryskeletonloader.cpp
@@ -45,6 +45,12 @@ bool gAsyncAgentCacheHydrated = false;
 bool gAsyncLibraryCacheHydrated = false;
 bool gAsyncParentChildMapPrimed = false;
 
+LLAsyncInventorySkeletonLoader::~LLAsyncInventorySkeletonLoader()
+{
+    disconnectCapsCallback();
+    removeIdleCallback();
+}
+
 void LLAsyncInventorySkeletonLoader::reset()
 {
     disconnectCapsCallback();

--- a/indra/newview/llasyncinventoryskeletonloader.cpp
+++ b/indra/newview/llasyncinventoryskeletonloader.cpp
@@ -233,6 +233,13 @@ void LLAsyncInventorySkeletonLoader::processQueue()
     while (!mFetchQueue.empty() && mActiveFetches.size() < mMaxConcurrentFetches)
     {
         FetchRequest request = mFetchQueue.front();
+
+        // During essential phase, only dispatch essential requests
+        if (!mEssentialReady && !request.mEssential)
+        {
+            break;
+        }
+
         mFetchQueue.pop_front();
 
         AISAPI::completion_t cb = [this, request](const LLUUID& response_id)

--- a/indra/newview/llasyncinventoryskeletonloader.cpp
+++ b/indra/newview/llasyncinventoryskeletonloader.cpp
@@ -577,7 +577,14 @@ void LLAsyncInventorySkeletonLoader::markFailed(const std::string& reason)
     mPhase = Phase::Failed;
     mFetchTimer.stop();
     mTotalTimer.stop();
-    LL_WARNS("AppInit") << "Async inventory skeleton loader failed: " << mFailureReason << LL_ENDL;
+    if (mEssentialReady)
+    {
+        LL_WARNS("AppInit") << "Async inventory skeleton loader failed after essential-ready: " << mFailureReason << LL_ENDL;
+    }
+    else
+    {
+        LL_WARNS("AppInit") << "Async inventory skeleton loader failed: " << mFailureReason << LL_ENDL;
+    }
 }
 
 bool LLAsyncInventorySkeletonLoader::hasFetchedCurrentOutfit() const

--- a/indra/newview/llasyncinventoryskeletonloader.cpp
+++ b/indra/newview/llasyncinventoryskeletonloader.cpp
@@ -280,7 +280,11 @@ void LLAsyncInventorySkeletonLoader::handleFetchComplete(const LLUUID& request_i
         LL_WARNS("AppInit") << "Async inventory skeleton loader failed to fetch "
                              << request_id << " (library="
                              << (request.mIsLibrary ? "true" : "false") << ")" << LL_ENDL;
-        markFailed("AIS skeleton fetch returned no data for category " + request_id.asString());
+        if (request.mEssential)
+        {
+            markFailed("AIS skeleton fetch returned no data for essential category " + request_id.asString());
+        }
+        processQueue();
         return;
     }
 

--- a/indra/newview/llasyncinventoryskeletonloader.cpp
+++ b/indra/newview/llasyncinventoryskeletonloader.cpp
@@ -207,14 +207,14 @@ void LLAsyncInventorySkeletonLoader::scheduleInitialFetches()
     const LLUUID agent_root = gInventory.getRootFolderID();
     if (agent_root.notNull())
     {
-        enqueueFetch(agent_root, false, true, gInventory.getCachedCategoryVersion(agent_root));
+        enqueueFetch(agent_root, false, true, gInventory.getCachedCategoryVersion(agent_root), 0);
         mEssentialPending.insert(agent_root);
     }
 
     const LLUUID library_root = gInventory.getLibraryRootFolderID();
     if (library_root.notNull())
     {
-        enqueueFetch(library_root, true, false, gInventory.getCachedCategoryVersion(library_root));
+        enqueueFetch(library_root, true, false, gInventory.getCachedCategoryVersion(library_root), 0);
     }
 
     mEssentialTimer.reset();
@@ -251,7 +251,7 @@ void LLAsyncInventorySkeletonLoader::processQueue()
                                       requestType(request.mIsLibrary),
                                       false,
                                       cb,
-                                      1);
+                                      request.mRequestDepth);
         mActiveFetches.emplace(request.mCategoryId, request);
     }
 }
@@ -517,7 +517,8 @@ void LLAsyncInventorySkeletonLoader::discoverEssentialFolders()
 void LLAsyncInventorySkeletonLoader::enqueueFetch(const LLUUID& category_id,
                                                   bool is_library,
                                                   bool essential,
-                                                  S32 cached_version)
+                                                  S32 cached_version,
+                                                  S32 depth)
 {
     if (category_id.isNull())
     {
@@ -534,6 +535,7 @@ void LLAsyncInventorySkeletonLoader::enqueueFetch(const LLUUID& category_id,
     request.mIsLibrary = is_library;
     request.mEssential = essential;
     request.mCachedVersion = cached_version;
+    request.mRequestDepth = depth;
 
     if (essential)
     {

--- a/indra/newview/llasyncinventoryskeletonloader.h
+++ b/indra/newview/llasyncinventoryskeletonloader.h
@@ -108,6 +108,7 @@ private:
 
     U32 mMaxConcurrentFetches = 4;
     bool mSawCurrentOutfitFolder = false;
+    LLUUID mCurrentOutfitFolderId;
 
     LLFrameTimer mCapsTimer;
     LLFrameTimer mFetchTimer;

--- a/indra/newview/llasyncinventoryskeletonloader.h
+++ b/indra/newview/llasyncinventoryskeletonloader.h
@@ -45,6 +45,8 @@ class LLViewerRegion;
 class LLAsyncInventorySkeletonLoader
 {
 public:
+    ~LLAsyncInventorySkeletonLoader();
+
     void start(bool force_async);
     void update();
     bool isRunning() const;

--- a/indra/newview/llasyncinventoryskeletonloader.h
+++ b/indra/newview/llasyncinventoryskeletonloader.h
@@ -64,6 +64,7 @@ private:
         bool mIsLibrary = false;
         bool mEssential = false;
     S32 mCachedVersion = LLViewerInventoryCategory::VERSION_UNKNOWN;
+    S32 mRequestDepth = 1;
     };
 
     enum class Phase
@@ -88,7 +89,7 @@ private:
     void handleFetchComplete(const LLUUID& request_id, const LLUUID& response_id);
     void evaluateChildren(const FetchRequest& request, bool force_changed_scan);
     void discoverEssentialFolders();
-    void enqueueFetch(const LLUUID& category_id, bool is_library, bool essential, S32 cached_version);
+    void enqueueFetch(const LLUUID& category_id, bool is_library, bool essential, S32 cached_version, S32 depth = 1);
     bool isCategoryUpToDate(const LLViewerInventoryCategory* cat, S32 cached_version) const;
     AISAPI::ITEM_TYPE requestType(bool is_library) const;
     void markEssentialReady();

--- a/indra/newview/llinventorymodel.cpp
+++ b/indra/newview/llinventorymodel.cpp
@@ -3926,15 +3926,10 @@ bool LLInventoryModel::loadFromFile(const std::string& filename,
             LLSD::array_const_iterator end = llsd_cats.endArray();
             for (; iter != end; ++iter)
             {
-                LLSD::array_const_iterator iter = llsd_cats.beginArray();
-                LLSD::array_const_iterator end  = llsd_cats.endArray();
-                for (; iter != end; ++iter)
+                LLPointer<LLViewerInventoryCategory> inv_cat = new LLViewerInventoryCategory(LLUUID::null);
+                if (inv_cat->importLLSDMap(*iter))
                 {
-                    LLPointer<LLViewerInventoryCategory> inv_cat = new LLViewerInventoryCategory(LLUUID::null);
-                    if (inv_cat->importLLSDMap(*iter))
-                    {
-                        categories.push_back(inv_cat);
-                    }
+                    categories.push_back(inv_cat);
                 }
             }
         }

--- a/indra/newview/llinventorymodel.cpp
+++ b/indra/newview/llinventorymodel.cpp
@@ -5031,17 +5031,22 @@ LLPointer<LLInventoryValidationInfo> LLInventoryModel::validate() const
         }
         else if (cats->size() + items->size() != cat->getDescendentCount())
         {
-            // In the case of library this is not unexpected, since
-            // different user accounts may be getting the library
-            // contents from different inventory hosts.
-            if (topmost_ancestor_id.isNull() || topmost_ancestor_id != getLibraryRootFolderID())
+            // During async loading, descendent counts are expected to mismatch
+            // since only a subset of inventory is locally present.
+            if (!mAllowAsyncInventoryUpdates)
             {
-                LL_WARNS(LOG_INV) << "invalid desc count for " << cat_id << " [" << getFullPath(cat) << "]"
+                // In the case of library this is not unexpected, since
+                // different user accounts may be getting the library
+                // contents from different inventory hosts.
+                if (topmost_ancestor_id.isNull() || topmost_ancestor_id != getLibraryRootFolderID())
+                {
+                    LL_WARNS(LOG_INV) << "invalid desc count for " << cat_id << " [" << getFullPath(cat) << "]"
                                       << " cached " << cat->getDescendentCount()
                                       << " expected " << cats->size() << "+" << items->size()
-                                      << "=" << cats->size() +items->size() << LL_ENDL;
-                validation_info->mWarnings["invalid_descendent_count"]++;
-                warning_count++;
+                                      << "=" << cats->size() + items->size() << LL_ENDL;
+                    validation_info->mWarnings["invalid_descendent_count"]++;
+                    warning_count++;
+                }
             }
         }
         if (cat->getVersion() == LLViewerInventoryCategory::VERSION_UNKNOWN)

--- a/indra/newview/llinventorymodel.cpp
+++ b/indra/newview/llinventorymodel.cpp
@@ -2459,7 +2459,7 @@ void LLInventoryModel::cache(
         LL_WARNS(LOG_INV) << "Nothing to cache for " << parent_folder_id << LL_ENDL;
         return;
     }
-  
+
     // Fallback pass: catch any categories/items that collectDescendentsIf missed.
     // This can happen when:
     // 1. Categories have VERSION_UNKNOWN (e.g., during async loading)

--- a/indra/newview/llinventorypanel.cpp
+++ b/indra/newview/llinventorypanel.cpp
@@ -1045,22 +1045,62 @@ void LLInventoryPanel::initializeViews(F64 max_time)
 void LLInventoryPanel::initRootContent()
 {
     // Optimization: Build root folder and its immediate children (system folders)
-    // but not grandchildren. Children will be built lazily when folders are expanded.
-    // This ensures system folder widgets exist while avoiding the full tree build.
+    // but not grandchildren. Essential system folders (Calling Cards, My Outfits,
+    // Marketplace, etc.) also get their immediate children built so that nested
+    // system content (e.g. Friends subfolder, outfit folders) is available at init.
+    // Everything deeper is built lazily when folders are expanded.
     LLUUID root_id = getRootFolderID();
     if (root_id.notNull())
     {
         LLInventoryObject const* objectp = mInventory->getObject(root_id);
         buildNewViews(root_id, objectp, nullptr, BUILD_ONE_FOLDER);
+        buildEssentialChildViews(root_id);
     }
     else
     {
         // Default case: always add "My Inventory" root first, "Library" root second
         LLInventoryObject const* my_inv = mInventory->getObject(gInventory.getRootFolderID());
         buildNewViews(gInventory.getRootFolderID(), my_inv, nullptr, BUILD_ONE_FOLDER);
+        buildEssentialChildViews(gInventory.getRootFolderID());
 
         LLInventoryObject const* library = mInventory->getObject(gInventory.getLibraryRootFolderID());
         buildNewViews(gInventory.getLibraryRootFolderID(), library, nullptr, BUILD_ONE_FOLDER);
+    }
+}
+
+void LLInventoryPanel::buildEssentialChildViews(const LLUUID& root_id)
+{
+    // After building root + immediate children, also build one level deeper
+    // for essential system folders so their content is available at startup.
+    LLInventoryModel::cat_array_t* categories = nullptr;
+    LLInventoryModel::item_array_t* items = nullptr;
+    mInventory->getDirectDescendentsOf(root_id, categories, items);
+    if (!categories)
+    {
+        return;
+    }
+
+    for (const auto& cat : *categories)
+    {
+        if (!cat)
+        {
+            continue;
+        }
+        const LLFolderType::EType pref_type = cat->getPreferredType();
+        if (pref_type == LLFolderType::FT_NONE)
+        {
+            continue;
+        }
+        // Build immediate children for essential system folders
+        if (LLFolderType::lookupIsEssentialType(pref_type))
+        {
+            const LLUUID& cat_id = cat->getUUID();
+            LLInventoryObject const* objectp = mInventory->getObject(cat_id);
+            if (objectp)
+            {
+                buildNewViews(cat_id, objectp, getItemByID(cat_id), BUILD_ONE_FOLDER);
+            }
+        }
     }
 }
 

--- a/indra/newview/llinventorypanel.cpp
+++ b/indra/newview/llinventorypanel.cpp
@@ -1044,25 +1044,23 @@ void LLInventoryPanel::initializeViews(F64 max_time)
 
 void LLInventoryPanel::initRootContent()
 {
-    // Optimization: Only build root folder widget initially, no children.
-    // Children will be built lazily when folders are expanded/opened.
-    // This dramatically reduces startup time with large inventories (100k+ items).
-    // Instead of creating 430k widgets upfront (12 seconds), we create them on-demand.
+    // Optimization: Build root folder and its immediate children (system folders)
+    // but not grandchildren. Children will be built lazily when folders are expanded.
+    // This ensures system folder widgets exist while avoiding the full tree build.
     LLUUID root_id = getRootFolderID();
     if (root_id.notNull())
     {
         LLInventoryObject const* objectp = mInventory->getObject(root_id);
-        buildNewViews(root_id, objectp, nullptr, BUILD_NO_CHILDREN);
+        buildNewViews(root_id, objectp, nullptr, BUILD_ONE_FOLDER);
     }
     else
     {
         // Default case: always add "My Inventory" root first, "Library" root second
-        // Build only root widgets - children will load on-demand when expanded
         LLInventoryObject const* my_inv = mInventory->getObject(gInventory.getRootFolderID());
-        buildNewViews(gInventory.getRootFolderID(), my_inv, nullptr, BUILD_NO_CHILDREN);
+        buildNewViews(gInventory.getRootFolderID(), my_inv, nullptr, BUILD_ONE_FOLDER);
 
         LLInventoryObject const* library = mInventory->getObject(gInventory.getLibraryRootFolderID());
-        buildNewViews(gInventory.getLibraryRootFolderID(), library, nullptr, BUILD_NO_CHILDREN);
+        buildNewViews(gInventory.getLibraryRootFolderID(), library, nullptr, BUILD_ONE_FOLDER);
     }
 }
 

--- a/indra/newview/llinventorypanel.h
+++ b/indra/newview/llinventorypanel.h
@@ -338,6 +338,7 @@ protected:
     // Builds the UI.  Call this once the inventory is usable.
     void                initializeViews(F64 max_time);
     virtual void        initRootContent();
+    void                buildEssentialChildViews(const LLUUID& root_id);
     virtual void        findAndInitRootContent(const LLUUID& root_id) {};
 
     // Specific inventory colors

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -1992,6 +1992,13 @@ bool idle_startup()
                                  << (gInventory.isInventoryUsable() ? "true" : "false") << LL_ENDL;
         }
 
+        // Reset stale loader state from a previous session (e.g. relog without restart)
+        if (!gAsyncInventorySkeletonLoader.isRunning()
+            && (gAsyncInventorySkeletonLoader.isComplete() || gAsyncInventorySkeletonLoader.isEssentialReady()))
+        {
+            gAsyncInventorySkeletonLoader.reset();
+        }
+
         if (!gAsyncInventorySkeletonLoader.isRunning()
             && !gAsyncInventorySkeletonLoader.isComplete()
             && !gAsyncInventorySkeletonLoader.hasFailed())


### PR DESCRIPTION
Added destructor to clean up callbacks and connection if loading is interrupted.

Fixed mChildNameCache to avoid removing wrong pointers when siblings share names.

Restored singleton initialization flow to preserve dependency tracking.

Ensured system folders are created at startup while keeping lazy loading for subfolders.