### PR TITLE
#5809 Add 'mute' based filter for conversation history

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -11119,6 +11119,17 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>ShowBlockedConvHistory</key>
+    <map>
+      <key>Comment</key>
+      <string>Specifies whether blocked agents will be shown in Call Log</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
     <key>ShowMatureEvents</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llconversationloglist.cpp
+++ b/indra/newview/llconversationloglist.cpp
@@ -45,6 +45,7 @@ LLConversationLogList::LLConversationLogList(const Params& p)
     mIsDirty(true)
 {
     LLConversationLog::instance().addObserver(this);
+    LLMuteList::instance().addObserver(this);
 
     // Set up context menu.
     LLUICtrl::CommitCallbackRegistry::ScopedRegistrar registrar;
@@ -65,6 +66,15 @@ LLConversationLogList::LLConversationLogList(const Params& p)
     }
 
     mIsFriendsOnTop = gSavedSettings.getBOOL("SortFriendsFirst");
+    LLControlVariable* cntrl_ptr = gSavedSettings.getControl("ShowBlockedConvHistory");
+    if (cntrl_ptr)
+    {
+        mShowBlockedSignal = cntrl_ptr->getCommitSignal()->connect(
+            [this](LLControlVariable* control, const LLSD& value, const LLSD& previous)
+        {
+            setDirty(true);
+        });
+    }
 }
 
 LLConversationLogList::~LLConversationLogList()
@@ -74,6 +84,7 @@ LLConversationLogList::~LLConversationLogList()
         mContextMenu.get()->die();
     }
 
+    LLMuteList::getInstance()->removeObserver(this);
     LLConversationLog::instance().removeObserver(this);
 }
 
@@ -178,6 +189,44 @@ void LLConversationLogList::changed(const LLUUID& session_id, U32 mask)
     }
 }
 
