### PR TITLE
Remove Game Control from experimental features menu, and enable by default

### DIFF
--- a/indra/llwindow/llgamecontrol.cpp
+++ b/indra/llwindow/llgamecontrol.cpp
@@ -434,7 +434,7 @@ namespace
     U64 g_lastSend = 0;
     U64 g_nextResendPeriod = FIRST_RESEND_PERIOD;
 
-    bool g_enabled = false;
+    bool g_enabled = true;
     bool g_sendToServer = false;
     bool g_controlAgent = false;
     bool g_translateAgentActions = false;

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -2720,7 +2720,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
     <key>GameControlToServer</key>
     <map>

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -446,7 +446,6 @@ bool LLFloaterPreference::postBuild()
     mDisabledPopups = getChild<LLScrollListCtrl>("disabled_popups");
     mEnablePopupBtn = getChild<LLButton>("enable_this_popup");
     mDisablePopupBtn = getChild<LLButton>("disable_this_popup");
-    setPanelVisibility("game_control", LLGameControl::isEnabled());
 
     gSavedSettings.getControl("ChatFontSize")->getSignal()->connect(boost::bind(&LLFloaterIMSessionTab::processChatHistoryStyleUpdate, false));
 
@@ -1340,7 +1339,6 @@ void LLAvatarComplexityControls::setIndirectMaxArc()
 
 void LLFloaterPreference::refresh()
 {
-    setPanelVisibility("game_control", LLGameControl::isEnabled());
     LLTabContainer* tabcontainer = getChild<LLTabContainer>("pref core");
     for (LLView* view : *tabcontainer->getChildList())
     {

--- a/indra/newview/llpanelpreferencegamecontrol.cpp
+++ b/indra/newview/llpanelpreferencegamecontrol.cpp
@@ -443,10 +443,19 @@ void LLPanelPreferenceGameControl::onCommitNumericValue()
     }
 }
 
+void LLPanelPreferenceGameControl::onChangeGameControlEnabled()
+{
+    bool enabled = gSavedSettings.getBOOL("EnableGameControl");
+    LLGameControl::setEnabled(enabled);
+    updateEnable();
+}
+
 // Initializes all UI controls and sets up callbacks.
 // Called once when the panel is first built from XML.
 bool LLPanelPreferenceGameControl::postBuild()
 {
+    gSavedSettings.getControl("EnableGameControl")->getSignal()->connect(boost::bind(&LLPanelPreferenceGameControl::onChangeGameControlEnabled, this));
+
     // Main checkboxes that control how game input is used
     mCheckGameControlToServer = getChild<LLCheckBoxCtrl>("game_control_to_server");
     mCheckGameControlToAgent = getChild<LLCheckBoxCtrl>("game_control_to_agent");

--- a/indra/newview/llpanelpreferencegamecontrol.h
+++ b/indra/newview/llpanelpreferencegamecontrol.h
@@ -93,6 +93,7 @@ public:
     void onCommitInputChannel(LLUICtrl* ctrl); // Handle channel combobox selection
     void onAxisOptionsSelect();                // Handle axis options table selection
     void onCommitNumericValue();               // Handle deadzone/offset value changes
+    void onChangeGameControlEnabled();         // Handle EnableGameControl toggle
 
     // Live input capture support
     static bool isWaitingForInputChannel();    // True if a cell is waiting for input

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -80,7 +80,6 @@
 #include "llfloatertools.h"
 #include "llfloaterworldmap.h"
 #include "llfloaterbuildoptions.h"
-#include "llgamecontrol.h"
 #include "llgroupmgr.h"
 #include "lllandmarkactions.h"
 #include "lltooltip.h"
@@ -965,12 +964,6 @@ class LLAdvancedToggleExperiment : public view_listener_t
     bool handleEvent(const LLSD& userdata)
     {
         std::string feature = userdata.asString();
-        if (feature == "GameControl")
-        {
-            LLGameControl::setEnabled(! LLGameControl::isEnabled());
-            LLFloaterPreference::refreshInstance();
-            return true;
-        }
         return false;
     }
 };
@@ -981,10 +974,6 @@ class LLAdvancedCheckExperiment : public view_listener_t
     {
         bool value = false;
         std::string feature = userdata.asString();
-        if (feature == "GameControl")
-        {
-            value = LLGameControl::isEnabled();
-        }
         return value;
     }
 };

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -2538,7 +2538,7 @@ function="World.EnvPreset"
      name="Develop"
      tear_off="true"
      visible="false">
-        <menu
+        <!--menu
          create_jump_keys="true"
          label="Experimental Features"
          name="Experimental Features"
@@ -2553,7 +2553,7 @@ function="World.EnvPreset"
                  function="Advanced.ToggleExperiment"
                  parameter="GameControl" />
             </menu_item_check>
-        </menu>
+        </menu-->
         <menu
          create_jump_keys="true"
          label="Consoles"

--- a/indra/newview/skins/default/xui/en/panel_preferences_game_control.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_game_control.xml
@@ -10,9 +10,10 @@
     top="1"
     width="517">
     <check_box
-        name="game_control_to_server"
-        control_name="GameControlToServer"
-        label="Send GameControl Data to server"
+        name="game_control_enabled"
+        control_name="EnableGameControl"
+        label="Gamecontroller"
+        tool_tip="Enable Gamecontroller support"
         layout="topleft"
         height="15"
         left="10"
@@ -23,6 +24,14 @@
         label="GameControl moves avatar and flycam"
         layout="topleft"
         height="15"
+        left="250"
+        top="10"/>
+    <check_box
+        name="game_control_to_server"
+        control_name="GameControlToServer"
+        label="Send GameControl Data to server"
+        layout="topleft"
+        height="15"
         left="10"
         top="30"/>
     <check_box
@@ -31,13 +40,13 @@
         label="Avatar actions interpreted as GameControl"
         layout="topleft"
         height="15"
-        left="10"
-        top="50"/>
+        left="250"
+        top="30"/>
     <tab_container
         name="game_control_tabs"
         layout="topleft"
         follows="all"
-        top="70"
+        top="50"
         left="2"
         right="-2"
         bottom="-32">


### PR DESCRIPTION
## Description

For @AndrewMeadows

Remove Game Control from experimental features.

Added Control to toggle it to the preferences panel.

<img width="816" height="665" alt="image" src="https://github.com/user-attachments/assets/c30ba6b4-fc1d-4663-8a5a-d2f0317825d5" />

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).


## Additional Notes

I chose to use the saved settings signal instead of the commit from the checkbox that the rest of the preference menu items use, in case a user toggled it via some other method like debug settings.