### PR TITLE
#5719 Partial detection of shutdown from task manager

### DIFF
--- a/indra/llcommon/llapp.h
+++ b/indra/llcommon/llapp.h
@@ -285,6 +285,7 @@ public:
 
 #ifdef LL_WINDOWS
     virtual bool reportCrashToBugsplat(void* pExcepInfo /*EXCEPTION_POINTERS*/) { return false; }
+    virtual bool reportCustomToBugsplat(const std::string& desription) { return false; }
 #endif
 
 public:

--- a/indra/llcommon/llapp.h
+++ b/indra/llcommon/llapp.h
@@ -285,7 +285,7 @@ public:
 
 #ifdef LL_WINDOWS
     virtual bool reportCrashToBugsplat(void* pExcepInfo /*EXCEPTION_POINTERS*/) { return false; }
-    virtual bool reportCustomToBugsplat(const std::string& desription) { return false; }
+    virtual bool reportCustomToBugsplat(const std::string& description) { return false; }
 #endif
 
 public:

--- a/indra/llcommon/llwatchdog.cpp
+++ b/indra/llcommon/llwatchdog.cpp
@@ -173,6 +173,17 @@ void LLWatchdog::add(LLWatchdogEntry* e)
 {
     lockThread();
     mSuspects.insert(e);
+
+    if (!mFrozeList.empty())
+    {
+        mFrozeList.erase(e);
+        if (mFrozeList.empty())
+        {
+            // Clear error marker file if there is no frozen threads,
+            // viewer is responsive again.
+            mClearMarkerFnc();
+        }
+    }
     unlockThread();
 }
 
@@ -183,7 +194,12 @@ void LLWatchdog::remove(LLWatchdogEntry* e)
     unlockThread();
 }
 
-void LLWatchdog::init(func_t set_error_state_callback)
+void LLWatchdog::init(
+    create_marker_func_t error_state_callback,
+    clear_marker_func_t clear_marker_callback,
+    report_func_t report_callback,
+    notify_func_t notify_callback,
+    bool crash_on_freeze)
 {
     if (!mSuspectsAccessMutex && !mTimer)
     {
@@ -196,7 +212,11 @@ void LLWatchdog::init(func_t set_error_state_callback)
         // start needs to use the mSuspectsAccessMutex
         mTimer->start();
     }
-    mCreateMarkerFnc = set_error_state_callback;
+    mCreateMarkerFnc = error_state_callback;
+    mClearMarkerFnc  = clear_marker_callback;
+    mCrashReportFnc = report_callback;
+    mNotifyFnc = notify_callback;
+    mCrashOnFreeze = crash_on_freeze;
 }
 
 void LLWatchdog::cleanup()
@@ -251,21 +271,45 @@ void LLWatchdog::run()
                 mTimer->stop();
             }
 
-            // Sets error marker file
-            mCreateMarkerFnc();
-            // Todo1: Warn user?
-            // Todo2: We probably want to report even if 5 seconds passed, just not error 'yet'.
             std::string last_state = (*result)->getLastState();
-            if (last_state.empty())
+            std::string description = "Watchdog timer for thread " + (*result)->getThreadName() + " expired";
+            if (!last_state.empty())
             {
-                LL_ERRS() << "Watchdog timer for thread " << (*result)->getThreadName()
-                    << " expired; assuming viewer is hung and crashing" << LL_ENDL;
+                description += " with state: " + last_state;
+            }
+            description += "; assuming viewer is hung and crashing";
+
+            if (!mCrashOnFreeze)
+            {
+                // Sets watchdog marker file
+                mCreateMarkerFnc(false);
+                // If it's mainloop and it somehow recovers, it will re-add itself
+                mSuspects.erase(*result);
+                mFrozeList.insert(*result);
+                LL_WARNS() << description << LL_ENDL;
             }
             else
             {
-                LL_ERRS() << "Watchdog timer for thread " << (*result)->getThreadName()
-                    << " expired with state: " << last_state
-                    << "; assuming viewer is hung and crashing" << LL_ENDL;
+
+                if (!mCrashReportFnc(description))
+                {
+                    // Sets error marker file
+                    mCreateMarkerFnc(true);
+                    // If false is returned, then we failed to report the issue to bugsplat,
+                    // instead, Notify user, then crash viewer.
+                    // Todo: ask user if viewer should quit or wait?
+                    mNotifyFnc();
+                    LL_ERRS() << description << LL_ENDL;
+                }
+                else
+                {
+                    // Sets watchdog marker file
+                    mCreateMarkerFnc(false);
+                    // Already reported, don't report again.
+                    // If it's mainloop and it somehow recovers, it will re-add itself
+                    mSuspects.erase(result);
+                    mFrozeList.insert(*result);
+                }
             }
         }
     }

