### PR TITLE
#3342 Fix "Cut" and "Copy" options for objects in notecards

### DIFF
--- a/indra/llui/lltextbase.h
+++ b/indra/llui/lltextbase.h
@@ -327,6 +327,7 @@ class LLTextBase
 public:
     friend class LLTextSegment;
     friend class LLNormalTextSegment;
+    friend class LLEmbeddedItemSegment;
     friend class LLUICtrlFactory;
 
     typedef boost::signals2::signal<bool (const LLUUID& user_id)> is_friend_signal_t;

--- a/indra/llui/lltexteditor.h
+++ b/indra/llui/lltexteditor.h
@@ -208,6 +208,7 @@ public:
 
     void            setShowContextMenu(bool show) { mShowContextMenu = show; }
     bool            getShowContextMenu() const { return mShowContextMenu; }
+    void            showContextMenu(S32 x, S32 y);
 
     void            showEmojiHelper();
     void            hideEmojiHelper();
@@ -219,7 +220,6 @@ public:
     LLWString       getConvertedText() const;
 
 protected:
-    void            showContextMenu(S32 x, S32 y);
     void            drawPreeditMarker();
 
     void            removeCharOrTab();

--- a/indra/newview/llviewertexteditor.cpp
+++ b/indra/newview/llviewertexteditor.cpp
@@ -249,6 +249,25 @@ public:
 
     /*virtual*/ bool            canEdit() const { return false; }
 
+    /*virtual*/ bool            handleRightMouseDown(S32 x, S32 y, MASK mask)
+    {
+        bool show_menu = !mEditor.hasSelection()
+            || (mEditor.mSelectionStart == mStart && mEditor.mSelectionEnd == mStart + 1);
+        if (show_menu && mEditor.getShowContextMenu())
+        {
+            // User clicked an item, user expects the menu to be
+            // in 'context' for the item. Change selection to match.
+            // Todo: Might be better to 'smartly' deselect here
+            // and to have an object specific menu.
+            mEditor.setCursorPos(mStart + 1);
+            mEditor.mSelectionStart = mStart;
+            mEditor.mSelectionEnd = mStart + 1;
+
+            mEditor.showContextMenu(x, y);
+            return true;
+        }
+        return false;
+    }
 
     /*virtual*/ bool            handleHover(S32 x, S32 y, MASK mask)
     {


### PR DESCRIPTION
Since objects are a special case, made the segment select itself on right click

P.S. probably should deselect everythign else too, but arguably it should have an entirely different context menu. For now I'm minimizing impact so no deselect.