### PR TITLE
Fix picks pointing to the wrong location if the region moved

### DIFF
--- a/indra/newview/llpanelprofilepicks.cpp
+++ b/indra/newview/llpanelprofilepicks.cpp
@@ -896,6 +896,10 @@ void LLPanelProfilePick::sendParcelInfoRequest()
 
 void LLPanelProfilePick::processParcelInfo(const LLParcelData& parcel_data)
 {
+    // Region might have moved since the pick was saved; refresh the stored global position
+    // using the parcel info so map/teleport use the current location.
+    setPosGlobal(LLVector3d(parcel_data.global_x, parcel_data.global_y, parcel_data.global_z));
+
     setPickLocation(createLocationText(LLStringUtil::null, parcel_data.name, parcel_data.sim_name, getPosGlobal()));
 
     // We have received parcel info for the requested ID so clear it now.


### PR DESCRIPTION
This fixes #5519

A pick pointing to an old region will use the wrong global coordinate. 
You can test the fix using Dan Linden's "bug island" pick that is pointing to the old global coordinates.

This change makes it so the global coordinate used are the latest received instead of the potentially stale ones
