### PR TITLE
docs: fix typo — 'judgment' → 'judgement'

### DIFF
--- a/doc/LGPL-license.txt
+++ b/doc/LGPL-license.txt
@@ -371,7 +371,7 @@ restrictions on the recipients' exercise of the rights granted herein.
 You are not responsible for enforcing compliance by third parties with
 this License.
 
-  11. If, as a consequence of a court judgment or allegation of patent
+  11. If, as a consequence of a court judgement or allegation of patent
 infringement or for any other reason (not limited to patent issues),
 conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not


### PR DESCRIPTION
This PR fixes a typo found in issue #5639.

**Change**: `judgment` → `judgement`

Fixes #5639