### PR TITLE
FIX - Transparent highlights omitting HUDs

### DIFF
--- a/indra/newview/lldrawpoolalpha.cpp
+++ b/indra/newview/lldrawpoolalpha.cpp
@@ -267,8 +267,8 @@ void LLDrawPoolAlpha::forwardRender(bool rigged)
 
     gGL.setColorMask(true, false);
 
-    if (!rigged && getType() == LLDrawPoolAlpha::POOL_ALPHA_POST_WATER)
-    { //render "highlight alpha" on final non-rigged pass
+    if (!rigged && (LLPipeline::sRenderingHUDs || getType() == LLDrawPoolAlpha::POOL_ALPHA_POST_WATER))
+    { //render "highlight alpha" on final non-rigged pass for non-HUDs (HUDs only run pre-water alpha pass)
         // NOTE -- hacky call here protected by !rigged instead of alongside "forwardRender"
         // so renderDebugAlpha is executed while gls_pipeline_alpha and depth GL state
         // variables above are still in scope
@@ -278,7 +278,7 @@ void LLDrawPoolAlpha::forwardRender(bool rigged)
 
 void LLDrawPoolAlpha::renderDebugAlpha()
 {
-    if (sShowDebugAlpha && !gCubeSnapshot)
+    if (sShowDebugAlpha && !gCubeSnapshot && !LLPipeline::sReflectionRender)
     {
         gHighlightProgram.bind();
         gGL.diffuseColor4f(1, 0, 0, 1);


### PR DESCRIPTION
fixes #5874

As mentioned in the issue thread, the change to have the debug alphas render with the post water pass made the HUD alphas not render since HUD are rendered in the pre-water pass. Adjusting the check to include HUDs fixes the issue with HUD alphas not highlighting.