### PR TITLE
fix: prefill abuse report summary from chat message

### DIFF
--- a/indra/newview/llchathistory.cpp
+++ b/indra/newview/llchathistory.cpp
@@ -475,7 +475,21 @@ public:
                     LLStringUtil::format(time_string, substitution);
                 }
             }
-            LLFloaterReporter::showFromChat(mAvatarID, mFrom, time_string, mText);
+            std::string summary = mText;
+            const size_t newline_pos = summary.find_first_of("\r\n");
+            if (newline_pos != std::string::npos)
+            {
+                summary.erase(newline_pos);
+            }
+            LLStringUtil::trim(summary);
+
+            if (summary.size() > 64)
+            {
+                summary.resize(64);
+                LLStringUtil::trim(summary);
+            }
+
+            LLFloaterReporter::showFromChat(mAvatarID, mFrom, time_string, mText, summary);
         }
         else if(level == "block_unblock")
         {

--- a/indra/newview/llfloaterreporter.cpp
+++ b/indra/newview/llfloaterreporter.cpp
@@ -660,7 +660,11 @@ void LLFloaterReporter::showFromAvatar(const LLUUID& avatar_id, const std::strin
 }
 
 // static
-void LLFloaterReporter::showFromChat(const LLUUID& avatar_id, const std::string& avatar_name, const std::string& time, const std::string& description)
+void LLFloaterReporter::showFromChat(const LLUUID& avatar_id,
+                                     const std::string& avatar_name,
+                                     const std::string& time,
+                                     const std::string& description,
+                                     const std::string& summary)
 {
     show(avatar_id, avatar_name);
 
@@ -671,8 +675,9 @@ void LLFloaterReporter::showFromChat(const LLUUID& avatar_id, const std::string&
     LLFloaterReporter *self = LLFloaterReg::findTypedInstance<LLFloaterReporter>("reporter");
     if (self)
     {
-        std::string description = self->getString("chat_report_format", args);
-        self->getChild<LLUICtrl>("details_edit")->setValue(description);
+        std::string formatted_description = self->getString("chat_report_format", args);
+        self->getChild<LLUICtrl>("details_edit")->setValue(formatted_description);
+        self->getChild<LLUICtrl>("summary_edit")->setValue(summary);
     }
 }
 

--- a/indra/newview/llfloaterreporter.h
+++ b/indra/newview/llfloaterreporter.h
@@ -93,7 +93,11 @@ public:
 
     static void showFromObject(const LLUUID& object_id, const LLUUID& experience_id = LLUUID::null);
     static void showFromAvatar(const LLUUID& avatar_id, const std::string avatar_name);
-    static void showFromChat(const LLUUID& avatar_id, const std::string& avatar_name, const std::string& time, const std::string& description);
+    static void showFromChat(const LLUUID& avatar_id,
+                             const std::string& avatar_name,
+                             const std::string& time,
+                             const std::string& description,
+                             const std::string& summary);
     static void showFromExperience(const LLUUID& experience_id);
 
     static void onClickSend         (void *userdata);


### PR DESCRIPTION
## Summary
- prefill the abuse report summary field from the selected chat line
- keep the full selected chat text in the abuse report details field
- trim the summary to a single line that fits the report form limit

## Testing
- git diff --check
- python3 targeted source assertions to confirm the updated call path and summary prefill

Fixes #5744
