### PR TITLE
(cherry pick) secondlife/viewer#5702: Ensure non-visible preloaded media has PRIORITY_HIDDEN

### DIFF
--- a/indra/newview/llmediactrl.cpp
+++ b/indra/newview/llmediactrl.cpp
@@ -739,7 +739,7 @@ bool LLMediaCtrl::ensureMediaSourceExists()
             mMediaSource->setUsedInUI(true);
             mMediaSource->setHomeURL(mHomePageUrl, mHomePageMimeType);
             mMediaSource->setTarget(mTarget);
-            mMediaSource->setVisible( getVisible() );
+            mMediaSource->setVisible( isInVisibleChain() );
             mMediaSource->addObserver( this );
             mMediaSource->setBackgroundColor( getBackgroundColor() );
             mMediaSource->setTrustedBrowser(mTrusted);


### PR DESCRIPTION
## Description

This is cherry-picked from https://github.com/secondlife/viewer/pull/5705 . See that PR for more info