### PR TITLE
#3729 Reduce inventory memory overhead

### DIFF
--- a/indra/llui/llfolderview.cpp
+++ b/indra/llui/llfolderview.cpp
@@ -4,7 +4,7 @@
  *
  * $LicenseInfo:firstyear=2001&license=viewerlgpl$
  * Second Life Viewer Source Code
- * Copyright (C) 2010, Linden Research, Inc.
+ * Copyright (C) 2026, Linden Research, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -1423,6 +1423,7 @@ bool LLFolderView::search(LLFolderViewItem* first_item, const std::string &searc
             }
         }
 
+        // Note: for inventory getSearchableName should already be 'upper' case.
         std::string current_item_label(search_item->getViewModelItem()->getSearchableName());
         LLStringUtil::toUpper(current_item_label);
         auto search_string_length = llmin(upper_case_string.size(), current_item_label.size());

--- a/indra/llui/llfolderviewitem.cpp
+++ b/indra/llui/llfolderviewitem.cpp
@@ -190,7 +190,7 @@ LLFolderViewItem::LLFolderViewItem(const LLFolderViewItem::Params& p)
     mItemHeight(p.item_height),
     mControlLabelRotation(0.f),
     mDragAndDropTarget(false),
-    mLabel(utf8str_to_wstring(p.name)),
+    mLabel(utf8str_to_wstring(p.name)), // will be immediately reset in postBuild()
     mRoot(p.root),
     mViewModelItem(p.listener),
     mIsMouseOverTitle(false),
@@ -244,8 +244,10 @@ bool LLFolderViewItem::postBuild()
     llassert(vmi); // not supposed to happen, if happens, find out why and fix
     if (vmi)
     {
-        // getDisplayName() is expensive (due to internal getLabelSuffix() and name building)
-        // it also sets search strings so it requires a filter reset
+        // First getDisplayName() is expensive due to internal
+        // lazy getLabelSuffix(), it is however needed as it sets
+        // search string, which can later determine visibility.
+        // Refreshing a search string also requires a filter reset.
         mLabel = utf8str_to_wstring(vmi->getDisplayName());
         mIsFavorite = vmi->isFavorite() && !vmi->isItemInTrash();
 
@@ -253,11 +255,8 @@ bool LLFolderViewItem::postBuild()
         vmi->dirtyFilter();
     }
 
-    // Don't do full refresh on constructor if it is possible to avoid
+    // Don't do full refresh on constructor if it is possible to avoid,
     // it significantly slows down bulk view creation.
-    // Todo: Ideally we need to move getDisplayName() out of constructor as well.
-    // Like: make a logic that will let filter update search string,
-    // while LLFolderViewItem::arrange() updates visual part
     mSuffixNeedsRefresh = true;
     mLabelWidthDirty = true;
     return true;

--- a/indra/llui/llfolderviewitem.cpp
+++ b/indra/llui/llfolderviewitem.cpp
@@ -4,7 +4,7 @@
 *
 * $LicenseInfo:firstyear=2001&license=viewerlgpl$
 * Second Life Viewer Source Code
-* Copyright (C) 2010, Linden Research, Inc.
+* Copyright (C) 2026, Linden Research, Inc.
 *
 * This library is free software; you can redistribute it and/or
 * modify it under the terms of the GNU Lesser General Public
@@ -248,7 +248,6 @@ bool LLFolderViewItem::postBuild()
         // it also sets search strings so it requires a filter reset
         mLabel = utf8str_to_wstring(vmi->getDisplayName());
         mIsFavorite = vmi->isFavorite() && !vmi->isItemInTrash();
-        setToolTip(vmi->getName());
 
         // Dirty the filter flag of the model from the view (CHUI-849)
         vmi->dirtyFilter();
@@ -363,7 +362,6 @@ void LLFolderViewItem::refresh()
     mLabel = utf8str_to_wstring(vmi.getDisplayName());
     mLabelFontBuffer.reset();
     mIsFavorite = vmi.isFavorite() && !vmi.isItemInTrash();
-    setToolTip(vmi.getName());
     // icons are slightly expensive to get, can be optimized
     // see LLInventoryIcon::getIcon()
     mIcon = vmi.getIcon();
