### PR TITLE
#5677 Left side of Profile's Pick's location string can be cut

### DIFF
--- a/indra/newview/llpanelprofilepicks.cpp
+++ b/indra/newview/llpanelprofilepicks.cpp
@@ -622,6 +622,7 @@ bool LLPanelProfilePick::postBuild()
 {
     mPickName = getChild<LLLineEditor>("pick_name");
     mPickDescription = getChild<LLTextEditor>("pick_desc");
+    mPickLocation = getChild<LLLineEditor>("pick_location");
     mSaveButton = getChild<LLButton>("save_changes_btn");
     mCreateButton = getChild<LLButton>("create_changes_btn");
     mCancelButton = getChild<LLButton>("cancel_changes_btn");
@@ -646,9 +647,15 @@ bool LLPanelProfilePick::postBuild()
     mPickDescription->setKeystrokeCallback(boost::bind(&LLPanelProfilePick::onPickChanged, this, _1));
     mPickDescription->setFocusReceivedCallback(boost::bind(&LLPanelProfilePick::onDescriptionFocusReceived, this));
 
-    getChild<LLUICtrl>("pick_location")->setEnabled(false);
+    mPickLocation->setEnabled(false);
 
     return true;
+}
+
+void LLPanelProfilePick::reshape(S32 width, S32 height, bool called_from_parent)
+{
+    LLPanelProfilePropertiesProcessorTab::reshape(width, height, called_from_parent);
+    mPickLocation->setCursor(0);
 }
 
 void LLPanelProfilePick::onDescriptionFocusReceived()
@@ -749,7 +756,14 @@ void LLPanelProfilePick::setPickLocation(const LLUUID &parcel_id, const std::str
 
 void LLPanelProfilePick::setPickLocation(const std::string& location)
 {
-    getChild<LLUICtrl>("pick_location")->setValue(location);
+    mPickLocation->setValue(location);
+    // Pick location can be set with a long 'substitute' value or
+    // just a long value.
+    // If user sets cursor at the end, application of the substitute
+    // value can shift text from visible are to the left. When text
+    // gets restored or set, text position isn't, so just drop cursor
+    // position.
+    mPickLocation->setCursor(0);
     mPickLocationStr = location;
     mLastRequestTimer.reset();
 }

--- a/indra/newview/llpanelprofilepicks.h
+++ b/indra/newview/llpanelprofilepicks.h
@@ -112,6 +112,8 @@ public:
 
     void setAvatarId(const LLUUID& avatar_id) override;
 
+    void reshape(S32 width, S32 height, bool called_from_parent = true) override;
+
     void setPickId(const LLUUID& id) { mPickId = id; }
     virtual LLUUID& getPickId() { return mPickId; }
 
@@ -231,6 +233,7 @@ protected:
     LLTextureCtrl*      mSnapshotCtrl;
     LLLineEditor*       mPickName;
     LLTextEditor*       mPickDescription;
+    LLLineEditor*       mPickLocation;
     LLButton*           mSetCurrentLocationButton;
     LLButton*           mSaveButton;
     LLButton*           mCreateButton;


### PR DESCRIPTION
Editor attempt to preserve curson position and that can result in undesirable shifts.