### PR TITLE
Replace the Snapshot to Disk shortcut with Ctrl+Shift+D

### DIFF
--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -2467,7 +2467,7 @@ function="World.EnvPreset"
             <menu_item_call
              label="Snapshot to Disk"
              name="Snapshot to Disk"
-             shortcut="control|`"
+             shortcut="control|shift|D"
              use_mac_ctrl="true">
                 <menu_item_call.on_click
                  function="File.TakeSnapshotToDisk" />


### PR DESCRIPTION
﻿The old `Snapshot to Disk` shortcut relied on an OEM key, which does not behave consistently on international keyboard layouts.

This switches it to `Ctrl+Shift+D` and leaves the existing save-to-disk behavior as-is.

Tested on Windows with `pt-BR` and `US-International`.
