### PR TITLE
#5802 Open teleport history with a keystroke

### DIFF
--- a/indra/newview/llpanelplaces.cpp
+++ b/indra/newview/llpanelplaces.cpp
@@ -84,6 +84,7 @@ static const std::string LANDMARK_INFO_TYPE         = "landmark";
 static const std::string REMOTE_PLACE_INFO_TYPE     = "remote_place";
 static const std::string TELEPORT_HISTORY_INFO_TYPE = "teleport_history";
 static const std::string LANDMARK_TAB_INFO_TYPE     = "open_landmark_tab";
+static const std::string TELEPORT_HISTORY_TAB_INFO_TYPE = "open_teleport_history_tab";
 
 // Support for secondlife:///app/parcel/{UUID}/about SLapps
 class LLParcelHandler : public LLCommandHandler
@@ -409,6 +410,15 @@ void LLPanelPlaces::onOpen(const LLSD& key)
             // Update the active tab
             onTabSelected();
             // Update the buttons at the bottom of the panel
+            updateVerbs();
+        }
+        else if (key_type == TELEPORT_HISTORY_TAB_INFO_TYPE)
+        {
+            // toggle twice, similar to LANDMARK_TAB_INFO_TYPE
+            togglePlaceInfoPanel(false);
+            mPlaceInfoType = key_type;
+            togglePlaceInfoPanel(false);
+            onTabSelected();
             updateVerbs();
         }
         else if (key_type == CREATE_PICK_TYPE)
@@ -1101,6 +1111,18 @@ void LLPanelPlaces::togglePlaceInfoPanel(bool visible)
                 {
                     landmarks_panel->resetSelection();
                 }
+            }
+        }
+    }
+    else if (mPlaceInfoType == TELEPORT_HISTORY_TAB_INFO_TYPE)
+    {
+        mLandmarkInfo->setVisible(false);
+        mPlaceProfile->setVisible(false);
+        if (!visible)
+        {
+            if (LLPanel* teleport_history_panel = mTabContainer->getPanelByName("Teleport History"))
+            {
+                mTabContainer->selectTabPanel(teleport_history_panel);
             }
         }
     }

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -5183,6 +5183,27 @@ void handle_link_objects()
     }
 }
 
+void handle_unlink_objects()
+{
+    if (LLSelectMgr::getInstance()->getSelection()->isEmpty())
+    {
+        LLPanel* visited_panel = LLFloaterSidePanelContainer::getPanel("places", "Teleport History");
+        if (visited_panel && visited_panel->isInVisibleChain())
+        {
+            LLFloaterReg::hideInstance("places");
+        }
+        else
+        {
+            LLFloaterReg::toggleInstanceOrBringToFront("places");
+            LLFloaterSidePanelContainer::showPanel("places", LLSD().with("type", "open_teleport_history_tab"));
+        }
+    }
+    else
+    {
+        LLSelectMgr::getInstance()->unlinkObjects();
+    }
+}
+
 // You can return an object to its owner if it is on your land.
 class LLObjectReturn : public view_listener_t
 {
@@ -9940,7 +9961,7 @@ void initialize_menus()
     view_listener_t::addMenu(new LLToolsUseSelectionForGrid(), "Tools.UseSelectionForGrid");
     view_listener_t::addMenu(new LLToolsSelectNextPartFace(), "Tools.SelectNextPart");
     commit.add("Tools.Link", boost::bind(&handle_link_objects));
-    commit.add("Tools.Unlink", boost::bind(&LLSelectMgr::unlinkObjects, LLSelectMgr::getInstance()));
+    commit.add("Tools.Unlink", boost::bind(&handle_unlink_objects));
     view_listener_t::addMenu(new LLToolsStopAllAnimations(), "Tools.StopAllAnimations");
     view_listener_t::addMenu(new LLToolsReleaseKeys(), "Tools.ReleaseKeys");
     view_listener_t::addMenu(new LLToolsEnableReleaseKeys(), "Tools.EnableReleaseKeys");

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -44,6 +44,13 @@
          function="Tools.Link"/>
       </menu_item_call>
       <menu_item_call
+       label="Visited places..."
+       name="Visited Places"
+       shortcut="control|shift|L">
+        <menu_item_call.on_click
+         function="Tools.Unlink"/>
+      </menu_item_call>
+      <menu_item_call
        label="Picks..."
        name="Picks">
         <menu_item_call.on_click


### PR DESCRIPTION
Just a new menu option to open Visited (Teleport history) tab of Places floater