+// inherited from LLMuteListObserver
+void LLConversationLogList::onChange()
+{
+}
+
+// inherited from LLMuteListObserver
+void LLConversationLogList::onChangeDetailed(const LLMute& mute)
+{
+    if (isDirty())
+    {
+        // Going to refresh either way.
+        return;
+    }
+
+    static LLCachedControl<bool> show_blocked(gSavedSettings, "ShowBlockedConvHistory", false);
+    if (!show_blocked())
+    {
+        // Check if any conversation in the log has this participant
+        const std::vector<LLConversation>& conversations = LLConversationLog::instance().getConversations();
+
+        // Note sure if actually need this update. List can be rather large
+        // and rebuilding it on every event can be expensive.
+        // But 'mute' events are also rare, so maybe not a problem.
+        // There also might be a way to react only to relevant changes,
+        // instead of reacting to everything, like ignoring voice only mutes,
+        // which are not relevant for this log by themselves.
+        for (const LLConversation& conversation : conversations)
+        {
+            if (conversation.getParticipantID() == mute.mID)
+            {
+                setDirty(true);
+                break;
+            }
+        }
+    }
+    // else don't need to hide anything
+}
+
 void LLConversationLogList::addNewItem(const LLConversation* conversation)
 {
     LLConversationLogListItem* item = new LLConversationLogListItem(&*conversation);
@@ -207,12 +256,20 @@ void LLConversationLogList::rebuildList()
 
     const std::vector<LLConversation>& conversations = log_instance.getConversations();
     std::vector<LLConversation>::const_iterator iter = conversations.begin();
+    LLMuteList* mutes = LLMuteList::getInstance();
+
+    static LLCachedControl<bool> show_blocked(gSavedSettings, "ShowBlockedConvHistory", false);
 
     for (; iter != conversations.end(); ++iter)
     {
         bool not_found = have_filter && !findInsensitive(iter->getConversationName(), mNameFilter) && !findInsensitive(iter->getTimestamp(), mNameFilter);
         if (not_found)
             continue;
+
+        if (!show_blocked() && mutes->isMuted(iter->getParticipantID()))
+        {
+            continue;
+        }
 
         addNewItem(&*iter);
     }
@@ -517,8 +574,8 @@ bool LLConversationLogListNameComparator::doCompare(const LLConversationLogListI
     LLStringUtil::toUpper(name1);
     LLStringUtil::toUpper(name2);
 
-    bool friends_first = gSavedSettings.getBOOL("SortFriendsFirst");
-    if (friends_first && (LLAvatarActions::isFriend(id1) ^ LLAvatarActions::isFriend(id2)))
+    static LLCachedControl<bool> sort_friends_first(gSavedSettings, "SortFriendsFirst", true);
+    if (sort_friends_first() && (LLAvatarActions::isFriend(id1) ^ LLAvatarActions::isFriend(id2)))
     {
         return LLAvatarActions::isFriend(id1);
     }
@@ -533,8 +590,8 @@ bool LLConversationLogListDateComparator::doCompare(const LLConversationLogListI
     const LLUUID& id1 = conversation1->getConversation()->getParticipantID();
     const LLUUID& id2 = conversation2->getConversation()->getParticipantID();
 
-    bool friends_first = gSavedSettings.getBOOL("SortFriendsFirst");
-    if (friends_first && (LLAvatarActions::isFriend(id1) ^ LLAvatarActions::isFriend(id2)))
+    static LLCachedControl<bool> sort_friends_first(gSavedSettings, "SortFriendsFirst", true);
+    if (sort_friends_first() && (LLAvatarActions::isFriend(id1) ^ LLAvatarActions::isFriend(id2)))
     {
         return LLAvatarActions::isFriend(id1);
     }

--- a/indra/newview/llconversationloglist.h
+++ b/indra/newview/llconversationloglist.h
@@ -39,7 +39,7 @@ class LLConversationLogListItem;
  * it's always in actual state.
  */
 
-class LLConversationLogList: public LLFlatListViewEx, public LLConversationLogObserver
+class LLConversationLogList: public LLFlatListViewEx, public LLConversationLogObserver, public LLMuteListObserver
 {
     LOG_CLASS(LLConversationLogList);
 public:
@@ -76,6 +76,12 @@ public:
     virtual void changed();
     virtual void changed(const LLUUID& session_id, U32 mask);
 
+    /**
+     * Changes from LLMuteListObserver
+     */
+    virtual void onChange();
+    virtual void onChangeDetailed(const LLMute& mute);
+
 private:
 
     void setDirty(bool dirty = true) { mIsDirty = dirty; }
@@ -104,6 +110,8 @@ private:
     bool mIsDirty;
     bool mIsFriendsOnTop;
     std::string mNameFilter;
+
+    boost::signals2::scoped_connection mShowBlockedSignal;
 };
 
 /**

--- a/indra/newview/llfloaterconversationlog.cpp
+++ b/indra/newview/llfloaterconversationlog.cpp
@@ -100,6 +100,10 @@ void LLFloaterConversationLog::onCustomAction (const LLSD& userdata)
     {
         mConversationLogList->toggleSortFriendsOnTop();
     }
+    else if ("show_blocked" == command_name)
+    {
+        gSavedSettings.setBOOL("ShowBlockedConvHistory", !gSavedSettings.getBOOL("ShowBlockedConvHistory"));
+    }
     else if ("view_nearby_chat_history" == command_name)
     {
         LLFloaterReg::showInstance("preview_conversation", LLSD(LLUUID::null), true);
@@ -128,6 +132,10 @@ bool LLFloaterConversationLog::isActionChecked(const LLSD& userdata)
     else if ("sort_friends_on_top" == command_name)
     {
         return gSavedSettings.getBOOL("SortFriendsFirst");
+    }
+    else if ("show_blocked" == command_name)
+    {
+        return gSavedSettings.getBOOL("ShowBlockedConvHistory");
     }
 
     return false;

--- a/indra/newview/llfloaterimcontainer.cpp
+++ b/indra/newview/llfloaterimcontainer.cpp
@@ -1948,7 +1948,7 @@ bool LLFloaterIMContainer::removeConversationListItem(const LLUUID& uuid, bool c
     mConversationEventQueue.erase(uuid);
 
     // Don't let the focus fall IW, select and refocus on the first conversation in the list
-    if (change_focus && isInVisibleChain())
+    if (change_focus && is_widget_selected && isInVisibleChain())
     {
         setFocus(true);
         if (new_selection)

--- a/indra/newview/skins/default/xui/en/menu_conversation_log_view.xml
+++ b/indra/newview/skins/default/xui/en/menu_conversation_log_view.xml
@@ -34,6 +34,16 @@
        function="CallLog.Check"
        parameter="sort_friends_on_top" />
   </menu_item_check>
+    <menu_item_check
+     label="Show muted"
+     name="show_muted">
+        <on_click
+         function="CallLog.Action"
+         parameter="show_blocked" />
+        <on_check
+         function="CallLog.Check"
+         parameter="show_blocked" />
+    </menu_item_check>
   <menu_item_separator />
   <menu_item_call
    label="View Nearby chat history..."


### PR DESCRIPTION
- Don't add blocked conversations
- Menus and global setting to control this mechanics
- Refresh on changes
- Cherry picked marchcat's focus change since it's relevant for the same 'abuse report' this change is attempting to fix

Decided just not to add blocked conversation to the list, an alternate way is to alter visibility logic or filter logic.