### PR TITLE
Clarify restricted script permission message

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_live_lsleditor.xml
+++ b/indra/newview/skins/default/xui/en/floater_live_lsleditor.xml
@@ -15,7 +15,7 @@
   width="508">
   <floater.string
     name="not_allowed">
-    You can not view or edit this script, since it has been set as &quot;no copy&quot;. You need full permissions to view or edit a script inside an object.
+    You cannot view or edit this script because it has restricted permissions. You need full permissions to view or edit a script inside an object.
   </floater.string>
   <floater.string
     name="script_running">

--- a/indra/newview/skins/default/xui/en/panel_script_ed.xml
+++ b/indra/newview/skins/default/xui/en/panel_script_ed.xml
@@ -14,7 +14,7 @@
   </panel.string>
   <panel.string
     name="can_not_view">
-    You can not view or edit this script, since it has been set as &quot;no copy&quot;. You need full permissions to view or edit a script inside an object.
+    You cannot view or edit this script because it has restricted permissions. You need full permissions to view or edit this script.
   </panel.string>
   <panel.string
     name="public_objects_can_not_run">


### PR DESCRIPTION
Fixes #3430

## Summary
- update the object script editor warning to refer to restricted permissions instead of no-copy
- use inventory script preview wording that does not say the script is inside an object

## Verification
- `ruby -r rexml/document -e 'ARGV.each { |path| REXML::Document.new(File.read(path)); puts "#{path}: ok" }' indra/newview/skins/default/xui/en/floater_live_lsleditor.xml indra/newview/skins/default/xui/en/panel_script_ed.xml`