### PR TITLE
Some minor tweaks to the color picker after interest was expressed during a Content Creator User Group

### DIFF
--- a/indra/newview/llfloatercolorpicker.cpp
+++ b/indra/newview/llfloatercolorpicker.cpp
@@ -32,6 +32,7 @@
 #include "lltoolmgr.h"
 #include "lltoolpipette.h"
 #include "llviewercontrol.h"
+#include "llviewerwindow.h"
 #include "llworld.h"
 
 // Linden library includes
@@ -45,6 +46,7 @@
 #include "lllineeditor.h"
 #include "v4coloru.h"
 #include "llbutton.h"
+#include "llcombobox.h"
 #include "lluictrlfactory.h"
 #include "llgl.h"
 #include "llpointer.h"
@@ -76,7 +78,7 @@ LLFloaterColorPicker::LLFloaterColorPicker (LLColorSwatchCtrl* swatch, bool show
       mMouseDownInSwatch    ( false ),
       // *TODO: Specify this in XML
       mRGBViewerImageLeft   ( 140 ),
-      mRGBViewerImageTop    ( 356 ),
+      mRGBViewerImageTop    ( 436 ),
       mRGBViewerImageWidth  ( 256 ),
       mRGBViewerImageHeight ( 256 ),
       mLumRegionLeft        ( mRGBViewerImageLeft + mRGBViewerImageWidth + 16 ),
@@ -86,18 +88,18 @@ LLFloaterColorPicker::LLFloaterColorPicker (LLColorSwatchCtrl* swatch, bool show
       mLumMarkerSize        ( 6 ),
       // *TODO: Specify this in XML
       mSwatchRegionLeft     ( 12 ),
-      mSwatchRegionTop      ( 190 ),
+      mSwatchRegionTop      ( 249 ),
       mSwatchRegionWidth    ( 116 ),
       mSwatchRegionHeight   ( 60 ),
       mSwatchView           ( NULL ),
       // *TODO: Specify this in XML
       numPaletteColumns     ( 16 ),
-      numPaletteRows        ( 2 ),
+      numPaletteRows        ( 4 ),
       highlightEntry        ( -1 ),
       mPaletteRegionLeft    ( 11 ),
-      mPaletteRegionTop     ( 100 - 8 ),
+      mPaletteRegionTop     ( 180 - 8 ),
       mPaletteRegionWidth   ( mLumRegionLeft + mLumRegionWidth - 10 ),
-      mPaletteRegionHeight  ( 40 ),
+      mPaletteRegionHeight  ( 120 ),
       mSwatch               ( swatch ),
       mActive               ( true ),
       mCanApplyImmediately  ( show_apply_immediate ),
@@ -154,7 +156,7 @@ void LLFloaterColorPicker::createUI ()
     // create palette
     for ( S32 each = 0; each < numPaletteColumns * numPaletteRows; ++each )
     {
-        mPalette.push_back(new LLColor4(LLUIColorTable::instance().getColor(llformat("ColorPaletteEntry%02d", each + 1))));
+        mPalette.push_back(new LLColor4(LLUIColorTable::instance().getColor(llformat("ColorPaletteEntry%02d", each + 1), LLColor4::grey)));
     }
 }
 
@@ -232,6 +234,7 @@ bool LLFloaterColorPicker::postBuild()
     childSetCommitCallback("hspin", onTextCommit, (void*)this );
     childSetCommitCallback("sspin", onTextCommit, (void*)this );
     childSetCommitCallback("lspin", onTextCommit, (void*)this );
+    childSetCommitCallback("hex_color", onTextCommit, (void*)this );
 
     mPipetteConnection = LLToolPipette::getInstance()->setToolSelectCallback(
         [this](LLPointer<LLViewerObject> object, S32 te_index)
@@ -242,6 +245,9 @@ bool LLFloaterColorPicker::postBuild()
             onColorSelect(entry->getColor());
         }
     });
