### PR TITLE
Render Snapshot to Disk accelerator from the active keyboard layout

### DIFF
--- a/indra/llui/llmenugl.cpp
+++ b/indra/llui/llmenugl.cpp
@@ -316,7 +316,15 @@ bool LLMenuItemGL::addToAcceleratorList(std::list <LLMenuKeyboardBinding*> *list
 // the current accelerator key and mask to the provided string.
 void LLMenuItemGL::appendAcceleratorString( std::string& st ) const
 {
-    st = LLKeyboard::stringFromAccelerator( mAcceleratorMask, mAcceleratorKey );
+    st = LLKeyboard::stringFromAccelerator(mAcceleratorMask);
+    std::string key_string = LLKeyboard::stringFromAcceleratorMenuKey(mAcceleratorKey);
+    if ((mAcceleratorMask & MASK_NORMALKEYS) &&
+        !key_string.empty() &&
+        (key_string[0] == '-' || key_string[0] == '=' || key_string[0] == '+'))
+    {
+        st.append(" ");
+    }
+    st.append(key_string);
     LL_DEBUGS("HotKeys") << "appendAcceleratorString: " << st << LL_ENDL;
 }
 

--- a/indra/llwindow/llkeyboard.cpp
+++ b/indra/llwindow/llkeyboard.cpp
@@ -368,6 +368,22 @@ std::string LLKeyboard::stringFromKey(KEY key, bool translate)
     return res;
 }
 
+// static
+std::string LLKeyboard::stringFromAcceleratorMenuKey(KEY key, bool translate)
+{
+    if (gKeyboard != NULL)
+    {
+        return gKeyboard->stringFromAcceleratorMenuKeyImpl(key, translate);
+    }
+
+    return stringFromKey(key, translate);
+}
+
+std::string LLKeyboard::stringFromAcceleratorMenuKeyImpl(KEY key, bool translate)
+{
+    return stringFromKey(key, translate);
+}
+
 //static
 std::string LLKeyboard::stringFromMouse(EMouseClickType click, bool translate)
 {

--- a/indra/llwindow/llkeyboard.h
+++ b/indra/llwindow/llkeyboard.h
@@ -95,6 +95,7 @@ public:
     static bool     maskFromString(const std::string& str, MASK *mask);     // False on failure
     static bool     keyFromString(const std::string& str, KEY *key);            // False on failure
     static std::string stringFromKey(KEY key, bool translate = true);
+    static std::string stringFromAcceleratorMenuKey(KEY key, bool translate = true);
     static std::string stringFromMouse(EMouseClickType click, bool translate = true);
     static std::string stringFromAccelerator( MASK accel_mask ); // separated for convinience, returns with "+": "Shift+" or "Shift+Alt+"...
     static std::string stringFromAccelerator( MASK accel_mask, KEY key );
@@ -108,6 +109,7 @@ public:
 
 protected:
     void            addKeyName(KEY key, const std::string& name);
+    virtual std::string stringFromAcceleratorMenuKeyImpl(KEY key, bool translate);
 
 protected:
     std::map<U16, KEY>  mTranslateKeyMap;       // Map of translations from OS keys to Linden KEYs

--- a/indra/llwindow/llkeyboardwin32.cpp
+++ b/indra/llwindow/llkeyboardwin32.cpp
@@ -321,4 +321,46 @@ U16  LLKeyboardWin32::inverseTranslateExtendedKey(const KEY translated_key)
     return inverseTranslateKey(converted_key);
 }
 
+std::string LLKeyboardWin32::stringFromAcceleratorMenuKeyImpl(KEY key, bool translate)
+{
+    U16 os_key = inverseTranslateExtendedKey(key);
+    if (os_key == 0)
+    {
+        return LLKeyboard::stringFromAcceleratorMenuKeyImpl(key, translate);
+    }
+
+    HKL layout = GetKeyboardLayout(0);
+    UINT scan_code = MapVirtualKeyEx(os_key, MAPVK_VK_TO_VSC, layout);
+    BYTE keyboard_state[256] = {};
+    wchar_t chars[8] = {};
+    int res = ToUnicodeEx(
+        os_key,
+        scan_code,
+        keyboard_state,
+        chars,
+        8,
+        1 << 2,
+        layout);
+
+    if ((res == 1 || res == -1) && chars[0] >= 0x20)
+    {
+        std::string key_string = ll_convert_wide_to_string(std::wstring(chars, 1));
+        if (!key_string.empty())
+        {
+            if (translate)
+            {
+                LLKeyStringTranslatorFunc* trans = mStringTranslator;
+                if (trans != NULL)
+                {
+                    key_string = trans(key_string);
+                }
+            }
+
+            return key_string;
+        }
+    }
+
+    return LLKeyboard::stringFromAcceleratorMenuKeyImpl(key, translate);
+}
+
 #endif

--- a/indra/llwindow/llkeyboardwin32.h
+++ b/indra/llwindow/llkeyboardwin32.h
@@ -49,6 +49,7 @@ public:
 
 protected:
     MASK    updateModifiers();
+    std::string stringFromAcceleratorMenuKeyImpl(KEY key, bool translate) override;
     //void  setModifierKeyLevel( KEY key, bool new_state );
 private:
     std::map<U16, KEY> mTranslateNumpadMap;


### PR DESCRIPTION
This keeps the existing `Snapshot to Disk` shortcut as-is, but renders its menu accelerator from the active keyboard layout on Windows.

Tested on `US`, `US-International`, `pt-BR`, and `German`.