@@ -621,6 +619,19 @@ const std::string& LLFolderViewItem::getName( void ) const
 {
     static const std::string noName("");
     return getViewModelItem() ? getViewModelItem()->getName() : noName;
+}
+
+const std::string LLFolderViewItem::getToolTip() const
+{
+    // Return the item name as tooltip without storing it
+    if (!LLView::sDebugUnicode)
+    {
+        if (const LLFolderViewModelItem* vmi = getViewModelItem())
+        {
+            return vmi->getName();
+        }
+    }
+    return LLView::getToolTip();
 }
 
 // LLView functionality

--- a/indra/llui/llfolderviewitem.h
+++ b/indra/llui/llfolderviewitem.h
@@ -4,7 +4,7 @@
 *
 * $LicenseInfo:firstyear=2001&license=viewerlgpl$
 * Second Life Viewer Source Code
-* Copyright (C) 2010, Linden Research, Inc.
+* Copyright (C) 2026, Linden Research, Inc.
 *
 * This library is free software; you can redistribute it and/or
 * modify it under the terms of the GNU Lesser General Public
@@ -252,6 +252,11 @@ public:
     // This method returns the actual name of the thing being
     // viewed. This method will ask the viewed object itself.
     const std::string& getName( void ) const;
+
+    // Override to provide lazy tooltip generation without memory overhead
+    // Inventory can consist of millions of items, yet most stay invisible,
+    // much less need to show a tooltip, so avoid storing tooltips.
+    virtual const std::string getToolTip() const;
 
     // This method returns the label displayed on the view. This
     // method was primarily added to allow sorting on the folder

--- a/indra/newview/llinventorybridge.cpp
+++ b/indra/newview/llinventorybridge.cpp
@@ -4,7 +4,7 @@
  *
  * $LicenseInfo:firstyear=2001&license=viewerlgpl$
  * Second Life Viewer Source Code
- * Copyright (C) 2010, Linden Research, Inc.
+ * Copyright (C) 2026, Linden Research, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -249,11 +249,27 @@ const std::string& LLInvFVBridge::getName() const
 
 const std::string& LLInvFVBridge::getDisplayName() const
 {
-    if(mDisplayName.empty())
+    if(mSearchableName.empty())
     {
-        buildDisplayName();
+        // first request of display name, build search string and cache it for later use
+        buildSearchableName();
     }
-    return mDisplayName;
+
+    LLInventoryModel* model = getInventoryModel();
+    if (model)
+    {
+        LLViewerInventoryCategory* cat = model->getCategory(mUUID);
+        if (cat)
+        {
+            return cat->getDisplayName();
+        }
+        LLViewerInventoryItem* item = model->getItem(mUUID);
+        if (item)
+        {
+            return item->getName();
+        }
+    }
+    return LLStringUtil::null;
 }
 
 std::string LLInvFVBridge::getSearchableDescription() const
@@ -2035,22 +2051,22 @@ PermissionMask LLItemBridge::getPermissionMask() const
 }
 
 // virtual
-void LLItemBridge::buildDisplayName() const
+void LLItemBridge::buildSearchableName() const
 {
-    if (getItem())
+    LLViewerInventoryItem* item = getItem();
+    if (item)
     {
-        mDisplayName.assign(getItem()->getName());
+        // for items, display name matches item name
+        mSearchableName.assign(item->getName());
     }
     else
     {
-        mDisplayName.assign(LLStringUtil::null);
+        mSearchableName.assign(LLStringUtil::null);
     }
-
-    mSearchableName.assign(mDisplayName);
     mSearchableName.append(getLabelSuffix());
     LLStringUtil::toUpper(mSearchableName);
 
-    // Name set, so trigger a sort
+    // Searchable and name set, so trigger a sort
     LLInventorySort sorter = static_cast<LLFolderViewModelInventory&>(mRootViewModel).getSorter();
     if (mParent && !sorter.isByDate())
     {
@@ -2371,39 +2387,17 @@ void LLFolderBridge::selectItem()
     }
 }
 
