### PR TITLE
[#5665] Fix experiences search and new classifieds content rating labels showing incorrectly

### DIFF
--- a/indra/llui/llcombobox.cpp
+++ b/indra/llui/llcombobox.cpp
@@ -521,7 +521,7 @@ bool LLComboBox::setCurrentByIndex(S32 index)
         if (item->getEnabled())
         {
             mList->selectItem(item, -1, true);
-            LLSD::String label = item->getColumn(0)->getValue().asString();
+            LLSD::String label = getSelectedItemLabel();
             if (mTextEntry)
             {
                 mTextEntry->setText(label);


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/5665

Simply fixes the above issue by getting the correct selected label on combo boxes, so icons_combo_box display the correct initial label.