### PR TITLE
#5744 Prefill 'report' floater for objects' IMs

### DIFF
--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -2285,6 +2285,7 @@ void LLTextBase::createUrlContextMenu(S32 x, S32 y, const std::string &in_url)
     registrar.add("Url.AddFriend", boost::bind(&LLUrlAction::addFriend, url));
     registrar.add("Url.RemoveFriend", boost::bind(&LLUrlAction::removeFriend, url));
     registrar.add("Url.ReportAbuse", boost::bind(&LLUrlAction::reportAbuse, url));
+    registrar.add("Url.ReportAbuseObj", boost::bind(&LLUrlAction::reportAbuseObj, url));
     registrar.add("Url.SendIM", boost::bind(&LLUrlAction::sendIM, url));
     registrar.add("Url.ZoomInObject", boost::bind(&LLUrlAction::zoomInObject, url));
     registrar.add("Url.ShowOnMap", boost::bind(&LLUrlAction::showLocationOnMap, url));

--- a/indra/llui/llurlaction.cpp
+++ b/indra/llui/llurlaction.cpp
@@ -269,13 +269,22 @@ void LLUrlAction::reportAbuse(std::string url)
     }
 }
 
+void LLUrlAction::reportAbuseObj(std::string url)
+{
+    std::string object_id = getObjectId(url);
+    if (LLUUID::validate(object_id))
+    {
+        executeSLURL("secondlife:///app/object/" + object_id + "/reportAbuse");
+    }
+}
+
 void LLUrlAction::blockObject(std::string url)
 {
     std::string object_id = getObjectId(url);
     std::string object_name = getObjectName(url);
     if (LLUUID::validate(object_id))
     {
-        executeSLURL("secondlife:///app/agent/" + object_id + "/block/" + LLURI::escape(object_name));
+        executeSLURL("secondlife:///app/object/" + object_id + "/block/" + LLURI::escape(object_name));
     }
 }
 
@@ -285,6 +294,6 @@ void LLUrlAction::unblockObject(std::string url)
     std::string object_name = getObjectName(url);
     if (LLUUID::validate(object_id))
     {
-        executeSLURL("secondlife:///app/agent/" + object_id + "/unblock/" + object_name);
+        executeSLURL("secondlife:///app/object/" + object_id + "/unblock/" + LLURI::escape(object_name));
     }
 }

--- a/indra/llui/llurlaction.h
+++ b/indra/llui/llurlaction.h
@@ -89,6 +89,7 @@ public:
     static void addFriend(std::string url);
     static void removeFriend(std::string url);
     static void reportAbuse(std::string url);
+    static void reportAbuseObj(std::string url);
     static void blockObject(std::string url);
     static void unblockObject(std::string url);
 

--- a/indra/newview/llchathistory.cpp
+++ b/indra/newview/llchathistory.cpp
@@ -175,6 +175,49 @@ public:
             LLFloaterSidePanelContainer::showPanel("people", "panel_people",
                 LLSD().with("people_panel_tab_name", "blocked_panel").with("blocked_to_select", getAvatarId()));
         }
