### PR TITLE
(develop) Fix display of ad-hoc session type in About and display p2p instead as appropriate

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -353,9 +353,16 @@ void LLWebRTCVoiceClient::updateVersion()
     {
         // A WebRTC session can be connected to multiple servers at once. To more easily disambiguate which server version is being printed, show the connection type. In most cases, this shouldn't matter and the Janus version should be the same for all connections. Janus versions are also logged for each connection.
         mVoiceVersion.serverVersion = session->getVersion();
-        if (session->isCallbackPossible())
+        if (dynamic_cast<adhocSessionState*>(session.get()))
         {
-            mVoiceVersion.mBuildVersion = "ad-hoc";
+            if (session->mHangupOnLastLeave)
+            {
+                mVoiceVersion.mBuildVersion = "p2p";
+            }
+            else
+            {
+                mVoiceVersion.mBuildVersion = "ad-hoc";
+            }
         }
         else if (session->isEstate())
         {


### PR DESCRIPTION
## Description

Fixes https://github.com/secondlife/3p-janus-gateway/issues/126 . For WebRTC connections to a voice server that sends version info, About > Secondlife should now correctly show "p2p" or "ad-hoc" when currently in that type of voice chat.

This is the develop version of the following 26.3 PR: https://github.com/secondlife/viewer/pull/5816

## Related Issues

- [x] https://github.com/secondlife/3p-janus-gateway/issues/126

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).