### PR TITLE
#5732 fix showing incorrect 'Packets Lost' statistic

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -3429,9 +3429,10 @@ void LLVoiceWebRTCConnection::OnStatsDelivered(const llwebrtc::LLWebRTCStatsMap&
             {
                 if (attributes.contains("packetsLost"))
                 {
-                    U32 out_packets_lost = 0;
-                    LLStringUtil::convertToU32(attributes.at("packetsLost"), out_packets_lost);
-                    sample(LLStatViewer::WEBRTC_PACKETS_OUT_LOST, out_packets_lost);
+                    // packetsLost may be negative, clamp to zero for unsigned Viewer stats
+                    S32 out_packets_lost = 0;
+                    LLStringUtil::convertToS32(attributes.at("packetsLost"), out_packets_lost);
+                    sample(LLStatViewer::WEBRTC_PACKETS_OUT_LOST, static_cast<U32>(llmax(out_packets_lost, 0)));
                 }
                 if (attributes.contains("jitter"))
                 {
@@ -3445,9 +3446,10 @@ void LLVoiceWebRTCConnection::OnStatsDelivered(const llwebrtc::LLWebRTCStatsMap&
             {
                 if (attributes.contains("packetsLost"))
                 {
-                    U32 in_packets_lost = 0;
-                    LLStringUtil::convertToU32(attributes.at("packetsLost"), in_packets_lost);
-                    sample(LLStatViewer::WEBRTC_PACKETS_IN_LOST, in_packets_lost);
+                    // packetsLost may be negative, clamp to zero for unsigned Viewer stats
+                    S32 in_packets_lost = 0;
+                    LLStringUtil::convertToS32(attributes.at("packetsLost"), in_packets_lost);
+                    sample(LLStatViewer::WEBRTC_PACKETS_IN_LOST, static_cast<U32>(llmax(in_packets_lost, 0)));
                 }
                 if (attributes.contains("packetsReceived"))
                 {


### PR DESCRIPTION
`packetsLost` was parsed as U32, but it can be negative in WebRTC.  So just parse it as signed first and then clamp negatives to zero.