### PR TITLE
#5806 add option to reset environment after teleport

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -13229,6 +13229,17 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
+    <key>SwitchToSharedEnvAfterTeleport</key>
+    <map>
+      <key>Comment</key>
+      <string>Switch to Shared Environment after teleport</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
     <key>PreferredBrowserBehavior</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -44,6 +44,7 @@
 #include "llchicletbar.h"
 #include "llconsole.h"
 #include "lldonotdisturbnotificationstorage.h"
+#include "llenvironment.h"
 #include "llfirstuse.h"
 #include "llfloatercamera.h"
 #include "llfloaterimcontainer.h"
@@ -4171,6 +4172,11 @@ void LLAgent::handleTeleportFinished()
                                   << LL_ENDL;
             mRegionp->setCapabilitiesReceivedCallback(boost::bind(&LLAgent::onCapabilitiesReceivedAfterTeleport));
         }
+    }
+    static LLCachedControl<bool> shared_env_on_teleport(gSavedSettings, "SwitchToSharedEnvAfterTeleport", true);
+    if (shared_env_on_teleport)
+    {
+        LLEnvironment::instance().setSharedEnvironment();
     }
     LLPerfStats::tunables.autoTuneTimeout = true;
 }

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -1003,6 +1003,17 @@
                  parameter="region" />
             </menu_item_check>
         <menu_item_separator/>
+           <menu_item_check
+             label="Switch to Shared after teleport"
+             name="Switch to Shared after teleport">
+                <menu_item_check.on_click
+                 function="ToggleControl"
+                 parameter="SwitchToSharedEnvAfterTeleport" />
+                <menu_item_check.on_check
+                 function="CheckControl"
+                 parameter="SwitchToSharedEnvAfterTeleport" />
+            </menu_item_check>
+            <menu_item_separator/>
 	     	<menu_item_call
 	     	 label="My Environments..."
 	     	 name="my_environs">


### PR DESCRIPTION
Option to set Shared Environment automatically after teleportation, enabled by default.