### PR TITLE
#2965 Indicate when role members aren't loaded

### DIFF
--- a/indra/newview/llpanelgrouproles.cpp
+++ b/indra/newview/llpanelgrouproles.cpp
@@ -1938,9 +1938,11 @@ LLPanelGroupRolesSubTab::LLPanelGroupRolesSubTab()
     mRolesList(NULL),
     mAssignedMembersList(NULL),
     mAllowedActionsList(NULL),
+    mActionDescription(NULL),
     mRoleName(NULL),
     mRoleTitle(NULL),
     mRoleDescription(NULL),
+    mMembersNotLoadedLbl(NULL),
     mMemberVisibleCheck(NULL),
     mDeleteRoleButton(NULL),
     mCopyRoleButton(NULL),
@@ -1969,6 +1971,7 @@ bool LLPanelGroupRolesSubTab::postBuildSubTab(LLView* root)
     mAssignedMembersList = parent->getChild<LLNameListCtrl>("role_assigned_members");
     mAllowedActionsList = parent->getChild<LLScrollListCtrl>("role_allowed_actions");
     mActionDescription  = parent->getChild<LLTextEditor>("role_action_description");
+    mMembersNotLoadedLbl = parent->getChild<LLUICtrl>("members_not_loaded");
 
     mRoleName = parent->getChild<LLLineEditor>("role_name");
     mRoleTitle = parent->getChild<LLLineEditor>("role_title");
@@ -2199,12 +2202,18 @@ void LLPanelGroupRolesSubTab::update(LLGroupChange gc)
         }
     }
 
-    if ((GC_ROLE_MEMBER_DATA == gc || GC_MEMBER_DATA == gc)
-        && gdatap
-        && gdatap->isMemberDataComplete()
-        && gdatap->isRoleMemberDataComplete())
+    if (gdatap && gdatap->isMemberDataComplete())
     {
-        buildMembersList();
+        if ((GC_ROLE_MEMBER_DATA == gc || GC_MEMBER_DATA == gc)
+            && gdatap->isRoleMemberDataComplete())
+        {
+            buildMembersList();
+        }
+        mMembersNotLoadedLbl->setVisible(false);
+    }
+    else
+    {
+        mMembersNotLoadedLbl->setVisible(true);
     }
 }
 

--- a/indra/newview/llpanelgrouproles.h
+++ b/indra/newview/llpanelgrouproles.h
@@ -297,6 +297,7 @@ protected:
     LLLineEditor* mRoleTitle;
     LLTextEditor* mRoleDescription;
 
+    LLUICtrl*       mMembersNotLoadedLbl;
     LLCheckBoxCtrl* mMemberVisibleCheck;
     LLButton*       mDeleteRoleButton;
     LLButton*       mCreateRoleButton;

--- a/indra/newview/skins/default/xui/en/panel_group_roles.xml
+++ b/indra/newview/skins/default/xui/en/panel_group_roles.xml
@@ -565,6 +565,18 @@ things in this group. There&apos;s a broad variety of Abilities.
          right="-1"
          name="role_assigned_members"
          top_pad="0" />
+        <text
+         type="string"
+         height="125"
+         layout="topleft"
+         follows="left|top"
+         left="5"
+         name="members_not_loaded"
+         visible="false"
+         top_delta="3"
+         width="300">
+             Members are not loaded
+        </text>
         <check_box
          height="15"
          label="Reveal members"


### PR DESCRIPTION
Members only get loaded when you switch to members tab, show that list is not loaded, not empty.