### PR TITLE
Allow specifically mapped game control buttons to always be passed to server

### DIFF
--- a/indra/llwindow/llgamecontrol.cpp
+++ b/indra/llwindow/llgamecontrol.cpp
@@ -1116,11 +1116,9 @@ void LLGameControllerManager::computeFinalState()
     // finish by accumulating "external" state (if enabled)
     U32 old_buttons = g_finalState.mButtons;
     g_finalState.mButtons = mButtonAccumulator;
-    if (g_translateAgentActions)
-    {
-        // accumulate from mExternalState
-        g_finalState.mButtons |= mExternalState.mButtons;
-    }
+
+    g_finalState.mButtons |= mExternalState.mButtons;
+
     if (old_buttons != g_finalState.mButtons)
     {
         g_nextResendPeriod = 0; // packet needs to go out ASAP


### PR DESCRIPTION
## Description

This PR is mostly for @AndrewMeadows concern got the Game Control Project

This change allows specifically mapped gamecontrol buttons to always be passed to gamecontrol even when `AgentToGameControl` setting is  false, as these buttons are not for agent movement

The setting makes sense for controls like `wasd`, `page up`, `page down`,` e`, `c`, etc. But if a user maps a specific key to `Game Control Buttons > BUTTON_0` then that should go to the server regardless of the `Avatar actions interpreted as GameControl` setting.

## Video

A brief video showing implementation working.
 - `Avatar actions interpreted as GameControl` Is off
 - Avatar movement with wasd, does not affect the game control hud.
 - But I am able to activate the game controller face buttons with custom bound keys

[screencast_20260520_122557.webm](https://github.com/user-attachments/assets/a4ed3383-1a61-42b1-9a74-2801fc98fda3)

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).