+
+   mCopyColorAsCombo = getChild<LLComboBox>("copy_color_combobox");
+    mCopyColorAsCombo->setCommitCallback(boost::bind(&LLFloaterColorPicker::onCopyColor, this));
 
     return true;
 }
@@ -678,6 +684,61 @@ void LLFloaterColorPicker::drawPalette ()
 }
 
 //////////////////////////////////////////////////////////////////////////////
+// Convert input RGB (0..1.0) to a hex color string
+std::string rgbFloatToHex(float r, float g, float b)
+{
+    auto toUint8 = [](float val) -> unsigned char {
+        return static_cast<unsigned char>(std::round(std::clamp(val * 255.0f, 0.0f, 255.0f)));
+    };
+
+    std::ostringstream oss;
+    oss << std::hex << std::uppercase << std::setfill('0');
+    oss << std::setw(2) << static_cast<int>(toUint8(r));
+    oss << std::setw(2) << static_cast<int>(toUint8(g));
+    oss << std::setw(2) << static_cast<int>(toUint8(b));
+
+    return oss.str();
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Boolean test if input string is a valid hex color string
+bool LLFloaterColorPicker::isValidHexColor(std::string& hex_color, F32& hr, F32& hg, F32& hb)
+{
+    // Strip any whitespace and a leading # character if present
+    // (Often included in hex color strings from other places)
+    LLStringUtil::trim(hex_color);
+    if (!hex_color.empty() && hex_color.front() == '#')
+    {
+        hex_color = hex_color.substr(1);
+    }
+
+    // Make sure it's a real string and valid hex - we can't use the
+    // hex to dec code because that coerces invalid hex into decimal 0
+    if (hex_color.length() ==0 || hex_color.find_first_not_of("0123456789abcdefABCDEF") != std::string::npos)
+    {
+        return false;
+    }
+
+    // Convert the hex string to a decimal number
+    std::stringstream oss;
+    oss << std::hex << hex_color;
+    unsigned int dec_val;
+    oss >> dec_val;
+
+    // Break out the RGB values in 0..1.0 range and pass back
+    // (They will only be used if this function returns true.)
+    hr = F32(((dec_val >> 16) & 0xff)) / 255.0f;
+    hg = F32(((dec_val >> 8) & 0xff)) / 255.0f;
+    hb = F32(((dec_val >> 0) & 0xff)) / 255.0f;
+
+    // The max chars in the field is more than 6 now so we can paste in
+    // poorly formatted color strings and reformat them on commit.
+    // TODO: there must be a way to to the preformat when the string
+    // is pasted into the line editor control.
+    return dec_val > 0xffffff ? false : true;
+}
+
+//////////////////////////////////////////////////////////////////////////////
 // update text entry values for RGB/HSL (can't be done in ::draw () since this overwrites input
 void LLFloaterColorPicker::updateTextEntry ()
 {
@@ -688,6 +749,8 @@ void LLFloaterColorPicker::updateTextEntry ()
     getChild<LLUICtrl>("hspin")->setValue(( getCurH () * 360.0f ) );
     getChild<LLUICtrl>("sspin")->setValue(( getCurS () * 100.0f ) );
     getChild<LLUICtrl>("lspin")->setValue(( getCurL () * 100.0f ) );
+
+    getChild<LLUICtrl>("hex_color")->setValue(rgbFloatToHex(curR, curG, curB));
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -745,6 +808,22 @@ void LLFloaterColorPicker::onTextEntryChanged ( LLUICtrl* ctrl )
         selectCurHsl ( hVal, sVal, lVal );
 
         updateTextEntry ();
+    } else
+    if (name == "hex_color")
+    {
+        F32 rVal, gVal, bVal;
+        std::string hex = ctrl->getValue().asString();
+        if (isValidHexColor(hex, rVal, gVal, bVal))
+        {
+            // Valid hex color - update the picker with specified value
+            selectCurRgb ( rVal, gVal, bVal );
+            updateTextEntry ();
+        }
+        else
+        {
+            // Invalid hex color provided - update the hex color field with current color
+            updateTextEntry ();
+        }
     }
 }
 
