### PR TITLE
#5804 Prevent focus steal when removing unselected conversation widget

### DIFF
--- a/indra/newview/llfloaterimcontainer.cpp
+++ b/indra/newview/llfloaterimcontainer.cpp
@@ -1956,7 +1956,7 @@ bool LLFloaterIMContainer::removeConversationListItem(const LLUUID& uuid, bool c
     mConversationEventQueue.erase(uuid);
 
     // Don't let the focus fall IW, select and refocus on the first conversation in the list
-    if (change_focus && isInVisibleChain())
+    if (change_focus && is_widget_selected && isInVisibleChain())
     {
         setFocus(true);
         if (new_selection)


### PR DESCRIPTION
Steal focus and select next conversation only if the removed widget was actually the one selected. If it was just a background widget (like an auto-created-then-auto-removed muted session), removing it shouldn't affect focus at all.