+        else if (level == "report_abuse")
+        {
+            std::string time_string;
+            if (mTime > 0) // have frame time
+            {
+                time_t current_time = time_corrected();
+                time_t message_time = (time_t)(current_time - LLFrameTimer::getElapsedSeconds() + mTime);
+
+                // Report abuse shouldn't use AM/PM, use 24-hour time
+                time_string = "[" + LLTrans::getString("TimeMonth") + "]/["
+                    + LLTrans::getString("TimeDay") + "]/["
+                    + LLTrans::getString("TimeYear") + "] ["
+                    + LLTrans::getString("TimeHour") + "]:["
+                    + LLTrans::getString("TimeMin") + "]";
+
+                LLSD substitution;
+
+                substitution["datetime"] = (S32)message_time;
+                LLStringUtil::format(time_string, substitution);
+            }
+            else
+            {
+                // From history. This might be empty or not full.
+                // See LLChatLogParser::parse
+                time_string = getChild<LLTextBox>("time_box")->getValue().asString();
+
+                // Just add current date if not full.
+                // Should be fine since both times are supposed to be SLT.
+                if (!time_string.empty() && time_string.size() < 7)
+                {
+                    time_string = "[" + LLTrans::getString("TimeMonth") + "]/["
+                        + LLTrans::getString("TimeDay") + "]/["
+                        + LLTrans::getString("TimeYear") + "] " + time_string;
+
+                    LLSD substitution;
+                    // To avoid adding today's date to yesterday's timestamp,
+                    // use creation time instead of current time
+                    substitution["datetime"] = (S32)mCreationTime;
+                    LLStringUtil::format(time_string, substitution);
+                }
+            }
+            LLFloaterReporter::showFromChatObj(getAvatarId(), time_string, mText);
+        }
         else if (level == "unblock")
         {
             LLMuteList::getInstance()->remove(LLMute(getAvatarId(), mFrom, LLMute::OBJECT));
@@ -461,7 +504,7 @@ public:
                 time_string = getChild<LLTextBox>("time_box")->getValue().asString();
 
                 // Just add current date if not full.
-                // Should be fine since both times are supposed to be stl
+                // Should be fine since both times are supposed to be SLT.
                 if (!time_string.empty() && time_string.size() < 7)
                 {
                     time_string = "[" + LLTrans::getString("TimeMonth") + "]/["
@@ -475,7 +518,7 @@ public:
                     LLStringUtil::format(time_string, substitution);
                 }
             }
-            LLFloaterReporter::showFromChat(mAvatarID, mFrom, time_string, mText);
+            LLFloaterReporter::showFromChatAv(mAvatarID, mFrom, time_string, mText);
         }
         else if(level == "block_unblock")
         {

--- a/indra/newview/llchatitemscontainerctrl.cpp
+++ b/indra/newview/llchatitemscontainerctrl.cpp
@@ -35,8 +35,10 @@
 #include "llcommandhandler.h"
 #include "llfloaterreg.h"
 #include "lllocalcliprect.h"
+#include "llpanelblockedlist.h"
 #include "lltrans.h"
 #include "llfloaterimnearbychat.h"
+#include "llfloaterreporter.h"
 #include "llfloaterworldmap.h"
 #include "llviewermenu.h"
 
@@ -91,6 +93,32 @@ public:
                 LLFloaterWorldMap::getInstance()->trackURL(region_name, x, y, z);
                 LLFloaterReg::showInstance("world_map", "center");
             }
+            return true;
+        }
+        if (verb == "block")
+        {
+            if (params.size() > 2)
+            {
+                const std::string object_name = LLURI::unescape(params[2].asString());
+                LLMute mute(object_id, object_name, LLMute::OBJECT);
+                LLMuteList::getInstance()->add(mute);
+                LLPanelBlockedList::showPanelAndSelect(mute.mID);
+            }
+            return true;
+        }
+        if (verb == "unblock")
+        {
+            if (params.size() > 2)
+            {
+                const std::string object_name = params[2].asString();
+                LLMute mute(object_id, object_name, LLMute::OBJECT);
+                LLMuteList::getInstance()->remove(mute);
+            }
+            return true;
+        }
+        if (verb == "reportAbuse" && web == NULL)
+        {
+            LLFloaterReporter::showFromObject(object_id, LLUUID::null);
             return true;
         }
 

--- a/indra/newview/llfloaterreporter.cpp
+++ b/indra/newview/llfloaterreporter.cpp
@@ -660,9 +660,9 @@ void LLFloaterReporter::showFromAvatar(const LLUUID& avatar_id, const std::strin
 }
 
 // static