@@ -1094,5 +1173,76 @@ void LLFloaterColorPicker::stopUsingPipette()
     if (LLToolMgr::getInstance()->getCurrentTool() == LLToolPipette::getInstance())
     {
         LLToolMgr::getInstance()->clearTransientTool();
+    }
+}
+
+void LLFloaterColorPicker::onCopyColor()
+{
+    LLComboBox* combo = getChild<LLComboBox>("copy_color_combobox");
+    S32 combo_val = combo->getSelectedValue().asInteger();
+
+    std::ostringstream to_copy;
+
+    // LSL - e.g. <0.571, 0.929, 0.585>
+    if (combo_val == 1)
+    {
+        to_copy << "<";
+        to_copy << std::setfill('0') << std::setprecision(3) << ((getCurR() < 0.001) ? 0.0 : getCurR());
+        to_copy << ", ";
+        to_copy << std::setfill('0') << std::setprecision(3) << ((getCurG() < 0.001) ? 0.0 : getCurG());
+        to_copy << ", ";
+        to_copy << std::setfill('0') << std::setprecision(3) << ((getCurB() < 0.001) ? 0.0 : getCurB());
+        to_copy << ">";
+    } else
+    // HEX e.g. #92ED95
+    if (combo_val == 2)
+    {
+        to_copy << "#";
+        to_copy << rgbFloatToHex(getCurR(), getCurG(), getCurB());
+    } else
+    // RGB e.g. (146, 237, 149)
+    if (combo_val == 3)
+    {
+        to_copy << "(";
+        to_copy << (S32)(getCurR() * 255.0f + 0.5f);
+        to_copy << ", ";
+        to_copy << (S32)(getCurG() * 255.0f + 0.5f);
+        to_copy << ", ";
+        to_copy << (S32)(getCurB() * 255.0f + 0.5f);
+        to_copy << ")";
+    } else
+    // HSL e.g. (122°, 71%, 75%)
+    if (combo_val == 4)
+    {
+        to_copy << "(";
+        to_copy << (S32)(getCurH() * 360.0f + 0.5f);
+        to_copy << "\xC2\xB0, ";
+        to_copy << (S32)(getCurS() * 100.0f + 0.5f);
+        to_copy << "%, ";
+        to_copy << (S32)(getCurL() * 100.0f + 0.5f);
+        to_copy << "%)";
+    }
+    // CMYK e.g. (38%, 0%, 37%, 7%)
+    if (combo_val == 5)
+    {
+        F32 k = 1.0f - std::max({getCurR(), getCurG(), getCurB()});
+        F32 c = (k == 1.0f) ? 0.0f : (1.0f - getCurR() - k) / (1.0f - k);
+        F32 m = (k == 1.0f) ? 0.0f : (1.0f - getCurG() - k) / (1.0f - k);
+        F32 y = (k == 1.0f) ? 0.0f : (1.0f - getCurB() - k) / (1.0f - k);
+        to_copy << "(";
+        to_copy << (S32)(c * 100.0f + 0.5f);
+        to_copy << "%, ";
+        to_copy << (S32)(m * 100.0f + 0.5f);
+        to_copy << "%, ";
+        to_copy << (S32)(y * 100.0f + 0.5f);
+        to_copy << "%, ";
+        to_copy << (S32)(k * 100.0f + 0.5f);
+        to_copy << "%";
+        to_copy << ")";
+    }
+
+    if (! to_copy.str().empty())
+    {
+        gViewerWindow->getWindow()->copyTextToClipboard(utf8str_to_wstring(to_copy.str()));
     }
 }

--- a/indra/newview/llfloatercolorpicker.h
+++ b/indra/newview/llfloatercolorpicker.h
@@ -37,6 +37,7 @@
 class LLButton;
 class LLLineEditor;
 class LLCheckBoxCtrl;
