### PR TITLE
#5820 Add 'Set UI Size to Default' to help menu on login screen

### DIFF
--- a/indra/newview/skins/default/xui/en/menu_login.xml
+++ b/indra/newview/skins/default/xui/en/menu_login.xml
@@ -98,7 +98,14 @@
              name="Report Bug">
                 <menu_item_call.on_click
                  function="Advanced.ReportBug"/>
-            </menu_item_call>
+        </menu_item_call>
+        <menu_item_call
+             label="Set UI Size to Default"
+             name="Set UI Size to Default"
+             shortcut="control|alt|shift|R">
+                <menu_item_call.on_click
+                 function="View.DefaultUISize" />
+        </menu_item_call>
         <menu_item_separator/>
         <menu_item_call
          label="About [APP_NAME]"


### PR DESCRIPTION
A more visible option to get out of an unfortunate situation where user is truck on high scale.