### PR TITLE
secondlife/viewer#5702: Ensure non-visible preloaded media has PRIORITY_HIDDEN

### DIFF
--- a/indra/newview/llmediactrl.cpp
+++ b/indra/newview/llmediactrl.cpp
@@ -739,7 +739,7 @@ bool LLMediaCtrl::ensureMediaSourceExists()
             mMediaSource->setUsedInUI(true);
             mMediaSource->setHomeURL(mHomePageUrl, mHomePageMimeType);
             mMediaSource->setTarget(mTarget);
-            mMediaSource->setVisible( getVisible() );
+            mMediaSource->setVisible( isInVisibleChain() );
             mMediaSource->addObserver( this );
             mMediaSource->setBackgroundColor( getBackgroundColor() );
             mMediaSource->setTrustedBrowser(mTrusted);


### PR DESCRIPTION
## Description

This fix reduces, but does not eliminate, browser updates while the respective floater is not opened.

Unfortunately, setting the priority to `PRIORITY_HIDDEN` does not reduce the update rate to 1 Hz. Instead, the browser is updated in quick bursts of many updates (about 10 per burst on my machine), 1 second apart. These updates in turn send graphics update messages to `LLPluginClassMedia::receivePluginMessage`, which may trigger one or more calls to `doMediaTexUpdate` per browser per second. Activity rate varies by web content.

Future potential work in order of risk level:

- ~Investigate setting the priority of browser updates in CEF~
- ~We may be able to add a function in dullahan which sets the framerate of the browser itself (`CefBrowserHost::SetWindowlessFrameRate`), and that could make updates truly 1 Hz.~
  - ~Alternatively, we may be able to reduce calls to the idle function based on priority (see `LLPluginProcessChild::idle` sending "idle" messages~
  - (it turns out frame limiting is working correctly but updates are still excessive)
- Investigate if it's possible to disable graphical updates when not visible
- Investigate suspending the preloaded webpage rather than stopping it

## Related Issues

- [x] https://github.com/secondlife/viewer/issues/5702

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

## Test plan

The browser update frequency for floaters should be reduced when the floater has never been opened. This should not significantly impact functionality. I recommend checking behavior of open/closed state of applicable floaters (marketplace, search, destinations, browser, etc).