+class LLComboBox;
 
 //////////////////////////////////////////////////////////////////////////////
 // floater class
@@ -127,6 +128,10 @@ class LLFloaterColorPicker
         // mutators for color values, can raise event to preview changes at object
         void selectCurRgb ( F32 curRIn, F32 curGIn, F32 curBIn );
         void selectCurHsl ( F32 curHIn, F32 curSIn, F32 curLIn );
+
+        // utility functions for manipulating hex colors
+        bool isValidHexColor(std::string& hex_color, F32& hr, F32& hg, F32& hb);
+
         // draws color selection palette
         void drawPalette ();
 
@@ -191,6 +196,9 @@ class LLFloaterColorPicker
         LLButton* mCancelBtn;
 
         LLButton* mPipetteBtn;
+
+        LLComboBox* mCopyColorAsCombo;
+        void onCopyColor();
 
         F32       mContextConeOpacity;
         F32       mContextConeInAlpha;

--- a/indra/newview/skins/default/xui/en/floater_color_picker.xml
+++ b/indra/newview/skins/default/xui/en/floater_color_picker.xml
@@ -2,7 +2,7 @@
 <floater
  legacy_header_height="18"
  can_minimize="false"
- height="380"
+ height="460"
  layout="topleft"
  name="ColorPicker"
  help_topic="colorpicker"
@@ -153,6 +153,41 @@
      name="lspin"
      top_delta="0"
      width="50" />
+    <text
+     type="string"
+     length="1"
+     follows="left|top"
+     height="20"
+     layout="topleft"
+     top_pad="6"
+     left="10"
+     mouse_opaque="false"
+     name="hex_text"
+     width="413">
+        Hex:
+    </text>
+    <text
+     type="string"
+     length="1"
+     follows="left|top"
+     height="20"
+     layout="topleft"
+     left="60"
+     name="hash_text"
+     top_pad="-20"
+     width="20">
+        #
+    </text>
+    <line_editor
+     font="SansSerif"
+     max_length_bytes="16"
+     top_pad="-22"
+     follows="left"
+     height="20"
+     layout="topleft"
+     left_delta="13"
+     name="hex_color"
+     width="50" />
     <check_box
      follows="left|bottom"
      height="20"
@@ -160,7 +195,7 @@
      layout="topleft"
      left="10"
      name="apply_immediate"
-     top_pad="185"
+     top_pad="240"
      width="100" />
     <button
      follows="left|bottom"
@@ -168,19 +203,52 @@
      image_selected="eye_button_active.tga"
      image_unselected="eye_button_inactive.tga"
      layout="topleft"
-     left_pad="50"
+     left_pad="0"
      name="color_pipette"
      width="28" />
+    <combo_box
+     control_name="CopyColorDestination"
+     follows="right|bottom"
+     layout="topleft"
+     right="-197"
+     top_delta="8"
+     name="copy_color_combobox"
+     width="84">
+        <combo_box.item
+         label="Copy as..."
+         name="copy_as"
+         value="0" />
+        <combo_box.item
+         label="LSL"
+         name="lsl_color"
+         value="1" />
+        <combo_box.item
+         label="HEX"
+         name="hex_color"
+         value="2" />
+        <combo_box.item
+         label="RGB"
+         name="rgb_color"
+         value="3" />
+        <combo_box.item
+         label="HSL"
+         name="hsl_color"
+         value="4" />
+        <combo_box.item
+         label="CMYK"
+         name="cmyk_color"
+         value="5" />
+    </combo_box>
     <button
      follows="right|bottom"
      height="23"
      label="OK"
      label_selected="OK"
      layout="topleft"
-     right="-120"
-     top_delta="9"
+     right="-100"
+     top_delta="0"
      name="select_btn"
-     width="100" />
+     width="80" />
     <button
      follows="right|bottom"
      height="23"
@@ -190,7 +258,7 @@
      left_pad="5"
      right="-10"
      name="cancel_btn"
