### PR TITLE
Add missing button to control bindings preferences panel, and a controller debug output feature.

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -2733,6 +2733,17 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>DebugShowControllerState</key>
+    <map>
+      <key>Comment</key>
+      <string>Display internal controller state values</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
     <key>GameControlToServer</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -113,6 +113,7 @@
 #include "llfloaterworldmap.h"
 #include "llfocusmgr.h"
 #include "llfontfreetype.h"
+#include "llgamecontrol.h"
 #include "llgesturemgr.h"
 #include "llglheaders.h"
 #include "llhudmanager.h"
@@ -760,6 +761,49 @@ public:
                 ypos += y_inc;
                 av_iter++;
             }
+        }
+        static LLCachedControl<bool> debug_show_game_controller_state(gSavedSettings, "DebugShowControllerState", false);
+        if (debug_show_game_controller_state())
+        {
+            static const char* axis_names[LLGameControl::NUM_AXES] = {
+                "LEFT X", "LEFT Y", "RIGHT X", "RIGHT Y", "L TRIGGER", "R TRIGGER"
+            };
+            static const char* button_names[LLGameControl::NUM_BUTTONS] = {
+                "A", "B", "X", "Y", "BACK", "SELECT", "START", "LSTICK", "RSTICK",
+                "LSHOULDER", "RSHOULDER", "UP", "DOWN", "LEFT", "RIGHT",
+                "MISC1", "PADDLE1", "PADDLE2", "PADDLE3", "PADDLE4", "TOUCHPAD",
+                "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31",
+            };
+            const LLGameControl::State& gc_state = LLGameControl::getState();
+            for (size_t i = 0; i < gc_state.mAxes.size(); i+=2)
+            {
+                addText(xpos, ypos, llformat(
+                    "  %-10s %6d   %-10s %6d",
+                    (i < LLGameControl::NUM_AXES) ? axis_names[i] : "AXIS",
+                    (S32)gc_state.mAxes[i],
+                    ((i+1) < LLGameControl::NUM_AXES) ? axis_names[i+1] : "AXIS",
+                    i < gc_state.mAxes.size() ? (S32)gc_state.mAxes[i+1] : 0
+                ));
+                ypos += y_inc;
+            }
+            addText(xpos, ypos, "Game Controller Final State Axes");
+            ypos += y_inc;
+            static const char* pressed = "░░░░░░░░░░";
+            static const char* released = "          ";
+            for (U8 i = 0; i < LLGameControl::NUM_BUTTONS; i += 4)
+            {
+                addText(xpos, ypos, llformat(
+                    "  %-10s %-10s %-10s %-10s",
+                    gc_state.mButtons & (1 << (i+0)) ? pressed : released,
+                    gc_state.mButtons & (1 << (i+1)) ? pressed : released,
+                    gc_state.mButtons & (1 << (i+2)) ? pressed : released,
+                    gc_state.mButtons & (1 << (i+3)) ? pressed : released
+                ));
+                addText(xpos, ypos, llformat("  %-10s %-10s %-10s %-10s", button_names[i],button_names[i+1],button_names[i+2],button_names[i+3]));
+                ypos += y_inc;
+            }
+            addText(xpos, ypos, "Game Controller Final State Buttons");
+            ypos += y_inc;
         }
         static LLCachedControl<bool> debug_show_render_matrices(gSavedSettings, "DebugShowRenderMatrices", false);
         if (debug_show_render_matrices())

--- a/indra/newview/skins/default/xui/en/control_table_contents_game_control.xml
+++ b/indra/newview/skins/default/xui/en/control_table_contents_game_control.xml
@@ -214,6 +214,16 @@
          value="BUTTON_19" />
     </rows>
     <rows
+     name="game_control_button_20"
+     value="game_control_button_20">
+        <columns
+         column="lst_action"
+         font="SansSerif"
+         halign="left"
+         name="lst_action"
+         value="BUTTON_20" />
+    </rows>
+    <rows
      name="game_control_button_21"
      value="game_control_button_21">
         <columns

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -2790,6 +2790,16 @@ function="World.EnvPreset"
                function="ToggleControl"
                parameter="DebugShowMemory" />
             </menu_item_check>
+            <menu_item_check
+             label="Show Game Controller State"
+             name="Show Game Controller State">
+                <menu_item_check.on_check
+                 function="CheckControl"
+                 parameter="DebugShowControllerState" />
+                <menu_item_check.on_click
+                 function="ToggleControl"
+                 parameter="DebugShowControllerState" />
+            </menu_item_check>
 
             <menu_item_separator/>
 


### PR DESCRIPTION
## Description

For @AndrewMeadows 

This adds the missing `BUTTON_20` to the Controls preferences.

It also adds a debug display output for game controllers final state, accessed via the viewer menu

 `Develop > Show Info > Show Game Controller State`

[screencast_20260522_135908.webm](https://github.com/user-attachments/assets/468f6c3b-34c2-4cea-8450-422402287b28)

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).
