### PR TITLE
#5772 'Control not found' crash

### DIFF
--- a/indra/llxml/llcontrol.h
+++ b/indra/llxml/llcontrol.h
@@ -321,7 +321,7 @@ public:
     {
         if(!group.controlExists(name))
         {
-            LL_ERRS() << "Control named " << name << "not found." << LL_ENDL;
+            LL_ERRS() << "Control named " << name << " not found." << LL_ENDL;
         }
 
         bindToControl(group, name);

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -2676,7 +2676,7 @@ void LLAgent::onAnimStop(const LLUUID& id)
         const bool up_pos = (mControlFlags & AGENT_CONTROL_UP_POS) != 0;
         const F64 now = LLTimer::getTotalSeconds();
         const F64 elapsed = now - mLastJumpInputTime;
-        static LLCachedControl<F32> recent_jump_threshold_secs(gSavedSettings, "RecentJumpThresholdSecs");
+        static LLCachedControl<F32> recent_jump_threshold_secs(gSavedSettings, "RecentJumpThresholdSecs", 1.0);
         const bool recent_jump = (mLastJumpInputTime > 0.0) && (elapsed < recent_jump_threshold_secs);
 
         if (!up_pos && !recent_jump)


### PR DESCRIPTION
This shouldn't be crashing, likely file failed to replace or someone extracted the exe without updating files, but just in case assigning a default.