--- a/indra/llcommon/llwatchdog.cpp
+++ b/indra/llcommon/llwatchdog.cpp
@@ -191,6 +191,7 @@ void LLWatchdog::remove(LLWatchdogEntry* e)
 {
     lockThread();
     mSuspects.erase(e);
+    mFrozeList.erase(e);
     unlockThread();
 }
 
@@ -284,8 +285,9 @@ void LLWatchdog::run()
                 // Sets watchdog marker file
                 mCreateMarkerFnc(false);
                 // If it's mainloop and it somehow recovers, it will re-add itself
-                mSuspects.erase(*result);
-                mFrozeList.insert(*result);
+                LLWatchdogEntry* froze_entry = *result;
+                mSuspects.erase(result);
+                mFrozeList.insert(froze_entry);
                 LL_WARNS() << description << LL_ENDL;
             }
             else
@@ -307,8 +309,9 @@ void LLWatchdog::run()
                     mCreateMarkerFnc(false);
                     // Already reported, don't report again.
                     // If it's mainloop and it somehow recovers, it will re-add itself
+                    LLWatchdogEntry* froze_entry = *result;
                     mSuspects.erase(result);
-                    mFrozeList.insert(*result);
+                    mFrozeList.insert(froze_entry);
                 }
             }
         }

--- a/indra/llcommon/llwatchdog.h
+++ b/indra/llcommon/llwatchdog.h
@@ -93,8 +93,16 @@ public:
     void add(LLWatchdogEntry* e);
     void remove(LLWatchdogEntry* e);
 
-    typedef std::function<void()> func_t;
-    void init(func_t set_error_state_callback);
+    typedef std::function<void(bool)> create_marker_func_t;
+    typedef std::function<void()> clear_marker_func_t;
+    typedef std::function<bool(std::string&)> report_func_t;
+    typedef std::function<void()> notify_func_t;
+    void init(
+        create_marker_func_t error_state_callback,
+        clear_marker_func_t clear_marker_callback,
+        report_func_t report_callback,
+        notify_func_t notify_callback,
+        bool crash_on_freeze);
     void run();
     void cleanup();
 
@@ -105,14 +113,19 @@ private:
 
     typedef std::set<LLWatchdogEntry*> SuspectsRegistry;
     SuspectsRegistry mSuspects;
+    SuspectsRegistry mFrozeList;
     LLMutex* mSuspectsAccessMutex;
     LLWatchdogTimerThread* mTimer;
     U64 mLastClockCount;
+    bool mCrashOnFreeze;
 
     // At the moment watchdog expects app to set markers in mCreateMarkerFnc,
     // but technically can be used to set any error states or do some cleanup
     // or show warnings.
-    func_t mCreateMarkerFnc;
+    create_marker_func_t mCreateMarkerFnc;
+    clear_marker_func_t mClearMarkerFnc;
+    report_func_t mCrashReportFnc;
+    notify_func_t mNotifyFnc;
 };
 
 #endif // LL_LLTHREADWATCHDOG_H

--- a/indra/llwindow/llwindowcallbacks.cpp
+++ b/indra/llwindow/llwindowcallbacks.cpp
@@ -68,6 +68,10 @@ void LLWindowCallbacks::handleMouseLeave(LLWindow *window)
     return;
 }
 
+void LLWindowCallbacks::handlePreCloseRequest()
+{
+}
+
 bool LLWindowCallbacks::handleCloseRequest(LLWindow *window, bool from_user)
 {
     //allow the window to close

--- a/indra/llwindow/llwindowcallbacks.h
+++ b/indra/llwindow/llwindowcallbacks.h
@@ -41,6 +41,8 @@ public:
     virtual bool handleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
     virtual bool handleMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask);
     virtual void handleMouseLeave(LLWindow *window);
+    // Called before close request is processed (ex: to create marker file in case OS is about to kill app).
+    virtual void handlePreCloseRequest();
     // return true to allow window to close, which will then cause handleQuit to be called
     virtual bool handleCloseRequest(LLWindow *window, bool from_user);
     virtual bool handleSessionExit(LLWindow* window);

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -508,6 +508,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
     :
     LLWindow(callbacks, fullscreen, flags),
     mAbsoluteCursorPosition(false),
