### PR TITLE
fix: replace non-ASCII source comments

### DIFF
--- a/indra/llfilesystem/lldiskcache.cpp
+++ b/indra/llfilesystem/lldiskcache.cpp
@@ -64,9 +64,9 @@ LLDiskCache::LLDiskCache(const std::string& cache_dir,
 // WARNING: purge() is called by LLPurgeDiskCacheThread. As such it must
 // NOT touch any LLDiskCache data without introducing and locking a mutex!
 
-// Interaction through the filesystem itself should be safe. Let’s say thread
+// Interaction through the filesystem itself should be safe. Let's say thread
 // A is accessing the cache file for reading/writing and thread B is trimming
-// the cache. Let’s also assume using llifstream to open a file and
+// the cache. Let's also assume using llifstream to open a file and
 // boost::filesystem::remove are not atomic (which will be pretty much the
 // case).
 

--- a/indra/llkdu/llimagej2ckdu.cpp
+++ b/indra/llkdu/llimagej2ckdu.cpp
@@ -228,11 +228,11 @@ struct LLKDUMessageError : public LLKDUMessage
     {
         // According to the documentation nat found:
         // http://pirlwww.lpl.arizona.edu/resources/guide/software/Kakadu/html_pages/globals__kdu$mize_errors.html
-        // "If a kdu_error object is destroyed, handler→flush will be called with
+        // "If a kdu_error object is destroyed, handler->flush will be called with
         // an end_of_message argument equal to true and the process will
         // subsequently be terminated through exit. The termination may be
         // avoided, however, by throwing an exception from within the message
-        // terminating handler→flush call."
+        // terminating handler->flush call."
         // So throwing an exception here isn't arbitrary: we MUST throw an
         // exception if we want to recover from a KDU error.
         // Because this confused me: the above quote specifically refers to


### PR DESCRIPTION
## Summary
Fixes #5664

- Replaced the remaining non-ASCII punctuation in source comments with ASCII equivalents.
- Kept the change limited to comments so generated code behavior is unchanged.

/claim #5664

## Testing
- `python3` byte scan confirmed no non-ASCII bytes remain in the issue-mentioned files (`indra/llimagej2coj/llimagej2coj.cpp`, `indra/newview/llvelopack.cpp`) and the two follow-up source files changed here (`indra/llkdu/llimagej2ckdu.cpp`, `indra/llfilesystem/lldiskcache.cpp`).
- `git diff --check`
