### PR TITLE
fix: clarify restricted script editor permission message

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_live_lsleditor.xml
+++ b/indra/newview/skins/default/xui/en/floater_live_lsleditor.xml
@@ -15,7 +15,7 @@
   width="508">
   <floater.string
     name="not_allowed">
-    You can not view or edit this script, since it has been set as &quot;no copy&quot; or &quot;no modify&quot;. You need these permissions to view or edit a script.
+    You cannot view or edit this script. You do not have permission to copy or modify this script.
   </floater.string>
   <floater.string
     name="script_running">

--- a/indra/newview/skins/default/xui/en/panel_script_ed.xml
+++ b/indra/newview/skins/default/xui/en/panel_script_ed.xml
@@ -14,7 +14,7 @@
   </panel.string>
   <panel.string
     name="can_not_view">
-      You can not view or edit this script, since it has been set as &quot;no copy&quot; or &quot;no modify&quot;. You need these permissions to view or edit a script.
+      You cannot view or edit this script. You do not have permission to copy or modify this script.
   </panel.string>
   <panel.string
     name="public_objects_can_not_run">


### PR DESCRIPTION
## Description

Updates the restricted-script message so it explains the missing copy/modify permissions directly instead of saying the script was set as "no copy" or "no modify".

This keeps the existing permission checks unchanged and only clarifies the English UI strings used by the live LSL editor and script editor panel.

## Related Issue

Fixes #3430

## Validation

- `rg -q "You do not have permission to copy or modify this script" indra/newview/skins/default/xui/en/floater_live_lsleditor.xml indra/newview/skins/default/xui/en/panel_script_ed.xml && ! rg -q "has been set as.*no copy.*no modify" indra/newview/skins/default/xui/en/floater_live_lsleditor.xml indra/newview/skins/default/xui/en/panel_script_ed.xml`
- `xmllint --noout indra/newview/skins/default/xui/en/floater_live_lsleditor.xml indra/newview/skins/default/xui/en/panel_script_ed.xml`

## AI Assistance

AI assistance was used with OpenAI GPT-5 Codex. I reviewed the issue, limited the change to the relevant UI strings, and verified the XML and text checks above.