+    mReceivedSCClose(false),
     mMaxGLVersion(max_gl_version),
     mMaxCores(max_cores)
 {
@@ -2524,8 +2525,15 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
         case WM_SYSCOMMAND:
         {
             LL_PROFILE_ZONE_NAMED_CATEGORY_WIN32("mwp - WM_SYSCOMMAND");
-            switch (w_param)
+            switch (w_param & 0xFFF0)
             {
+            case SC_CLOSE:
+                // User clicked close from system menu/taskbar or 'end process' from task manager
+                // Do nothing, will cause WM_CLOSE.
+                // If we don't get this message before WM_CLOSE, we are likely getting
+                // a kill from some external program. Win11 task manager Does cause SC_CLOSE.
+                window_imp->mReceivedSCClose = true;
+                break;
             case SC_KEYMENU:
                 // Disallow the ALT key from triggering the default system menu.
                 return 0;
@@ -2540,9 +2548,30 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
         case WM_CLOSE:
         {
             LL_PROFILE_ZONE_NAMED_CATEGORY_WIN32("mwp - WM_CLOSE");
-            // todo: WM_CLOSE can be caused by user and by task manager,
-            // distinguish these cases.
-            // For now assume it is always user.
+
+            window_imp->mCallbacks->handlePreCloseRequest(); // mark app as potentially closing
+            if (!window_imp->mReceivedSCClose)
+            {
+                // Some external program is trying to close the app.
+                // Assume that it's going to destroy process if it fails
+                // and try to fast-quit without confirmation or cleanup.
+                window_imp->post([=]()
+                {
+                    // Check if app needs cleanup or can be closed immediately.
+                    if (window_imp->mCallbacks->handleSessionExit(window_imp))
+                    {
+                        // Get the app to initiate cleanup.
+                        window_imp->mCallbacks->handleQuit(window_imp);
+                    }
+                });
+                return 0;
+            }
+            window_imp->mReceivedSCClose = false;
+
+            // There is no way to tell the difference between a user issued
+            // WM_CLOSE or task manager's WM_CLOSE.
+            // Assume it is a user and ask for confirmation, but create a marker file.
+            // If App keeps doing something after a second, or gets 'destroy' message clear the marker.
             window_imp->post([=]()
                 {
                     // Will the app allow the window to close?
@@ -2563,6 +2592,16 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                 PostQuitMessage(0);  // Posts WM_QUIT with an exit code of 0
             }
             return 0;
+        }
+        case WM_NCDESTROY:
+            LL_INFOS("Window") << "Received WM_NCDESTROY" << LL_ENDL;
+            break;
+        case WM_WTSSESSION_CHANGE:
+        {
+            // Detects Remote Desktop disconnects, fast user switching, session logoff
+            // w_param: WTS_CONSOLE_CONNECT, WTS_CONSOLE_DISCONNECT, WTS_SESSION_LOGOFF, etc.
+            LL_INFOS("Window") << "Received WM_WTSSESSION_CHANGE with wParam: " << (U32)w_param << LL_ENDL;
+            break;
         }
         case WM_QUERYENDSESSION:
         {
@@ -2585,6 +2624,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                 || (end_session_flags & ENDSESSION_CRITICAL) // will shutdown regardless of app state
                 || (end_session_flags & ENDSESSION_LOGOFF)) // logoff, can delay shutdown
             {
+                window_imp->mCallbacks->handlePreCloseRequest(); // mark app as closing
                 window_imp->post([=]()
                 {
                     LL_INFOS("Window") << "Shutting down due to session terminating" << LL_ENDL;
@@ -3318,7 +3358,18 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
 
         case WM_DISPLAYCHANGE:
         {
-            WINDOW_IMP_POST(window_imp->mCallbacks->handleDisplayChanged());
+            LL_PROFILE_ZONE_NAMED_CATEGORY_WIN32("mwp - WM_DISPLAYCHANGE");
+            window_imp->post([=]() {
+                window_imp->mCallbacks->handleDisplayChanged();
+                // Note: WM_DISPLAYCHANGE was passing to WM_SETFOCUS
+                // which might have been unintended and was messing with zones.
+                // handleFocus was copied over and return 0 added, but
+                // handleFocus might be not needed here.
+                // handleFocus resets mouse, closes popups and keys, which
+                // we probablt should do on 'display change'.
+                window_imp->mCallbacks->handleFocus(window_imp);
+            });
+            return 0;
         }
 
         case WM_SETFOCUS:

--- a/indra/llwindow/llwindowwin32.h
+++ b/indra/llwindow/llwindowwin32.h
@@ -238,6 +238,7 @@ protected:
     LPWSTR      mIconResource;
     LPWSTR      mIconSmallResource;
     bool        mInputProcessingPaused;
+    bool        mReceivedSCClose; // received SC_CLOSE and expecting WM_CLOSE
 
     // The following variables are for Language Text Input control.
     // They are all static, since one context is shared by all LLWindowWin32

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -384,6 +384,7 @@ const std::string START_MARKER_FILE_NAME("SecondLife.start_marker");
 const std::string ERROR_MARKER_FILE_NAME("SecondLife.error_marker");
 const std::string LOGOUT_MARKER_FILE_NAME("SecondLife.logout_marker");
 const std::string WATCHDOG_MARKER_FILE_NAME("SecondLife.watchdog_marker");
+const std::string CLOSE_EVENT_MARKER_FILE_NAME("SecondLife.close_marker");
 static std::string gLaunchFileOnQuit;
 
 //----------------------------------------------------------------------------
@@ -4121,6 +4122,7 @@ void LLAppViewer::processMarkerFiles()
     // Bugsplat will set correct state in bugsplatSendLog.
     std::string error_marker_file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, ERROR_MARKER_FILE_NAME);
     std::string watchdog_marker_file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, WATCHDOG_MARKER_FILE_NAME);
+    std::string close_marker_file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, CLOSE_EVENT_MARKER_FILE_NAME);
     if(LLAPRFile::isExist(error_marker_file, NULL, LL_APR_RB))
     {
         S32 marker_code = getMarkerErrorCode(error_marker_file);
@@ -4150,20 +4152,16 @@ void LLAppViewer::processMarkerFiles()
             LL_INFOS("MarkerFile") << "Error marker '"<< error_marker_file << "' marker found, but versions did not match" << LL_ENDL;
         }
         LLAPRFile::remove(error_marker_file);
-        if (LLAPRFile::isExist(watchdog_marker_file, NULL, LL_APR_RB))
-        {
-            // If viewer crashed after a freeze was detected,
-            // crash still takes precendence. Just clear watchdog.
-            removeWatchdogMarker();
-        }
     }
     else
     {
-        // so only check watchdog marker if there is no error marker.
-        if (LLAPRFile::isExist(watchdog_marker_file, NULL, LL_APR_RB))
+        if (LAST_EXEC_UNKNOWN == gLastExecEvent
+            || LAST_EXEC_LOGOUT_UNKNOWN == gLastExecEvent)
         {
-            if (LAST_EXEC_UNKNOWN == gLastExecEvent
-                || LAST_EXEC_LOGOUT_UNKNOWN == gLastExecEvent)
+            // If viewer crashed after a freeze was detected,
+            // crash still takes precendence.
+            // So only check watchdog marker if there is no error marker.
+            if (LLAPRFile::isExist(watchdog_marker_file, NULL, LL_APR_RB))
             {
                 // watchdog marker gets created if we detect a freeze,
                 // so if viwer did not stop gracefully, and we know it wasn't a crash,
@@ -4175,8 +4173,34 @@ void LLAppViewer::processMarkerFiles()
                         << LL_ENDL;
                 }
             }
-            removeWatchdogMarker();
+            // If 'close' marker is found, viewer either started shutdown but
+            // failed, or viewer got killed by task manager.
+            // Marker does not indicate that viewer was closed or is closing,
+            // just that 'close' was requested before viewer died.
+            else if (LLAPRFile::isExist(close_marker_file, NULL, LL_APR_RB))
+            {
+                // For now treat as 'other' cause.
+                // Unfortunately we can't for certain distinguish task
+                // manager's case from other shutdown problems, so we
+                // have to report both.
+                // Todo: if this bears noticeable fruits, make a new state later.
+                // New categories need server/web side support.
+                if (markerIsSameVersion(close_marker_file))
+                {
+                    gLastExecEvent = LAST_EXEC_UNKNOWN == gLastExecEvent ? LAST_EXEC_OTHER_CRASH : LAST_EXEC_LOGOUT_CRASH;
+                    LL_INFOS("MarkerFile") << "'Close' marker '" << close_marker_file << "' found, setting LastExecEvent to CRASH"
+                        << LL_ENDL;
+                }
+            }
         }
+    }
+    if (LLAPRFile::isExist(watchdog_marker_file, NULL, LL_APR_RB))
+    {
+        removeWatchdogMarker();
+    }
+    if (LLAPRFile::isExist(close_marker_file, NULL, LL_APR_RB))
+    {
+        removeCloseRequestMarker();
     }
 
 #if LL_DARWIN
@@ -4221,6 +4245,7 @@ void LLAppViewer::removeMarkerFiles()
         {
             LL_WARNS("MarkerFile") << "logout marker '"<<mLogoutMarkerFileName<<"' not open"<< LL_ENDL;
         }
+        removeCloseRequestMarker();
         removeWatchdogMarker();
     }
     else
@@ -5609,6 +5634,34 @@ bool LLAppViewer::errorMarkerExists() const
     return LLAPRFile::isExist(error_marker_file, NULL, LL_APR_RB);
 }
 
