### PR TITLE
#1355 Permit smaller values in cloud scroll rate

### DIFF
--- a/indra/llui/llxyvector.cpp
+++ b/indra/llui/llxyvector.cpp
@@ -211,7 +211,16 @@ void LLXYVector::draw()
         mGhostY = pointY;
     }
 
-    if (abs(mValueX) >= mIncrementX || abs(mValueY) >= mIncrementY)
+    S32 dx = abs(pointX - centerX);
+    S32 dy = abs(pointY - centerY);
+    bool draw_arrow =
+        (abs(mValueX) >= mIncrementX || abs(mValueY) >= mIncrementY)
+        && (dx >= 1 || dy >= 1); // At least 1 pixel displacement
+
+    // Todo: Arrow doesn't display well with small values.
+    // Ex: (0.1, 0.05) will point to the right, as if it is (0.1, 0.0)
+    // as position will be offset by a single pixes on X, and 0 pixels on Y.
+    if (draw_arrow)
     {
         // draw the vector arrow
         drawArrow(centerX, centerY, pointX, pointY, mArrowColor);

--- a/indra/newview/skins/default/xui/en/panel_settings_sky_clouds.xml
+++ b/indra/newview/skins/default/xui/en/panel_settings_sky_clouds.xml
@@ -138,7 +138,9 @@
                     min_val_x="-30"
                     max_val_x="30"
                     min_val_y="-30"
-                    max_val_y="30" 
+                    max_val_y="30"
+                    increment_x="0.01f"
+                    increment_y="0.01f"
                     logarithmic="true"/>
 
             <text


### PR DESCRIPTION
Default value for day cycle is (0.2, 0.01), UI should permit setting such values.

P.S. But we might want to keep the 0.05 increment for the arrow.