-void LLFolderBridge::buildDisplayName() const
+void LLFolderBridge::buildSearchableName() const
 {
-    LLFolderType::EType preferred_type = getPreferredType();
-
-    // *TODO: to be removed when database supports multi language. This is a
-    // temporary attempt to display the inventory folder in the user locale.
-    // mantipov: *NOTE: be sure this code is synchronized with LLFriendCardsManager::findChildFolderUUID
-    //      it uses the same way to find localized string
-
-    // HACK: EXT - 6028 ([HARD CODED]? Inventory > Library > "Accessories" folder)
-    // Translation of Accessories folder in Library inventory folder
-    bool accessories = false;
-    if(getName() == "Accessories")
+    LLViewerInventoryCategory* cat = gInventory.getCategory(getUUID());
+    if (cat)
     {
-        //To ensure that Accessories folder is in Library we have to check its parent folder.
-        //Due to parent LLFolderViewFloder is not set to this item yet we have to check its parent via Inventory Model
-        LLInventoryCategory* cat = gInventory.getCategory(getUUID());
-        if(cat)
-        {
-            const LLUUID& parent_folder_id = cat->getParentUUID();
-            accessories = (parent_folder_id == gInventory.getLibraryRootFolderID());
-        }
+        mSearchableName.assign(cat->getDisplayName());
     }
-
-    //"Accessories" inventory category has folder type FT_NONE. So, this folder
-    //can not be detected as protected with LLFolderType::lookupIsProtectedType
-    mDisplayName.assign(getName());
-    if (accessories || LLFolderType::lookupIsProtectedType(preferred_type))
+    else
     {
-        LLTrans::findString(mDisplayName, std::string("InvFolder ") + getName(), LLSD());
+        mSearchableName.assign(LLStringUtil::null);
     }
-
-    mSearchableName.assign(mDisplayName);
     mSearchableName.append(getLabelSuffix());
     LLStringUtil::toUpper(mSearchableName);
 
@@ -2417,6 +2411,8 @@ void LLFolderBridge::buildDisplayName() const
 
 std::string LLFolderBridge::getLabelSuffix() const
 {
+    // Folders, unlike items, have context dependent suffixes
+    // that may change as the folder is loaded
     static LLCachedControl<bool> xui_debug(gSavedSettings, "DebugShowXUINames", 0);
 
     if (mIsLoading && mTimeSinceRequestStart.getElapsedTimeF32() >= FOLDER_LOADING_MESSAGE_DELAY)
@@ -6576,18 +6572,29 @@ void LLCallingCardBridge::refreshFolderViewItem()
 
 void LLCallingCardBridge::checkSearchBySuffixChanges()
 {
-    if (!mDisplayName.empty())
+    if (!mSearchableName.empty())
     {
-        // changes in mDisplayName are processed by rename function and here it will be always same
+        LLViewerInventoryItem* item = getItem();
+        if (!item)
+        {
+            // checkSearchBySuffixChanges is only used by friend list
+            // so if item is not found, we removed the calling card or
+            // are no longer friends.
+            mSearchableName.clear();
+            return;
+        }
+
+        // changes in display name are processed by rename function and here it will be always same
         // suffixes are also of fixed length, and we are processing change of one at a time,
         // so it should be safe to use length (note: mSearchableName is capitalized)
-        auto old_length = mSearchableName.length();
-        auto new_length = mDisplayName.length() + getLabelSuffix().length();
+        size_t old_length = mSearchableName.length();
+        const std::string& display_name = item->getName();
+        size_t new_length = display_name.length() + getLabelSuffix().length();
         if (old_length == new_length)
         {
             return;
         }
-        mSearchableName.assign(mDisplayName);
+        mSearchableName.assign(display_name);
         mSearchableName.append(getLabelSuffix());
         LLStringUtil::toUpper(mSearchableName);
         if (new_length<old_length)
@@ -7465,7 +7472,7 @@ bool LLObjectBridge::renameItem(const std::string& new_name)
         new_item->updateServer(false);
         model->updateItem(new_item);
         model->notifyObservers();
-        buildDisplayName();
+        buildSearchableName();
 
         if (isAgentAvatarValid())
         {

--- a/indra/newview/llinventorybridge.h
+++ b/indra/newview/llinventorybridge.h
@@ -4,7 +4,7 @@
  *
  * $LicenseInfo:firstyear=2001&license=viewerlgpl$
  * Second Life Viewer Source Code
- * Copyright (C) 2010, Linden Research, Inc.
+ * Copyright (C) 2026, Linden Research, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -87,7 +87,7 @@ public:
     virtual const LLUUID& getUUID() const { return mUUID; }
     virtual const LLUUID& getThumbnailUUID() const { return LLUUID::null; }
     virtual bool isFavorite() const { return false; }
-    virtual void clearDisplayName() { mDisplayName.clear(); }
+    virtual void clearSearchableName() { mSearchableName.clear(); }
     virtual void restoreItem() {}
     virtual void restoreToWorld() {}
 
@@ -202,12 +202,11 @@ protected:
     LLInventoryType::EType mInvType;
     bool                        mIsLink;
     LLTimer                     mTimeSinceRequestStart;
-    mutable std::string         mDisplayName;
     mutable std::string         mSearchableName;
 
     void purgeItem(LLInventoryModel *model, const LLUUID &uuid);
     void removeObject(LLInventoryModel *model, const LLUUID &uuid);
-    virtual void buildDisplayName() const {}
+    virtual void buildSearchableName() const {}
 };
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -266,7 +265,7 @@ public:
 protected:
     bool confirmRemoveItem(const LLSD& notification, const LLSD& response);
     virtual bool isItemPermissive() const;
-    virtual void buildDisplayName() const;
+    virtual void buildSearchableName() const;
     void doActionOnCurSelectedLandmark(LLLandmarkList::loaded_callback_t cb);
 
 private:
@@ -287,7 +286,7 @@ public:
     void callback_dropItemIntoFolder(const LLSD& notification, const LLSD& response, LLInventoryItem* inv_item);
     void callback_dropCategoryIntoFolder(const LLSD& notification, const LLSD& response, LLInventoryCategory* inv_category);
 
-    virtual void buildDisplayName() const;
+    virtual void buildSearchableName() const;
 
     virtual void performAction(LLInventoryModel* model, std::string action);
     virtual void openItem();

--- a/indra/newview/llinventorypanel.cpp
+++ b/indra/newview/llinventorypanel.cpp
@@ -198,7 +198,6 @@ LLFolderView * LLInventoryPanel::createFolderRoot(LLUUID root_id )
     p.title = getLabel();
     p.rect = LLRect(0, 0, getRect().getWidth(), 0);
     p.parent_panel = this;
-    p.tool_tip = p.name;
     p.listener = mInvFVBridgeBuilder->createBridge( LLAssetType::AT_CATEGORY,
                                                                     LLAssetType::AT_CATEGORY,
                                                                     LLInventoryType::IT_CATEGORY,
@@ -1067,7 +1066,6 @@ LLFolderViewFolder * LLInventoryPanel::createFolderViewFolder(LLInvFVBridge * br
     params.name = bridge->getDisplayName();
     params.root = mFolderRoot.get();
     params.listener = bridge;
-    params.tool_tip = params.name;
     params.allow_drop = allow_drop;
 
     params.font_color = (bridge->isLibraryItem() ? sLibraryColor : sDefaultColor);
@@ -1085,7 +1083,6 @@ LLFolderViewItem * LLInventoryPanel::createFolderViewItem(LLInvFVBridge * bridge
     params.root = mFolderRoot.get();
     params.listener = bridge;
     params.rect = LLRect (0, 0, 0, 0);
-    params.tool_tip = params.name;
 
     params.font_color = (bridge->isLibraryItem() ? sLibraryColor : sDefaultColor);
     params.font_highlight_color = (bridge->isLibraryItem() ? sLibraryColor : sDefaultHighlightColor);

--- a/indra/newview/llinventorypanel.cpp
+++ b/indra/newview/llinventorypanel.cpp
@@ -1063,7 +1063,18 @@ LLFolderViewFolder * LLInventoryPanel::createFolderViewFolder(LLInvFVBridge * br
 {
     LLFolderViewFolder::Params params(mParams.folder);
 
-    params.name = bridge->getDisplayName();
+#ifndef LL_RELEASE_FOR_DOWNLOAD
+    // Only usable for debug and first call has a large
+    // overhead from search string construction.
+    // As inventory names aren't unique and can change,
+    // there is little we can use them for in release builds.
+    params.name = bridge->getName();
+#else
+    // We don't have a source of unique names and inventory
+    // items can reach millions in quantity, just use
+    // a short descriptor
+    params.name = "fld";
+#endif
     params.root = mFolderRoot.get();
     params.listener = bridge;
     params.allow_drop = allow_drop;
@@ -1078,7 +1089,19 @@ LLFolderViewItem * LLInventoryPanel::createFolderViewItem(LLInvFVBridge * bridge
 {
     LLFolderViewItem::Params params(mParams.item);
 
-    params.name = bridge->getDisplayName();
+#ifndef LL_RELEASE_FOR_DOWNLOAD
+    // Only usable for debug and first call has a large
+    // overhead from search string construction.
+    // As inventory names aren't unique, are large and can change,
+    // there is little we can use them for in release builds.
+    // Prefer shorter
+    params.name = bridge->getName();
+#else
+    // We don't have a source of unique names and inventory
+    // items can reach millions in quantity, just use
+    // a short descriptor
+    params.name = "itm";
+#endif
     params.creation_date = bridge->getCreationDate();
     params.root = mFolderRoot.get();
     params.listener = bridge;

--- a/indra/newview/llinventorypanel.cpp
+++ b/indra/newview/llinventorypanel.cpp
@@ -4,7 +4,7 @@
  *
  * $LicenseInfo:firstyear=2001&license=viewerlgpl$
  * Second Life Viewer Source Code
- * Copyright (C) 2010, Linden Research, Inc.
+ * Copyright (C) 2026, Linden Research, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -581,8 +581,9 @@ void LLInventoryPanel::itemChanged(const LLUUID& item_id, U32 mask, const LLInve
             LLInvFVBridge* bridge = (LLInvFVBridge*)view_item->getViewModelItem();
             if(bridge)
             {
-                // Clear the display name first, so it gets properly re-built during refresh()
-                bridge->clearDisplayName();
+                // Clear the searchable name first, so it gets
+                // properly re-built during refresh()
+                bridge->clearSearchableName();
 
                 view_item->refresh();
             }
@@ -1676,7 +1677,7 @@ void LLInventoryPanel::onSelectionChange(const std::deque<LLFolderViewItem*>& it
                     LLFolderBridge* prev_bridge = (LLFolderBridge*)prev_folder_item->getViewModelItem();
                     if(prev_bridge)
                     {
-                        prev_bridge->clearDisplayName();
+                        prev_bridge->clearSearchableName();
                         prev_bridge->setShowDescendantsCount(false);
                         prev_folder_item->refresh();
                     }
@@ -1685,7 +1686,7 @@ void LLInventoryPanel::onSelectionChange(const std::deque<LLFolderViewItem*>& it
                 LLFolderBridge* bridge = (LLFolderBridge*)folder_item->getViewModelItem();
                 if(bridge)
                 {
-                    bridge->clearDisplayName();
+                    bridge->clearSearchableName();
                     bridge->setShowDescendantsCount(true);
                     folder_item->refresh();
                     mPreviousSelectedFolder = bridge->getUUID();
@@ -1700,7 +1701,7 @@ void LLInventoryPanel::onSelectionChange(const std::deque<LLFolderViewItem*>& it
             LLFolderBridge* prev_bridge = (LLFolderBridge*)prev_folder_item->getViewModelItem();
             if(prev_bridge)
             {
-                prev_bridge->clearDisplayName();
+                prev_bridge->clearSearchableName();
                 prev_bridge->setShowDescendantsCount(false);
                 prev_folder_item->refresh();
             }
@@ -1720,7 +1721,7 @@ void LLInventoryPanel::updateFolderLabel(const LLUUID& folder_id)
         LLFolderBridge* bridge = (LLFolderBridge*)folder_item->getViewModelItem();
         if(bridge)
         {
-            bridge->clearDisplayName();
+            bridge->clearSearchableName();
             bridge->setShowDescendantsCount(true);
             folder_item->refresh();
         }

--- a/indra/newview/llpanelmarketplaceinboxinventory.cpp
+++ b/indra/newview/llpanelmarketplaceinboxinventory.cpp
@@ -4,7 +4,7 @@
  *
  * $LicenseInfo:firstyear=2009&license=viewerlgpl$
  * Second Life Viewer Source Code
- * Copyright (C) 2010, Linden Research, Inc.
+ * Copyright (C) 2026, Linden Research, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -85,7 +85,6 @@ LLFolderViewFolder * LLInboxInventoryPanel::createFolderViewFolder(LLInvFVBridge
     params.name = bridge->getDisplayName();
     params.root = mFolderRoot.get();
     params.listener = bridge;
-    params.tool_tip = params.name;
     params.font_color = item_color;
     params.font_highlight_color = item_color;
     params.allow_drop = allow_drop;
@@ -104,7 +103,6 @@ LLFolderViewItem * LLInboxInventoryPanel::createFolderViewItem(LLInvFVBridge * b
     params.root = mFolderRoot.get();
     params.listener = bridge;
     params.rect = LLRect (0, 0, 0, 0);
-    params.tool_tip = params.name;
     params.font_color = item_color;
     params.font_highlight_color = item_color;
 

--- a/indra/newview/llpanelmarketplaceinboxinventory.cpp
+++ b/indra/newview/llpanelmarketplaceinboxinventory.cpp
@@ -82,7 +82,18 @@ LLFolderViewFolder * LLInboxInventoryPanel::createFolderViewFolder(LLInvFVBridge
 
     LLInboxFolderViewFolder::Params params;
 
-    params.name = bridge->getDisplayName();
+#ifndef LL_RELEASE_FOR_DOWNLOAD
+    // Only usable for debug and first call has a large
+    // overhead from search string construction.
+    // As inventory names aren't unique and can change,
+    // there is little we can use them for in release builds.
+    params.name = bridge->getName();
+#else
+    // We don't have a source of unique names and inventory
+    // items can reach millions in quantity, just use
+    // a short descriptor
+    params.name = "fld";
+#endif
     params.root = mFolderRoot.get();
     params.listener = bridge;
     params.font_color = item_color;
@@ -98,7 +109,18 @@ LLFolderViewItem * LLInboxInventoryPanel::createFolderViewItem(LLInvFVBridge * b
 
     LLInboxFolderViewItem::Params params;
 
-    params.name = bridge->getDisplayName();
+#ifndef LL_RELEASE_FOR_DOWNLOAD
+    // Only usable for debug and first call has a large
+    // overhead from search string construction.
+    // As inventory names aren't unique and can change,
+    // there is little we can use them for in release builds.
+    params.name = bridge->getName();
+#else
+    // We don't have a source of unique names and inventory
+    // items can reach millions in quantity, just use
+    // a short descriptor
+    params.name = "itm";
+#endif
     params.creation_date = bridge->getCreationDate();
     params.root = mFolderRoot.get();
     params.listener = bridge;

--- a/indra/newview/llpanelobjectinventory.cpp
+++ b/indra/newview/llpanelobjectinventory.cpp
@@ -4,7 +4,7 @@
  *
  * $LicenseInfo:firstyear=2002&license=viewerlgpl$
  * Second Life Viewer Source Code
- * Copyright (C) 2010, Linden Research, Inc.
+ * Copyright (C) 2026, Linden Research, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -1611,7 +1611,6 @@ void LLPanelObjectInventory::createViewsForCategory(LLInventoryObject::object_li
                     params.name = obj->getName();
                     params.root = mFolders;
                     params.listener = bridge;
-                    params.tool_tip = params.name;
                     params.font_color = item_color;
                     params.font_highlight_color = item_color;
                     view = LLUICtrlFactory::create<LLFolderViewFolder>(params);
@@ -1625,7 +1624,6 @@ void LLPanelObjectInventory::createViewsForCategory(LLInventoryObject::object_li
                     params.listener = bridge;
                     params.creation_date = bridge->getCreationDate();
                     params.rect = LLRect();
-                    params.tool_tip = params.name;
                     params.font_color = item_color;
                     params.font_highlight_color = item_color;
                     view = LLUICtrlFactory::create<LLFolderViewItem>(params);

--- a/indra/newview/llviewerinventory.cpp
+++ b/indra/newview/llviewerinventory.cpp
@@ -4,7 +4,7 @@
  *
  * $LicenseInfo:firstyear=2002&license=viewerlgpl$
  * Second Life Viewer Source Code
- * Copyright (C) 2014, Linden Research, Inc.
+ * Copyright (C) 2026, Linden Research, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -673,6 +673,25 @@ void LLViewerInventoryCategory::setVersion(S32 version)
     mVersion = version;
 }
 
+const std::string& LLViewerInventoryCategory::getDisplayName() const
+{
+    if (mNeedsDisplayNameUpdate)
+    {
+        buildDisplayName();
+    }
+    if (!mDisplayName.empty())
+    {
+        return mDisplayName;
+    }
+    return getName();
+}
+
+void LLViewerInventoryCategory::invalidateDisplayName()
+{
+    mNeedsDisplayNameUpdate = true;
+    mDisplayName.clear();
+}
+
 bool LLViewerInventoryCategory::fetch(S32 expiry_seconds)
 {
     if((VERSION_UNKNOWN == getVersion())
@@ -887,6 +906,34 @@ void LLViewerInventoryCategory::changeType(LLFolderType::EType new_folder_type)
 void LLViewerInventoryCategory::localizeName()
 {
     LLLocalizedInventoryItemsDictionary::getInstance()->localizeInventoryObjectName(mName);
+}
+
+void LLViewerInventoryCategory::buildDisplayName() const
+{
+    // Secure and library folders can't be renamed,
+    // so we only need to do this once.
+    mNeedsDisplayNameUpdate = false;
+
+    //"Accessories" inventory category has folder type FT_NONE. So, this folder
+    //can not be detected as protected with LLFolderType::lookupIsProtectedType
+    //
+    // HACK: EXT - 6028 ([HARD CODED]? Inventory > Library > "Accessories" folder)
+    // Translation of Accessories folder in Library inventory folder
+    LLFolderType::EType preferred_type = getPreferredType();
+
+    bool is_accessories = false;
+    if (getName() == "Accessories")
+    {
+        // To ensure that Accessories folder is in Library we have to check its parent folder.
+        const LLUUID& parent_folder_id = getParentUUID();
+        is_accessories = (parent_folder_id == gInventory.getLibraryRootFolderID());
+    }
+
+    if (is_accessories || LLFolderType::lookupIsProtectedType(preferred_type))
+    {
+        // All predefined folders have translations in strings.xml.
+        LLTrans::findString(mDisplayName, std::string("InvFolder ") + getName(), LLSD());
+    }
 }
 
 // virtual

--- a/indra/newview/llviewerinventory.h
+++ b/indra/newview/llviewerinventory.h
@@ -4,7 +4,7 @@
  *
  * $LicenseInfo:firstyear=2002&license=viewerlgpl$
  * Second Life Viewer Source Code
- * Copyright (C) 2010, Linden Research, Inc.
+ * Copyright (C) 2026, Linden Research, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -209,6 +209,13 @@ public:
     S32 getVersion() const;
     void setVersion(S32 version);
 
+    const std::string& getDisplayName() const;
+    // The display name gets cached on demand, so needs a cleanup method.
+    // But in practice only secure folders' display name mismatches
+    // actual name, and those folders can't be renamed, so in practice
+    // this is useless unless we want to free memory.
+    void invalidateDisplayName();
+
     // Returns true if a fetch was issued (not nessesary in progress).
     // no requests will happen during expiry_seconds even if fetch completed
     bool fetch(S32 expiry_seconds = 10);
@@ -253,6 +260,19 @@ protected:
     S32 mDescendentCount;
     EFetchType mFetching;
     LLFrameTimer mDescendentsRequested;
+
+    // Display names are generated on demand and cached.
+    // buildDisplayName is essentially a way to localize
+    // system and library folders.
+    //
+    // TODO: This is on demand and mutable because that's how it
+    // worked in inventory bridge, before it was moved.
+    // But system folders always get loaded, it's likely better
+    // to just generate from the get go.
+    // Consider merging with localizeName.
+    void buildDisplayName() const;
+    mutable std::string mDisplayName;
+    mutable bool mNeedsDisplayNameUpdate = true;
 };
 
 class LLInventoryCallback : public LLRefCount

--- a/indra/newview/skins/default/xui/en/panel_inbox_inventory.xml
+++ b/indra/newview/skins/default/xui/en/panel_inbox_inventory.xml
@@ -13,6 +13,7 @@
     border="false"
     bevel_style="none"
     show_item_link_overlays="true"
+    preinitialize_views="false"
     >
     <scroll reserve_scroll_corner="false" />
 </inbox_inventory_panel>


### PR DESCRIPTION
UI elements already cache display name, getDisplayName() calls are rare and only come with other calls.

For items, any UI calls already engage internal getItem optimizations, so doing getItem in getDisplayName() has negligible performance overhead while avoiding storing a dupplicate of item's name. This also cuts performance overhead from allocations, so it's a net benefit performance wise on first load.

System folders do utilize display names that are different from default names, but they are not panel specific, they are global localizations. Store those in the model, not in the bridge.

Usage example: LLFolderViewItem::postBuild() already calls getName after getDisplayName(), so getItem will utilize mLastItem either way and the only refresh needed happens if user renames the item. Without the user the update happens only once.