### PR TITLE
Fix P2P text chat timeout on WebRTC regions and delay voice renegotiation on disconnect

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -811,6 +811,8 @@ LLWebRTCPeerConnectionImpl::LLWebRTCPeerConnectionImpl() :
     mPeerConnection(nullptr),
     mMute(MUTE_INITIAL),
     mAnswerReceived(false),
+    mPeerConnectionState(webrtc::PeerConnectionInterface::PeerConnectionState::kNew),
+    mDisconnectCount(0),
     mPendingJobs(0)
 {
 }
@@ -1237,10 +1239,14 @@ void LLWebRTCPeerConnectionImpl::OnIceGatheringChange(webrtc::PeerConnectionInte
     }
 }
 
+static const webrtc::TimeDelta DISCONNECT_RENEGOTIATE_DELAY = webrtc::TimeDelta::Millis(10000);
+
 // Called any time the PeerConnectionState changes.
 void LLWebRTCPeerConnectionImpl::OnConnectionChange(webrtc::PeerConnectionInterface::PeerConnectionState new_state)
 {
     RTC_LOG(LS_ERROR) << __FUNCTION__ << " Peer Connection State Change " << new_state;
+
+    mPeerConnectionState = new_state;
 
     switch (new_state)
     {
@@ -1257,13 +1263,32 @@ void LLWebRTCPeerConnectionImpl::OnConnectionChange(webrtc::PeerConnectionInterf
             break;
         }
         case webrtc::PeerConnectionInterface::PeerConnectionState::kFailed:
-        case webrtc::PeerConnectionInterface::PeerConnectionState::kDisconnected:
         {
             for (auto &observer : mSignalingObserverList)
             {
                 observer->OnRenegotiationNeeded();
             }
-
+            break;
+        }
+        case webrtc::PeerConnectionInterface::PeerConnectionState::kDisconnected:
+        {
+            // Wait 10 seconds before renegotiating in case the connection recovers on its own.
+            // Use a sequence count so that only the most recent disconnect transition can trigger
+            // a renegotiation, avoiding stale delayed tasks from earlier disconnect/reconnect cycles.
+            uint32_t disconnect_count = ++mDisconnectCount;
+            mWebRTCImpl->PostDelayedSignalingTask(
+                [this, disconnect_count]()
+                {
+                    if (disconnect_count == mDisconnectCount
+                        && mPeerConnectionState == webrtc::PeerConnectionInterface::PeerConnectionState::kDisconnected)
+                    {
+                        for (auto &observer : mSignalingObserverList)
+                        {
+                            observer->OnRenegotiationNeeded();
+                        }
+                    }
+                },
+                DISCONNECT_RENEGOTIATE_DELAY);
             break;
         }
         default:

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -480,6 +480,13 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceO
         mSignalingThread->PostTask(std::move(task), location);
     }
 
+    void PostDelayedSignalingTask(absl::AnyInvocable<void() &&> task,
+                  webrtc::TimeDelta delay,
+                  const webrtc::Location& location = webrtc::Location::Current())
+    {
+        mSignalingThread->PostDelayedTask(std::move(task), delay, location);
+    }
+
     void PostNetworkTask(absl::AnyInvocable<void() &&> task,
                   const webrtc::Location& location = webrtc::Location::Current())
     {
@@ -675,6 +682,10 @@ class LLWebRTCPeerConnectionImpl : public LLWebRTCPeerConnectionInterface,
     // data
     std::vector<LLWebRTCDataObserver *> mDataObserverList;
     webrtc::scoped_refptr<webrtc::DataChannelInterface> mDataChannel;
+
+    // connection state tracking for delayed renegotiation on disconnect
+    webrtc::PeerConnectionInterface::PeerConnectionState mPeerConnectionState;
+    uint32_t mDisconnectCount;
 
     std::atomic<int> mPendingJobs;
 };

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -775,7 +775,8 @@ LLIMModel::LLIMSession::LLIMSession(const LLUUID& session_id,
 
     //we need to wait for session initialization for outgoing ad-hoc and group chat session
     //correct session id for initiated ad-hoc chat will be received from the server
-    if (!LLIMModel::getInstance()->sendStartSession(mSessionID, mOtherParticipantID, mInitialTargetIDs, mType, mP2PAsAdhocCall))
+    //only use p2p-as-adhoc server init when this is actually a voice call, not a text-only IM
+    if (!LLIMModel::getInstance()->sendStartSession(mSessionID, mOtherParticipantID, mInitialTargetIDs, mType, mP2PAsAdhocCall && mStartedAsIMCall))
     {
         //we don't need to wait for any responses
         //so we're already initialized

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -775,8 +775,7 @@ LLIMModel::LLIMSession::LLIMSession(const LLUUID& session_id,
 
     //we need to wait for session initialization for outgoing ad-hoc and group chat session
     //correct session id for initiated ad-hoc chat will be received from the server
-    //only use p2p-as-adhoc server init when this is actually a voice call, not a text-only IM
-    if (!LLIMModel::getInstance()->sendStartSession(mSessionID, mOtherParticipantID, mInitialTargetIDs, mType, mP2PAsAdhocCall && mStartedAsIMCall))
+    if (!LLIMModel::getInstance()->sendStartSession(mSessionID, mOtherParticipantID, mInitialTargetIDs, mType, mP2PAsAdhocCall))
     {
         //we don't need to wait for any responses
         //so we're already initialized


### PR DESCRIPTION
Split kFailed and kDisconnected handling in OnConnectionChange. kFailed still renegotiates immediately. kDisconnected now waits 10 seconds before renegotiating, giving the connection time to recover on its own. Uses a sequence counter to ensure only the most recent disconnect transition can trigger renegotiation, preventing stale delayed tasks from firing early after disconnect/reconnect cycles.

For WebRTC:
* Do general smoke test.
* Use clumsy with the following settings: "tcp or udp", lag 1000, drop 100%
* set up a viewer on the machine with clumsy, and another viewer on a different machine.
* Talk from the 'different machine' viewer so the other viewer can hear.
* "Start" on clumsy
* Validate that audio stops
* Wait 10 seconds and validate that the talk button doesn't disable (it will after about 5 seconds on the release viewer)
* "Stop" on clumsy
* Expect audio almost immediately


