### PR TITLE
#5777 Exception handling for an LLSD formatter

### DIFF
--- a/indra/llcommon/llsdserialize_xml.cpp
+++ b/indra/llcommon/llsdserialize_xml.cpp
@@ -63,15 +63,73 @@ S32 LLSDXMLFormatter::format(const LLSD& data, std::ostream& ostr,
                              EFormatterOptions options) const
 {
     std::streamsize old_precision = ostr.precision(25);
-
-    std::string post;
-    if (options & LLSDFormatter::OPTIONS_PRETTY)
+    // Only enable exception bits that aren't already enabled
+    // This prevents immediate throw if error bits are already set
+    std::ios_base::iostate old_exceptions = ostr.exceptions();
+    std::ios_base::iostate desired_exceptions = 0;
+    if ((old_exceptions & std::ios_base::failbit) == 0)
     {
-        post = "\n";
+        desired_exceptions |= std::ios_base::failbit;
     }
-    ostr << "<llsd>" << post;
-    S32 rv = format_impl(data, ostr, options, 1);
-    ostr << "</llsd>\n";
+    if ((old_exceptions & std::ios_base::badbit) == 0)
+    {
+        desired_exceptions |= std::ios_base::badbit;
+    }
+
+    S32 rv = 0;
+
+    try
+    {
+        if (desired_exceptions != 0)
+        {
+            // Enable exceptions for badbit and failbit to catch I/O errors
+            ostr.exceptions(desired_exceptions);
+        }
+
+        std::string post;
+        if (options & LLSDFormatter::OPTIONS_PRETTY)
+        {
+            post = "\n";
+        }
+        ostr << "<llsd>" << post;
+        rv = format_impl(data, ostr, options, 1);
+        ostr << "</llsd>\n";
+    }
+    catch (const std::ios_base::failure& e)
+    {
+        LL_WARNS() << "LLSDXMLFormatter::format: Stream I/O exception: " << e.what()
+            << " - Stream state: good=" << ostr.good()
+            << " eof=" << ostr.eof()
+            << " fail=" << ostr.fail()
+            << " bad=" << ostr.bad() << LL_ENDL;
+        rv = -1;
+    }
+    catch (const std::bad_alloc&)
+    {
+        // we might be saving something massive, don't error or crash
+        LL_WARNS() << "LLSDXMLFormatter::format: Memory allocation failed during formatting" << LL_ENDL;
+        rv = -1;
+    }
+    catch (const std::exception& e)
+    {
+        LL_WARNS() << "LLSDXMLFormatter::format: Standard exception: " << e.what() << LL_ENDL;
+        rv = -1;
+    }
+    catch (...)
+    {
+        LL_WARNS() << "LLSDXMLFormatter::format: Unknown exception during formatting" << LL_ENDL;
+        rv = -1;
+    }
+
+    try
+    {
+        // Restore original exceptions exactly as they were on entry.
+        ostr.exceptions(old_exceptions);
+    }
+    catch (...)
+    {
+        LL_WARNS() << "LLSDXMLFormatter::format: failed to restore exceptions" << LL_ENDL;
+    }
 
     ostr.precision(old_precision);
     return rv;

--- a/indra/llcommon/llsdserialize_xml.cpp
+++ b/indra/llcommon/llsdserialize_xml.cpp
@@ -63,27 +63,31 @@ S32 LLSDXMLFormatter::format(const LLSD& data, std::ostream& ostr,
                              EFormatterOptions options) const
 {
     std::streamsize old_precision = ostr.precision(25);
-    // Only enable exception bits that aren't already enabled
-    // This prevents immediate throw if error bits are already set
     std::ios_base::iostate old_exceptions = ostr.exceptions();
-    std::ios_base::iostate desired_exceptions = 0;
-    if ((old_exceptions & std::ios_base::failbit) == 0)
+    // Merged exception mask: preserve the caller's bits and add failbit|badbit
+    // for I/O error detection, so we never drop bits the caller already enabled.
+    std::ios_base::iostate new_exceptions =
+        old_exceptions | std::ios_base::badbit | std::ios_base::failbit;
+    // Bits we are newly adding (not already in the caller's mask).
+    std::ios_base::iostate added_bits = new_exceptions & ~old_exceptions;
+
+    // If the stream already has error-state bits that we would newly add to the
+    // exception mask, enabling those bits would throw immediately; bail out early.
+    if (added_bits && (ostr.rdstate() & added_bits))
     {
-        desired_exceptions |= std::ios_base::failbit;
-    }
-    if ((old_exceptions & std::ios_base::badbit) == 0)
-    {
-        desired_exceptions |= std::ios_base::badbit;
+        LL_WARNS() << "LLSDXMLFormatter::format: Stream already in error state" << LL_ENDL;
+        ostr.precision(old_precision);
+        return -1;
     }
 
     S32 rv = 0;
 
     try
     {
-        if (desired_exceptions != 0)
+        // Enable the merged exception mask to detect I/O errors during formatting.
+        if (added_bits)
         {
-            // Enable exceptions for badbit and failbit to catch I/O errors
-            ostr.exceptions(desired_exceptions);
+            ostr.exceptions(new_exceptions);
         }
 
         std::string post;
@@ -121,9 +125,12 @@ S32 LLSDXMLFormatter::format(const LLSD& data, std::ostream& ostr,
         rv = -1;
     }
 
+    // Restore original exception mask. First set to goodbit (never throws) so
+    // the subsequent restore call won't immediately throw if the stream is in
+    // error state for bits in old_exceptions.
     try
     {
-        // Restore original exceptions exactly as they were on entry.
+        ostr.exceptions(std::ios_base::goodbit);
         ostr.exceptions(old_exceptions);
     }
     catch (...)

--- a/indra/llcommon/tests/llsdserialize_test.cpp
+++ b/indra/llcommon/tests/llsdserialize_test.cpp
@@ -243,6 +243,58 @@ namespace tut
         xml_test("binary", expected);
     }
 
+    template<> template<>
+    void sd_xml_object::test<7>()
+    {
+        // Test that stream state (precision and exceptions) is correctly restored after format()
+        {
+            std::ostringstream ostr;
+
+            // Set custom precision
+            ostr.precision(10);
+
+            // Set some exception bits
+            ostr.exceptions(std::ios_base::badbit);
+            std::ios_base::iostate original_exceptions = ostr.exceptions();
+
+            // Format some LLSD data
+            mSD = 3.141592653589793;
+            S32 result = mFormatter->format(mSD, ostr);
+
+            // Verify formatting succeeded
+            ensure("format should succeed", result >= 0);
+
+            // Verify precision was restored
+            ensure_equals("precision should be restored",
+                ostr.precision(), 10);
+
+            // Verify exceptions were restored
+            ensure_equals("exception bits should be restored",
+                ostr.exceptions(), original_exceptions);
+        }
+
+        // Test with no bits set
+        {
+            std::ostringstream ostr;
+            ostr.precision(5);
+            std::ios_base::iostate original_exceptions = ostr.exceptions(); // 0
+
+            mSD = "test";
+            S32 result = mFormatter->format(mSD, ostr);
+
+            // Verify formatting succeeded
+            ensure("format should succeed", result >= 0);
+
+            // Verify exceptions were removed
+            ensure_equals("exception bits should remain unchanged",
+                ostr.exceptions(), original_exceptions);
+
+            // Verify precision was still restored even on failure
+            ensure_equals("precision should be restored even on stream failure",
+                ostr.precision(), (std::streamsize)5);
+        }
+    }
+
     class TestLLSDSerializeData
     {
     public:


### PR DESCRIPTION
Attempt to catch an inventory and name cache crash that we see in bugsplat.