### PR TITLE
LLMuteList use-cached response bugfix | #5269 followup

### DIFF
--- a/indra/newview/llmutelist.cpp
+++ b/indra/newview/llmutelist.cpp
@@ -167,7 +167,8 @@ LLMuteList::LLMuteList() :
     mLoadState(ML_INITIAL),
     mLoadSource(MLS_NONE),
     mRequestStartTime(0.f),
-    mTriedCacheFallback(false)
+    mTriedCacheFallback(false),
+    mTriedRegionChangeRetry(false)
 {
     gGenericDispatcher.addHandler("emptymutelist", &sDispatchEmptyMuteList);
 
@@ -857,6 +858,9 @@ void LLMuteList::requestFromServer(const LLUUID& agent_id)
         // Guard against potentially writing back to disk since we're not recovering our connection
         mLoadState = ML_LOADED;
         mLoadSource = MLS_FALLBACK_CACHE;
+        // This code path means we have disconnected/crashed before our request has been sent.
+        // As a result we do not NEED to do anything more than set these state values.
+        // cache() is liable to be called on shutdown, but since we've set a dirty state it will avoid writing to disk.
         return;
     }
     if (!gAgent.getRegion())

--- a/indra/newview/llmutelist.cpp
+++ b/indra/newview/llmutelist.cpp
@@ -879,7 +879,7 @@ void LLMuteList::requestFromServer(const LLUUID& agent_id)
 void LLMuteList::cache(const LLUUID& agent_id)
 {
     // Write to disk even if empty, but never from degraded fallback state.
-    if (isLoaded() && mLoadSource != MLS_FALLBACK_CACHE)
+    if (isLoaded() && !isLoadedDegraded())
     {
         const std::string filename = getCacheFilename(agent_id);
         saveToFile(filename);

--- a/indra/newview/llmutelist.h
+++ b/indra/newview/llmutelist.h
@@ -129,9 +129,9 @@ public:
     // Load state accessors.
     bool isLoaded() const { return mLoadState == ML_LOADED; } // Loaded, but not necessarily from server.
     bool isFailed() const { return mLoadState == ML_FAILED; } // Unable to load any mute list. Server did not reply.
-    // Loaded from server, which is the only source we consider authoritative.
-    bool isLoadedFromServer() const { return isLoaded() && (mLoadSource == MLS_SERVER || mLoadSource == MLS_SERVER_EMPTY); }
-    // Loaded, but from cache. Would be nice to upgrade to a server load from here if possible.
+    // Loaded from an authoritative server response, including when the server directs us to use our cached copy.
+    bool isLoadedFromServer() const { return isLoaded() && (mLoadSource == MLS_SERVER || mLoadSource == MLS_SERVER_EMPTY || mLoadSource == MLS_SERVER_CACHE); }
+    // Loaded without an authoritative server response. Would be nice to upgrade to a server load from here if possible.
     bool isLoadedDegraded() const { return isLoaded() && !isLoadedFromServer(); }
 
     // Advance the load state machine, trying cache fallback if necessary.


### PR DESCRIPTION
## Description

This is a followup to PR #5269 which fixes a bug discovered during offline code review. The bug occurs when the viewer sends a mute list request to the simulator, and receives a used cache response in exchange. This load source is not accepted by `LLMuteList::isLoadedFromServer()` correctly as currently written, causing the recovery attempt on region change to not be disconnected.

To fix this, `isLoadedFromServer()` now also checks for `mLoadSource == MLS_SERVER_CACHE` causing `mRegionChangedCallback` to get disconnected as should during the execution of `LLMuteList::setLoaded()`.

Huge thanks to Pantera for pointing out this bug in my previous PR, and directly suggesting or inspiring the following changes.

## Summary of additional changes

- Added missing initialization for `mTriedRegionChangeRetry` to `LLMuteList`.
- Added additional insight to the comments in `LLMuteList::requestFromServer()` for the `gDisconnected` path to justify the choices made there.
  - **Why:** It was not sufficiently clear why the choice was made to not notify observers, etc. In the previous PR there was a revision with more robust handling here, but it was determined during review at the time that this was unnecessary. The comments now reflect that this is a needs-focused path in terms of UX with focus instead on preserving existing disk cache integrity and facilitating a faster teardown.
- Aim for more predictable results in `LLMuteList::cache()` by requiring `isLoaded() && !isLoadedDegraded()` rather than simply `isLoaded() && mLoadSource != MLS_FALLBACK_CACHE` before writing to disk.
  - **Why:** This was not broken or wrong as written, so this is just a maintainability / readability improvement.

There have to be other things that can be done better, but I wanted to get this fix out into the world before viewers with the defective code make it too far into the wild.

### Project branch note
I targeted develop for this PR as is customary, but I do see that the previous revision of this work has landed in the graphics care package branch. I wanted to flag this in the event this project branch does not get further updates from develop before reaching beta/rc/release.