### PR TITLE
fix: reduce oversized callback texture loading

### DIFF
--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -1781,6 +1781,17 @@ void LLViewerFetchedTexture::processTextureStats()
         {
             mDesiredDiscardLevel =  llmin(getMaxDiscardLevel(), (S32)mLoadedCallbackDesiredDiscardLevel);
         }
+        else if (mSaveRawImage
+                 && mBoostLevel == LLGLTexture::BOOST_NONE
+                 && mKnownDrawWidth > 0
+                 && mKnownDrawHeight > 0)
+        {
+            mDesiredDiscardLevel = (S8)llmin(log((F32)mFullWidth / mKnownDrawWidth) / log_2,
+                                             log((F32)mFullHeight / mKnownDrawHeight) / log_2);
+            mDesiredDiscardLevel = llclamp(mDesiredDiscardLevel, (S8)0, (S8)getMaxDiscardLevel());
+            mDesiredDiscardLevel = llmin(mDesiredDiscardLevel, mMinDesiredDiscardLevel);
+            mDesiredDiscardLevel = llmin(mDesiredDiscardLevel, (S32)mLoadedCallbackDesiredDiscardLevel);
+        }
         else
         {
             if(!mKnownDrawWidth || !mKnownDrawHeight || (S32)mFullWidth <= mKnownDrawWidth || (S32)mFullHeight <= mKnownDrawHeight)
@@ -2345,6 +2356,14 @@ void LLViewerFetchedTexture::setLoadedCallback( loaded_callback_func loaded_call
     if(keep_imageraw)
     {
         mSaveRawImage = true;
+
+        if (mBoostLevel == LLGLTexture::BOOST_NONE
+            && mKnownDrawWidth > 0
+            && mKnownDrawHeight > 0
+            && (mKnownDrawWidth < mFullWidth || mKnownDrawHeight < mFullHeight))
+        {
+            setBoostLevel(LLGLTexture::BOOST_THUMBNAIL);
+        }
     }
     if (mNeedsAux && mAuxRawImage.isNull() && getDiscardLevel() >= 0)
     {


### PR DESCRIPTION
## Summary
- reduce fetched-texture callback requests for oversized textures when callers only need a smaller retained raw image
- reuse existing known draw size logic to request an appropriate discard level instead of defaulting to full resolution
- mark those retained callback textures as thumbnail-priority so they follow the existing oversize downscaling path before GL upload

## Testing
- git diff --check
- python3 sanity check confirming the new discard-selection branch and thumbnail boost hook are present exactly once
- manual code inspection of `LLViewerFetchedTexture::processTextureStats()` and `setLoadedCallback()`

Fixes #5654
/claim #5654
