### PR TITLE
#5724 Crash initing a buy_currency floater

### DIFF
--- a/indra/newview/llfloaterbuycurrency.cpp
+++ b/indra/newview/llfloaterbuycurrency.cpp
@@ -316,16 +316,23 @@ void LLFloaterBuyCurrency::handleBuyCurrency(bool has_piof, bool has_target, con
     if (has_piof)
     {
         LLFloaterBuyCurrencyUI* ui = LLFloaterReg::showTypedInstance<LLFloaterBuyCurrencyUI>("buy_currency");
-        if (has_target)
+        if (ui)
         {
-            ui->target(name, price);
+            if (has_target)
+            {
+                ui->target(name, price);
+            }
+            else
+            {
+                ui->noTarget();
+            }
+            ui->updateUI();
+            ui->collapsePanels(!has_target);
         }
         else
         {
-            ui->noTarget();
+            LL_WARNS() << "Cannot instantiate buy_currency floater" << LL_ENDL;
         }
-        ui->updateUI();
-        ui->collapsePanels(!has_target);
     }
     else
     {


### PR DESCRIPTION
I suspect a botched installation and would like to trow a 'missing files' error, but everything else work, logs are misteriously clean of any 'failed to create floater' errors and user was running viewer for a while without issues. And we handle other floaters the same way, so for now just logging the incident.