-     width="100" />
+     width="80" />
     <text
      type="string"
      length="1"
@@ -199,7 +267,7 @@
      layout="topleft"
      left="10"
      name="Current color:"
-     top="172"
+     top="194"
      width="110">
         Current color:
     </text>
@@ -211,7 +279,7 @@
      layout="topleft"
      left="10"
      name="(Drag below to save.)"
-     top_pad="66"
+     top_pad="62"
      width="130"
      wrap="true">
         (Drag below to save)


### PR DESCRIPTION
## Description

A request to tackle [this Canny](https://feedback.secondlife.com/feature-requests/p/please-give-us-more-colour-picker-save-spaces) came up in a recent Content Creators User Group and since creating the color picker was the first job I was given at Linden, I offered to help. This was back in early February and it languished in a private repo for far too long - I'll do better next time... 

The Viewer GitHub issue for this task is [here](https://github.com/secondlife/viewer/issues/5400).

## Changes
- Doubled the palette slots from 32 to 64
    - I experimented with adding more but making room by reducing the size of individual UI components makes it difficult to use and adding more slots makes the floater bigger. Moving to 64 vs 128/256 seemed like a good compromise.

- Added a hex color output / input (e.g. #AF4532)
    - Displays current color in uppercase hex
    - Allows you to paste a hex color from a different tool (strips off leading `#` and removes any whitespace)

- Added a "Copy As..." combo box
     - Allows you to copy the current color as:
         - LSL: <0.455, 0.321, 0.054>
         - HEX: #45FC12
         - RGB: (126, 34, 134)
         - HSL: (123°, 34%, 87%)
         - CMYK: (12%, 34%, 12%, 45%)
    - As a combo box, other formats can easily be added in the future - for example:
        - HEX lowercase: #45fc12
        - HSL unadorned: (123, 34, 87)
        - Dozens of other weird and wonderful color formats... let me know if you have a suggestion for one

## Out of scope
- Palette generator
    - A great idea but a lot of work - too much for this quick set of tweaks 
- Remove saving of colors.xml - save your colors online
    - Another great idea but we do not have an easy way to do this currently. Would likely be part of a unified plan to push all settings into the cloud.


## Testing
- First step is to run the current color picker test noting that there are some differences in widgets but that things should work as before (opening the floater, dragging colors, using the pipette in world, etc.)

- Confirm the existing functionality works as before with 64 slots vs 32
    - Selecting colors updates all the fields
    - Dragging a color from the swatch onto any of the palette slots works as before
    - Deleting colors.xml in the user_settings folder results in a standard set of colors in the palette and 32 grey unused entries afterwards

- Hex widget
    - Contains the correct hex representation of the current color
    - Updates like the RGB & HSL widgets when new colors are selected
    - Allows paste of a 6 digit valid hex color (no `#`) from a different tool (AB45CD)
    - Allows paste of a valid hex color with `#` symbol (#4512CE)
    - Allows paste of a valid hex color with whitespace (  12CEA5    )
    - Allows paste of a valid hex color with whitespace and `#` symbol (    #12CEA5    )
        - In all cases, the resulting entry in the hex field should represent the correct color 
    - Disallows paste of a 6 digit INVALID hex color from somewhere else (e.g. XYZ123)
    - Allows copy out of widget into a different tool
   
- Copy As... combo
    - Try each of the options and paste into a different tool or confirm visually in a text editor
    - See description above for expected formats
    - Confirm values at the limit exactly match the existing values in the input widgets
        - e.g. 255, 0, 0 in the RGB spinners should result in the right values for LSL <1.0, 0.0, 0.0> , RGB (255, 0, 0) etc.
    - Confirm random values exactly match the existing values in the input widgets
        - There is some rounding going on so confirm arbitrary values in the spinners match the copy/paste output. 
            - e.g. 123, 81, 45 in the spinners doesn't become RBB(122, 80, 45)
    - If any useful or common formats missing, suggest them - easy to add new ones

 
