### PR TITLE
[#5707] Revert PR#426 Get rid of a duplicate notification

### DIFF
--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -6743,6 +6743,14 @@ Your trash is overflowing. This may cause problems logging in.
   </notification>
 
   <notification
+   icon="notifytip.tga"
+   name="InventoryLimitReachedAIS"
+   type="notifytip">
+Your inventory is experiencing issues. Please, contact support.
+  <tag>fail</tag>
+  </notification>
+
+  <notification
    icon="alertmodal.tga"
    name="InventoryLimitReachedAISAlert"
    type="alertmodal">


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/5707

This notification was removed in error thinking it was a duplicate and not needed but it was indeed wanted/required.

We have had a few reports of users getting a notification error saying InventoryLimitReachedAIS does not exist.
Looking into this, if it is the first time the notification is to be shown, it shows InventoryLimitReachedAISAlert which is an alert and works, then every following time shows InventoryLimitReachedAIS which is just a notify tip instead of an alert, but that now notification errors.