-void LLFloaterReporter::showFromChat(const LLUUID& avatar_id, const std::string& avatar_name, const std::string& time, const std::string& description)
+void LLFloaterReporter::showFromChatObj(const LLUUID& object_id, const std::string& time, const std::string& description)
 {
-    show(avatar_id, avatar_name);
+    show(object_id, LLStringUtil::null, LLUUID::null);
 
     LLStringUtil::format_map_t args;
     args["[MSG_TIME]"] = time;
@@ -671,8 +671,25 @@ void LLFloaterReporter::showFromChat(const LLUUID& avatar_id, const std::string&
     LLFloaterReporter *self = LLFloaterReg::findTypedInstance<LLFloaterReporter>("reporter");
     if (self)
     {
-        std::string description = self->getString("chat_report_format", args);
-        self->getChild<LLUICtrl>("details_edit")->setValue(description);
+        std::string description_frmt = self->getString("chat_report_format", args);
+        self->getChild<LLUICtrl>("details_edit")->setValue(description_frmt);
+    }
+}
+
+// static
+void LLFloaterReporter::showFromChatAv(const LLUUID& avatar_id, const std::string& avatar_name, const std::string& time, const std::string& description)
+{
+    show(avatar_id, avatar_name);
+
+    LLStringUtil::format_map_t args;
+    args["[MSG_TIME]"] = time;
+    args["[MSG_DESCRIPTION]"] = description;
+
+    LLFloaterReporter* self = LLFloaterReg::findTypedInstance<LLFloaterReporter>("reporter");
+    if (self)
+    {
+        std::string description_frmt = self->getString("chat_report_format", args);
+        self->getChild<LLUICtrl>("details_edit")->setValue(description_frmt);
     }
 }
 

--- a/indra/newview/llfloaterreporter.h
+++ b/indra/newview/llfloaterreporter.h
@@ -93,7 +93,8 @@ public:
 
     static void showFromObject(const LLUUID& object_id, const LLUUID& experience_id = LLUUID::null);
     static void showFromAvatar(const LLUUID& avatar_id, const std::string avatar_name);
-    static void showFromChat(const LLUUID& avatar_id, const std::string& avatar_name, const std::string& time, const std::string& description);
+    static void showFromChatObj(const LLUUID& object_id, const std::string& time, const std::string& description);
+    static void showFromChatAv(const LLUUID& avatar_id, const std::string& avatar_name, const std::string& time, const std::string& description);
     static void showFromExperience(const LLUUID& experience_id);
 
     static void onClickSend         (void *userdata);

--- a/indra/newview/skins/default/xui/en/menu_object_icon.xml
+++ b/indra/newview/skins/default/xui/en/menu_object_icon.xml
@@ -28,6 +28,14 @@
          parameter="not_blocked" />
     </menu_item_call>
     <menu_item_call
+     label="Report Abuse..."
+     layout="topleft"
+     name="Report Abuse">
+        <menu_item_call.on_click
+         function="ObjectIcon.Action"
+         parameter="report_abuse" />
+    </menu_item_call>
+    <menu_item_call
      label="Unblock"
      layout="topleft"
      name="Unblock">

--- a/indra/newview/skins/default/xui/en/menu_url_objectim.xml
+++ b/indra/newview/skins/default/xui/en/menu_url_objectim.xml
@@ -23,6 +23,13 @@
         <menu_item_call.on_click
          function="Url.Unblock" />
     </menu_item_call>
+    <menu_item_call
+     label="Report Abuse..."
+     layout="topleft"
+     name="Report Abuse">
+        <menu_item_call.on_click
+         function="Url.ReportAbuseObj" />
+    </menu_item_call>
     <menu_item_separator
      layout="topleft" />
     <menu_item_call


### PR DESCRIPTION
1. Implemented 'report abuse' option for objects from chat
2. Implemented 'report abuse' option for objects from url (urls double as compact chat's headers)
3. Redirected 'block' actions for objects at objects' specific handler (leaving the one in avatar in case something else needs it)