### PR TITLE
Font crash fix

### DIFF
--- a/indra/llrender/llfontfreetype.cpp
+++ b/indra/llrender/llfontfreetype.cpp
@@ -720,7 +720,50 @@ void LLFontFreetype::renderGlyph(EFontGlyphType bitmap_type, U32 glyph_index, ll
         llassert_always_msg(FT_Err_Ok == error, message.c_str());
     }
 
-    llassert_always(! FT_Render_Glyph(mFTFace->glyph, gFontRenderMode) );
+    // TODO: Make this more sturdy, make asserts/ll_errs conditional
+    // to non-critical characters.
+    // Temporarily leaving them for data gathering, but unicode chars
+    // like emojis should not cause the app to crash and should either
+    // fallback to some predetermined bitmap or simply return.
+
+    // Verify glyph slot is valid
+    if (!mFTFace->glyph)
+    {
+        LL_ERRS() << "FT_Load_Glyph succeeded but glyph slot is null for wchar " << llformat("U+%xu", U32(wch)) << LL_ENDL;
+        return;
+    }
+
+    // Check if bitmap buffer is already allocated
+    // It can potentially be preallocated for:
+    // 1. SVG/color glyphs rendered by FreeType's SVG_RendererHooks
+    // 2. Embedded bitmap fonts
+    // 3. Some Color emoji that use FT_LOAD_COLOR
+    if (!mFTFace->glyph->bitmap.buffer)
+    {
+        error = FT_Render_Glyph(mFTFace->glyph, gFontRenderMode);
+        if (error != FT_Err_Ok)
+        {
+            std::string render_message = llformat(
+                "Error %d (%s) rendering wchar %u glyph %u: format=%lu, pixel_mode=%d, render_mode=%d",
+                error, FT_Error_String(error), wch, glyph_index,
+                (unsigned long)mFTFace->glyph->format, mFTFace->glyph->bitmap.pixel_mode, gFontRenderMode);
+
+            // Try with FT_RENDER_MODE_NORMAL as fallback
+            if (gFontRenderMode != FT_RENDER_MODE_NORMAL)
+            {
+                LL_WARNS_ONCE() << render_message << LL_ENDL;
+                error = FT_Render_Glyph(mFTFace->glyph, FT_RENDER_MODE_NORMAL);
+                if (error != FT_Err_Ok)
+                {
+                    LL_ERRS() << "Fallback to FT_RENDER_MODE_NORMAL failed. " << render_message << LL_ENDL;
+                }
+            }
+            else
+            {
+                LL_ERRS() << render_message << LL_ENDL;
+            }
+        }
+    }
 
     mRenderGlyphCount++;
 }

--- a/indra/newview/llaisapi.cpp
+++ b/indra/newview/llaisapi.cpp
@@ -1758,35 +1758,41 @@ void AISUpdate::doUpdate()
         const LLUUID id = ucv_it->first;
         S32 version = static_cast<S32>(ucv_it->second);
         LLViewerInventoryCategory *cat = gInventory.getCategory(id);
-        LL_DEBUGS("Inventory") << "cat version update " << cat->getName() << " to version " << cat->getVersion() << LL_ENDL;
-        if (cat->getVersion() != version)
+        // Update can be rather large and take time to process.
+        // By the time update gets to the category, it could
+        // could have been removed by the user
+        if (cat)
         {
-            // the AIS version should be considered the true version. Adjust
-            // our local category model to reflect this version number.  Otherwise
-            // it becomes possible to get stuck with the viewer being out of
-            // sync with the inventory system.  Under normal circumstances
-            // inventory COF is maintained on the viewer through calls to
-            // LLInventoryModel::accountForUpdate when a changing operation
-            // is performed.  This occasionally gets out of sync however.
-            if (version != LLViewerInventoryCategory::VERSION_UNKNOWN)
+            LL_DEBUGS("Inventory") << "cat " << cat->getName() << " version update from " << cat->getVersion() << " to AIS version " << version << LL_ENDL;
+            if (cat->getVersion() != version)
             {
-                LL_WARNS() << "Possible version mismatch for category " << cat->getName()
-                    << ", viewer version " << cat->getVersion()
-                    << " AIS version " << version << " !!!Adjusting local version!!!" << LL_ENDL;
-                cat->setVersion(version);
-            }
-            else
-            {
-                // We do not account for update if version is UNKNOWN, so we shouldn't rise version
-                // either or viewer will get stuck on descendants count -1, try to refetch folder instead
-                //
-                // Todo: proper backoff?
+                // the AIS version should be considered the true version. Adjust
+                // our local category model to reflect this version number.  Otherwise
+                // it becomes possible to get stuck with the viewer being out of
+                // sync with the inventory system.  Under normal circumstances
+                // inventory COF is maintained on the viewer through calls to
+                // LLInventoryModel::accountForUpdate when a changing operation
+                // is performed.  This occasionally gets out of sync however.
+                if (version != LLViewerInventoryCategory::VERSION_UNKNOWN)
+                {
+                    LL_WARNS() << "Possible version mismatch for category " << cat->getName()
+                        << ", viewer version " << cat->getVersion()
+                        << " AIS version " << version << " !!!Adjusting local version!!!" << LL_ENDL;
+                    cat->setVersion(version);
+                }
+                else
+                {
+                    // We do not account for update if version is UNKNOWN, so we shouldn't riase version
+                    // either or viewer will get stuck on descendants count -1, try to refetch folder instead
+                    //
+                    // Todo: proper backoff?
 
-                LL_WARNS() << "Possible version mismatch for category " << cat->getName()
-                    << ", viewer version " << cat->getVersion()
-                    << " AIS version " << version << " !!!Rerequesting category!!!" << LL_ENDL;
-                const S32 LONG_EXPIRY = 360;
-                cat->fetch(LONG_EXPIRY);
+                    LL_WARNS() << "Possible version mismatch for category " << cat->getName()
+                        << ", viewer version " << cat->getVersion()
+                        << " AIS version " << version << " !!!Rerequesting category!!!" << LL_ENDL;
+                    const S32 LONG_EXPIRY = 360;
+                    cat->fetch(LONG_EXPIRY);
+                }
             }
         }
     }


### PR DESCRIPTION
More crash handling.
- A simple null check for inventory
- Attempt to figure out what's going on with some of the font crashes. Assumption is that buffer was already filled.