+void LLAppViewer::createCloseRequestMarker() const
+{
+    // WINDOW THREAD! since we need this to act fast.
+    // This does not indicate that viewer was closed or is closing,
+    // but that 'close' was requested.
+    if (!mSecondInstance)
+    {
+        std::string close_marker = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, CLOSE_EVENT_MARKER_FILE_NAME);
+
+        LLAPRFile file;
+        file.open(close_marker, LL_APR_WB);
+        if (file.getFileHandle())
+        {
+            recordMarkerVersion(file);
+            file.close();
+        }
+    }
+}
+
+void LLAppViewer::removeCloseRequestMarker() const
+{
+    if (!mSecondInstance)
+    {
+        std::string error_marker_file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, CLOSE_EVENT_MARKER_FILE_NAME);
+        LLFile::remove(error_marker_file);
+    }
+}
+
 void LLAppViewer::createWatchdogMarker() const
 {
     if (!mSecondInstance)
@@ -5624,6 +5677,7 @@ void LLAppViewer::createWatchdogMarker() const
         }
     }
 }
+
 void LLAppViewer::removeWatchdogMarker() const
 {
     if (!mSecondInstance)

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -383,6 +383,7 @@ const std::string MARKER_FILE_NAME("SecondLife.exec_marker");
 const std::string START_MARKER_FILE_NAME("SecondLife.start_marker");
 const std::string ERROR_MARKER_FILE_NAME("SecondLife.error_marker");
 const std::string LOGOUT_MARKER_FILE_NAME("SecondLife.logout_marker");
+const std::string WATCHDOG_MARKER_FILE_NAME("SecondLife.watchdog_marker");
 static std::string gLaunchFileOnQuit;
 
 //----------------------------------------------------------------------------
@@ -3235,20 +3236,60 @@ bool LLAppViewer::initWindow()
                         << " (setting = " << watchdog_enabled_setting << ")"
                         << LL_ENDL;
 
-    if (use_watchdog)
+    // Watchdog reports to statistics via marker files, that is
+    // pointless without ability to write (!mSecondInstance) those files.
+    // If use_watchdog is set, watchdog also reports to bugspat.
+    if (use_watchdog || !mSecondInstance)
     {
-        LLWatchdog::getInstance()->init([]()
-        {
-            LLAppViewer* app = LLAppViewer::instance();
-            if (app->logoutRequestSent())
+        LLWatchdog::getInstance()->init(
+            [](bool final_marker)
             {
-                app->createErrorMarker(LAST_EXEC_LOGOUT_FROZE);
-            }
-            else
+                LLAppViewer* app = LLAppViewer::instance();
+                // Without watchdog everything will be counted as
+                // either 'unknown' (no crash marker) or based of present crash marker
+                if (final_marker)
+                {
+                    // watchdog is going to crash viewer, so crate a 'crash' marker
+                    if (app->logoutRequestSent())
+                    {
+                        app->createErrorMarker(LAST_EXEC_LOGOUT_FROZE);
+                    }
+                    else
+                    {
+                        app->createErrorMarker(LAST_EXEC_FROZE);
+                    }
+                }
+                else
+                {
+                    // not going to crash, just create a 'watchdog' marker
+                    app->createWatchdogMarker();
+                }
+            },
+            []()
             {
-                app->createErrorMarker(LAST_EXEC_FROZE);
-            }
-        });
+                LLAppViewer* app = LLAppViewer::instance();
+                // in case process recovered from freeze, remove watchdog marker.
+                app->removeWatchdogMarker();
+            },
+            [](std::string &desc)
+            {
+#if LL_WINDOWS && LL_BUGSPLAT
+                LLAppViewer* app = LLAppViewer::instance();
+                app->writeDebugInfo();
+                return app->reportCustomToBugsplat(desc);
+#else
+                return false;
+#endif
+            },
+            []()
+            {
+                LLAppViewer* app = LLAppViewer::instance();
+                app->sendLogoutRequest();
+                // Might be better to ask user if user wants to terminate the app or wait.
+                OSMessageBox(LLTrans::getString("MBFreezeDetected"), LLTrans::getString("MBFatalError"), OSMB_OK);
+            },
+            use_watchdog);
+
     }
 
     LLNotificationsUI::LLNotificationManager::getInstance();
