### PR TITLE
#5785 fix login and world UI overlap

### DIFF
--- a/indra/newview/lllogininstance.cpp
+++ b/indra/newview/lllogininstance.cpp
@@ -134,6 +134,7 @@ void LLLoginInstance::reconnect()
 {
     // Sort of like connect, only using the pre-existing
     // request params.
+    mAttemptComplete = false;
     std::vector<std::string> uris;
     LLGridManager::getInstance()->getLoginURIs(uris);
     mLoginModule->connect(uris.front(), mRequestData);

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -1354,6 +1354,10 @@ bool idle_startup()
     {
         set_startup_status(0.30f, LLTrans::getString("LoginInitializingWorld"), gAgent.mMOTD);
         do_startup_frame();
+
+        // close login UI before world UI is initialized, if it is still visible
+        LLPanelLogin::closePanel();
+
         // We should have an agent id by this point.
         llassert(!(gAgentID == LLUUID::null));
 


### PR DESCRIPTION
Reset attempt completion state on reconnect().
Close login panel at STATE_WORLD_INIT (before world initialization begins).