### PR TITLE
#5798 fix displaying outfit Search results and update default filtering

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -14416,7 +14416,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
     <key>OutfitOperationsTimeout</key>
     <map>

--- a/indra/newview/lloutfitslist.cpp
+++ b/indra/newview/lloutfitslist.cpp
@@ -519,6 +519,22 @@ void LLOutfitsList::resetItemSelection(LLWearableItemsList* list, const LLUUID& 
     list->resetSelection();
     mItemSelected = false;
     signalSelectionOutfitUUID(category_id);
+
+    // If filtering was applied while tab was collapsed, item visibility is updated but the parent tab height might not be updated.
+    // Force rearrange to recompute the height, when tab is expanded.
+    static LLCachedControl<bool> show_all_items(gSavedSettings, "OutfitListFilterFullList", 1);
+    if (!show_all_items)
+    {
+        outfits_map_t::const_iterator tab_iter = mOutfitsMap.find(category_id);
+        if (tab_iter != mOutfitsMap.end())
+        {
+            LLOutfitAccordionCtrlTab* tab = tab_iter->second;
+            if (tab && tab->getDisplayChildren())
+            {
+                list->notify(LLSD().with("rearrange", true));
+            }
+        }
+    }
 }
 
 void LLOutfitsList::onChangeOutfitSelection(LLWearableItemsList* list, const LLUUID& category_id)
@@ -1648,7 +1664,7 @@ bool LLOutfitListSortMenu::onEnable(LLSD::String param)
     }
     else if ("show_entire_outfit" == param)
     {
-        static LLCachedControl<bool> filter_mode(gSavedSettings, "OutfitListFilterFullList", 0);
+        static LLCachedControl<bool> filter_mode(gSavedSettings, "OutfitListFilterFullList", 1);
         return filter_mode;
     }
 


### PR DESCRIPTION
Change default setting to display all items if Outfit name matches the Search text.
Fix the issue with 'empty space' inside Outfit tabs, when not matching items are hidden.