@@ -4021,13 +4062,8 @@ void LLAppViewer::processMarkerFiles()
         {
             // the file existed, is ours, and matched our version, so we can report on what it says
             LL_INFOS("MarkerFile") << "Exec marker '"<< mMarkerFileName << "' found; last exec crashed or froze" << LL_ENDL;
-#if LL_WINDOWS && LL_BUGSPLAT
-            // bugsplat will set correct state in bugsplatSendLog
-            // Might be more accurate to rename this one into 'unknown'
+            // App terminated unexpectedly or froze, we don't know the cause yet.
             gLastExecEvent = LAST_EXEC_UNKNOWN;
-#else
-            gLastExecEvent = LAST_EXEC_OTHER_CRASH;
-#endif // LL_WINDOWS
 
         }
         else
@@ -4080,22 +4116,28 @@ void LLAppViewer::processMarkerFiles()
         }
         LLAPRFile::remove(logout_marker_file);
     }
-    // and last refine based on whether or not a marker created during a non-llerr crash is found
+    // Refine based on whether or not a marker created during
+    // a crash is found or if wathdog caught a freeze.
+    // Bugsplat will set correct state in bugsplatSendLog.
     std::string error_marker_file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, ERROR_MARKER_FILE_NAME);
+    std::string watchdog_marker_file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, WATCHDOG_MARKER_FILE_NAME);
     if(LLAPRFile::isExist(error_marker_file, NULL, LL_APR_RB))
     {
         S32 marker_code = getMarkerErrorCode(error_marker_file);
         if (marker_code >= 0)
         {
-            if (gLastExecEvent == LAST_EXEC_LOGOUT_FROZE)
+            if (marker_code > 0 && marker_code < (S32)LAST_EXEC_COUNT)
             {
-                gLastExecEvent = LAST_EXEC_LOGOUT_CRASH;
-                LL_INFOS("MarkerFile") << "Error marker '"<< error_marker_file << "' crashed, setting LastExecEvent to LOGOUT_CRASH" << LL_ENDL;
-            }
-            else if (marker_code > 0 && marker_code < (S32)LAST_EXEC_COUNT)
-            {
+                // If we have a code, it takes precendence
                 gLastExecEvent = (eLastExecEvent)marker_code;
                 LL_INFOS("MarkerFile") << "Error marker '"<< error_marker_file << "' crashed, setting LastExecEvent to " << gLastExecEvent << LL_ENDL;
+            }
+            // if we have the marker, even without a code, it's a crash.
+            else if (gLastExecEvent == LAST_EXEC_LOGOUT_UNKNOWN
+                    || gLastExecEvent == LAST_EXEC_LOGOUT_FROZE)
+            {
+                gLastExecEvent = LAST_EXEC_LOGOUT_CRASH;
+                LL_INFOS("MarkerFile") << "Error marker '" << error_marker_file << "' crashed, setting LastExecEvent to LOGOUT_CRASH" << LL_ENDL;
             }
             else
             {
@@ -4108,6 +4150,33 @@ void LLAppViewer::processMarkerFiles()
             LL_INFOS("MarkerFile") << "Error marker '"<< error_marker_file << "' marker found, but versions did not match" << LL_ENDL;
         }
         LLAPRFile::remove(error_marker_file);
+        if (LLAPRFile::isExist(watchdog_marker_file, NULL, LL_APR_RB))
+        {
+            // If viewer crashed after a freeze was detected,
+            // crash still takes precendence. Just clear watchdog.
+            removeWatchdogMarker();
+        }
+    }
+    else
+    {
+        // so only check watchdog marker if there is no error marker.
+        if (LLAPRFile::isExist(watchdog_marker_file, NULL, LL_APR_RB))
+        {
+            if (LAST_EXEC_UNKNOWN == gLastExecEvent
+                || LAST_EXEC_LOGOUT_UNKNOWN == gLastExecEvent)
+            {
+                // watchdog marker gets created if we detect a freeze,
+                // so if viwer did not stop gracefully, and we know it wasn't a crash,
+                // we have no other info, check watchdog.
+                if (markerIsSameVersion(watchdog_marker_file))
+                {
+                    gLastExecEvent = LAST_EXEC_UNKNOWN == gLastExecEvent ? LAST_EXEC_FROZE : LAST_EXEC_LOGOUT_FROZE;
+                    LL_INFOS("MarkerFile") << "Watchdog marker '" << watchdog_marker_file << "' found, setting LastExecEvent to FROZE"
+                        << LL_ENDL;
+                }
+            }
+            removeWatchdogMarker();
+        }
     }
 
 #if LL_DARWIN
@@ -4152,6 +4221,7 @@ void LLAppViewer::removeMarkerFiles()
         {
             LL_WARNS("MarkerFile") << "logout marker '"<<mLogoutMarkerFileName<<"' not open"<< LL_ENDL;
         }
+        removeWatchdogMarker();
     }
     else
     {
@@ -5537,6 +5607,30 @@ bool LLAppViewer::errorMarkerExists() const
 {
     std::string error_marker_file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, ERROR_MARKER_FILE_NAME);
     return LLAPRFile::isExist(error_marker_file, NULL, LL_APR_RB);
+}
+
+void LLAppViewer::createWatchdogMarker() const
+{
+    if (!mSecondInstance)
+    {
+        std::string error_marker = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, WATCHDOG_MARKER_FILE_NAME);
+
+        LLAPRFile file;
+        file.open(error_marker, LL_APR_WB);
+        if (file.getFileHandle())
+        {
+            recordMarkerVersion(file);
+            file.close();
+        }
+    }
+}
+void LLAppViewer::removeWatchdogMarker() const
+{
+    if (!mSecondInstance)
+    {
+        std::string error_marker_file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, WATCHDOG_MARKER_FILE_NAME);
+        LLFile::remove(error_marker_file);
+    }
 }
 
 void LLAppViewer::outOfMemorySoftQuit()

