### PR TITLE
Clarify restricted script permission message

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_live_lsleditor.xml
+++ b/indra/newview/skins/default/xui/en/floater_live_lsleditor.xml
@@ -15,7 +15,7 @@
   width="508">
   <floater.string
     name="not_allowed">
-    You can not view or edit this script, since it has been set as &quot;no copy&quot; or &quot;no modify&quot;. You need these permissions to view or edit a script.
+    You can not view or edit this script because its permissions restrict access. You need copy and modify permissions to view or edit a script.
   </floater.string>
   <floater.string
     name="script_running">

--- a/indra/newview/skins/default/xui/en/panel_script_ed.xml
+++ b/indra/newview/skins/default/xui/en/panel_script_ed.xml
@@ -14,7 +14,7 @@
   </panel.string>
   <panel.string
     name="can_not_view">
-      You can not view or edit this script, since it has been set as &quot;no copy&quot; or &quot;no modify&quot;. You need these permissions to view or edit a script.
+      You can not view or edit this script because its permissions restrict access. You need copy and modify permissions to view or edit a script.
   </panel.string>
   <panel.string
     name="public_objects_can_not_run">


### PR DESCRIPTION
Summary:
- follow up on #5822 by replacing the explicit no-copy/no-modify wording with the issue's more general restricted-permissions wording
- remove the inside-an-object wording so the same message is accurate for inventory scripts too

Fixes #3430

Testing:
- xmllint --noout indra/newview/skins/default/xui/en/floater_live_lsleditor.xml
- xmllint --noout indra/newview/skins/default/xui/en/panel_script_ed.xml