### PR TITLE
fix: guard LLConsole font initialization

### DIFF
--- a/indra/llui/llconsole.cpp
+++ b/indra/llui/llconsole.cpp
@@ -59,13 +59,17 @@ LLConsole::LLConsole(const LLConsole::Params& p)
 :   LLUICtrl(p),
     LLFixedBuffer(p.max_lines),
     mLinePersistTime(p.persist_time), // seconds
-    mFont(p.font),
+    mFont(p.font.isProvided() ? static_cast<const LLFontGL*>(p.font) : LLFontGL::getFontDefault()),
     mConsoleWidth(0),
     mConsoleHeight(0)
 {
     if (p.font_size_index.isProvided())
     {
         setFontSize(p.font_size_index);
+    }
+    else if (mFont == NULL)
+    {
+        mFont = LLFontGL::getFontDefault();
     }
     mFadeTime = mLinePersistTime - FADE_DURATION;
     setMaxLines(LLUI::getInstance()->mSettingGroups["config"]->getS32("ConsoleMaxLines"));


### PR DESCRIPTION
## Summary
- Ensure LLConsole starts with a valid fallback font when the `font` param is missing or unresolved during startup.
- Preserve the existing `font_size_index` override behavior.
- Prevent the startup crash in `LLConsole::reshape()` caused by calling `LLFontGL::getLineHeight()` on a null font pointer.

## Changes
- Initialize `mFont` with `LLFontGL::getFontDefault()` when `p.font` is not provided.
- Add a secondary null guard in the constructor for the case where the provided font resolves to null and no size override is present.

## Testing
- `python3` source assertions verifying the fallback initialization and null guard are present in `indra/llui/llconsole.cpp`
- `git diff --check`

Fixes #5726

/claim #5726