--- a/indra/newview/llappviewer.h
+++ b/indra/newview/llappviewer.h
@@ -254,6 +254,8 @@ public:
     void createErrorMarker(eLastExecEvent error_code) const;
     bool errorMarkerExists() const;
 
+    void createCloseRequestMarker() const;
+    void removeCloseRequestMarker() const;
     void createWatchdogMarker() const;
     void removeWatchdogMarker() const;
 

--- a/indra/newview/llappviewer.h
+++ b/indra/newview/llappviewer.h
@@ -254,6 +254,9 @@ public:
     void createErrorMarker(eLastExecEvent error_code) const;
     bool errorMarkerExists() const;
 
+    void createWatchdogMarker() const;
+    void removeWatchdogMarker() const;
+
     // Attempt a 'soft' quit with disconnect and saving of settings/cache.
     // Intended to be thread safe.
     // Good chance of viewer crashing either way, but better than alternatives.

--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -119,7 +119,7 @@ namespace
     // MiniDmpSender pointer. As things stand, though, we must define an
     // actual function and store the pointer statically.
     static MiniDmpSender *sBugSplatSender = nullptr;
-    static std::string sBugsplatDesriptionField;
+    static std::string sBugsplatDescriptionField;
 
     bool bugsplatSendLog(UINT nCode, LPVOID lpVal1, LPVOID lpVal2)
     {
@@ -156,15 +156,15 @@ namespace
                     WCSTR(gDirUtilp->getExpandedFilename(LL_PATH_PER_SL_ACCOUNT, "settings_per_account.xml")));
             }
 
