### PR TITLE
fix: shrink profile tab minimum width

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_profile.xml
+++ b/indra/newview/skins/default/xui/en/floater_profile.xml
@@ -31,7 +31,7 @@
          follows="all"
          layout="topleft"
          halign="center"
-         tab_min_width="81"
+         tab_min_width="70"
          tab_height="30"
          tab_position="top"
         >


### PR DESCRIPTION
## Summary
- reduce the profile tab minimum width from 81 to 70 so all six tabs fit again in the 505px profile floater
- keep the fix scoped to the profile floater XUI instead of changing shared tab container behavior

## Testing
- parsed `indra/newview/skins/default/xui/en/floater_profile.xml` with Python's `xml.etree.ElementTree`
- ran `git diff --check`

Fixes #5733
