### PR TITLE
#4320 Bugsplat fails to catch thread crashes on Apple Silicon

### DIFF
--- a/indra/llcommon/llapp.cpp
+++ b/indra/llcommon/llapp.cpp
@@ -324,7 +324,6 @@ void LLApp::setupErrorHandling(bool second_instance)
 
 #else  // ! LL_WINDOWS
 
-#if ! defined(LL_BUGSPLAT)
     //
     // Start up signal handling.
     //
@@ -332,7 +331,6 @@ void LLApp::setupErrorHandling(bool second_instance)
     // thread, asynchronous signals can be delivered to any thread (in theory)
     //
     setup_signals();
-#endif // ! LL_BUGSPLAT
 
 #endif // ! LL_WINDOWS
 }
@@ -508,7 +506,9 @@ void setup_signals()
 {
     //
     // Set up signal handlers that may result in program termination
+    // Related: restoreErrorTrap
     //
+    // TODO: add tests that generate signals
     struct sigaction act;
     act.sa_sigaction = default_unix_signal_handler;
     sigemptyset( &act.sa_mask );

--- a/indra/llcommon/llthread.cpp
+++ b/indra/llcommon/llthread.cpp
@@ -174,6 +174,24 @@ void LLThread::threadRun()
     // this is the first point at which we're actually running in the new thread
     mID = currentID();
 
+#if !LL_WINDOWS
+    // On Unix platforms, make sure this thread's signal mask does not block
+    // crash signals. Signal dispositions are process-wide, but the signal mask
+    // is maintained per-thread, explicitly unblock these signals.
+    // This is critical on ARM64 macOS where thread crashes may not be properly
+    // captured by BugSplat if crash signals remain blocked in the thread mask.
+    // The signal handlers were installed process-wide in setupErrorHandling().
+    sigset_t signals;
+    sigemptyset(&signals);
+    sigaddset(&signals, SIGSEGV);
+    sigaddset(&signals, SIGBUS);
+    sigaddset(&signals, SIGILL);
+    sigaddset(&signals, SIGFPE);
+    sigaddset(&signals, SIGSYS);
+    // Unblock crash signals for this thread
+    pthread_sigmask(SIG_UNBLOCK, &signals, nullptr);
+#endif
+
     // for now, hard code all LLThreads to report to single master thread recorder, which is known to be running on main thread
     mRecorder = new LLTrace::ThreadRecorder(*LLTrace::get_master_thread_recorder());
 


### PR DESCRIPTION
Bugsplat fails to catch thread crashes on Apple Silicon, want to see if explicitly setting up signal handling helps.

Just throwing things at a wall to see what sticks.