-            if (!sBugsplatDesriptionField.empty())
+            if (!sBugsplatDescriptionField.empty())
             {
                 // Can be set by watchdog or other code that detects a problem
                 // and wants to add some context to the crash report.
                 // Will be visible in the BugSplat web UI.
-                sBugSplatSender->setDefaultUserDescription(WCSTR(LLError::getFatalMessage()));
-                // This type of crash is not nessesarily a crash, or final.
+                sBugSplatSender->setDefaultUserDescription(WCSTR(sBugsplatDescriptionField));
+                // This type of crash is not necessarily a crash, or final.
                 // Prepare for the next one.
-                sBugsplatDesriptionField.clear();
+                sBugsplatDescriptionField.clear();
             }
             else
             {
@@ -892,7 +892,7 @@ bool LLAppViewerWin32::reportCustomToBugsplat(const std::string &description)
 #if defined(LL_BUGSPLAT)
     if (sBugSplatSender)
     {
-        sBugsplatDesriptionField = description;
+        sBugsplatDescriptionField = description;
 
         __try
         {

--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -119,6 +119,7 @@ namespace
     // MiniDmpSender pointer. As things stand, though, we must define an
     // actual function and store the pointer statically.
     static MiniDmpSender *sBugSplatSender = nullptr;
+    static std::string sBugsplatDesriptionField;
 
     bool bugsplatSendLog(UINT nCode, LPVOID lpVal1, LPVOID lpVal2)
     {
@@ -155,8 +156,21 @@ namespace
                     WCSTR(gDirUtilp->getExpandedFilename(LL_PATH_PER_SL_ACCOUNT, "settings_per_account.xml")));
             }
 
-            // LL_ERRS message, when there is one
-            sBugSplatSender->setDefaultUserDescription(WCSTR(LLError::getFatalMessage()));
+            if (!sBugsplatDesriptionField.empty())
+            {
+                // Can be set by watchdog or other code that detects a problem
+                // and wants to add some context to the crash report.
+                // Will be visible in the BugSplat web UI.
+                sBugSplatSender->setDefaultUserDescription(WCSTR(LLError::getFatalMessage()));
+                // This type of crash is not nessesarily a crash, or final.
+                // Prepare for the next one.
+                sBugsplatDesriptionField.clear();
+            }
+            else
+            {
+                // LL_ERRS message, when there is one
+                sBugSplatSender->setDefaultUserDescription(WCSTR(LLError::getFatalMessage()));
+            }
 
             sBugSplatSender->setAttribute(WCSTR(L"OS"), WCSTR(LLOSInfo::instance().getOSStringSimple())); // In case we ever stop using email for this
             sBugSplatSender->setAttribute(WCSTR(L"AppState"), WCSTR(LLStartUp::getStartupStateString()));
@@ -856,6 +870,38 @@ bool LLAppViewerWin32::reportCrashToBugsplat(void* pExcepInfo)
     if (sBugSplatSender)
     {
         sBugSplatSender->createReport((EXCEPTION_POINTERS*)pExcepInfo);
+        return true;
+    }
+#endif // LL_BUGSPLAT
+    return false;
+}
+
+#if defined(LL_BUGSPLAT)
+static int reportCustomToBugsplatFilter(EXCEPTION_POINTERS* pExcepInfo)
+{
+    if (sBugSplatSender)
+    {
+        sBugSplatSender->createReport(pExcepInfo);
+    }
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+#endif
+
+bool LLAppViewerWin32::reportCustomToBugsplat(const std::string &description)
+{
+#if defined(LL_BUGSPLAT)
+    if (sBugSplatSender)
+    {
+        sBugsplatDesriptionField = description;
+
+        __try
+        {
+            // Generate a custom exception code
+            RaiseException(0xE0000001, 0, 0, NULL);
+        }
+        __except (reportCustomToBugsplatFilter(GetExceptionInformation()))
+        {
+        }
         return true;
     }
 #endif // LL_BUGSPLAT

--- a/indra/newview/llappviewerwin32.h
+++ b/indra/newview/llappviewerwin32.h
@@ -44,7 +44,7 @@ public:
     bool cleanup() override;
 
     bool reportCrashToBugsplat(void* pExcepInfo) override;
-    bool reportCustomToBugsplat(const std::string& desription) override;
+    bool reportCustomToBugsplat(const std::string& description) override;
 
     // returns true if other windows were found and are still running.
     static bool sendShutdownToOtherInstances(const std::wstring& install_dir);

--- a/indra/newview/llappviewerwin32.h
+++ b/indra/newview/llappviewerwin32.h
@@ -44,6 +44,7 @@ public:
     bool cleanup() override;
 
     bool reportCrashToBugsplat(void* pExcepInfo) override;
+    bool reportCustomToBugsplat(const std::string& desription) override;
 
     // returns true if other windows were found and are still running.
     static bool sendShutdownToOtherInstances(const std::wstring& install_dir);

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -38,6 +38,7 @@
 
 #include "llagent.h"
 #include "llagentcamera.h"
+#include "llcallbacklist.h"
 #include "llcommandhandler.h"
 #include "llcommunicationchannel.h"
 #include "llfloaterreg.h"
@@ -1466,12 +1467,32 @@ void LLViewerWindow::handleMouseLeave(LLWindow *window)
     LLToolTipMgr::instance().blockToolTips();
 }
 
+void LLViewerWindow::handlePreCloseRequest()
+{
+    // WINDOW THREAD! since we need this to act fast.
+    if (!LLApp::isExiting() && !LLApp::isStopped())
+    {
+        LLAppViewer::instance()->createCloseRequestMarker();
+    }
+
+}
+
 bool LLViewerWindow::handleCloseRequest(LLWindow *window, bool from_user)
 {
     if (!LLApp::isExiting() && !LLApp::isStopped())
     {
         if (from_user)
         {
+            // Task naamger kills viewer after 1 second, 3 seconds
+            // is overkill, but decided to be on a safe side.
+            doAfterInterval([]()
+            {
+                // if user quits, marker will be cleaned by cleanup,
+                // if user cancels quit, marker will be cleaned here,
+                // but if task manager kills us, marker stays.
+                LLAppViewer::instance()->removeCloseRequestMarker();
+            }, 3.0f);
+
             // User has indicated they want to close, but we may need to ask
             // about modified documents.
             LLAppViewer::instance()->userQuit();

--- a/indra/newview/llviewerwindow.h
+++ b/indra/newview/llviewerwindow.h
@@ -202,6 +202,7 @@ public:
     /*virtual*/ bool handleUnicodeChar(llwchar uni_char, MASK mask);    // NOT going to handle extended
     /*virtual*/ bool handleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
     /*virtual*/ bool handleMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask);
+    /*virtual*/ void handlePreCloseRequest();
     /*virtual*/ bool handleCloseRequest(LLWindow *window, bool from_user);
     /*virtual*/ bool handleSessionExit(LLWindow* window);
     /*virtual*/ void handleQuit(LLWindow *window);

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -3008,6 +3008,9 @@ If this message persists, restart your computer.
 		[APP_NAME] appears to have frozen or crashed on the previous run.
 Would you like to send a crash report?
 	</string>
+    <string name="MBFreezeDetected">
+        [APP_NAME] appears to have frozen. If this issue occurs regularly, please contact support at https://support.secondlife.com.
+    </string>
 	<string name="MBAlert">Notification</string>
 	<string name="MBNoDirectX">
 		[APP_NAME] is unable to detect DirectX 9.0b or greater.


### PR DESCRIPTION
Attempt to detect task manager issued shutdowns. We can't be absolutely certain about the source in this case, but at least try to distinguish termination caused by task manager from 'unknown' crashes.

This change depends onto previous watchdog improvements, so I had to cherry pick it from 26.2 early.