### PR TITLE
#5853 Fix wrong combo box being disabled in preferences

### DIFF
--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -775,8 +775,8 @@ void LLFloaterPreference::onOpen(const LLSD& key)
     updateClickActionViews();
 
 #if LL_LINUX
-    // Lixux doesn't support automatic mode
-    LLComboBox* combo = getChild<LLComboBox>("double_click_action_combo");
+    // Lixux doesn't support automatic maose warp mode
+    LLComboBox* combo = getChild<LLComboBox>("mouse_warp_combo");
     S32 mode = gSavedSettings.getS32("MouseWarpMode");
     if (mode == 0)
     {


### PR DESCRIPTION
On Linux, the "No action" option for "Double click on land" is greyed out and therefore can't be chosen. Instead Mouse Warp is enabled.