### PR TITLE
Fix Win32 white flash on startup by handling WM_ERASEBKGND with black brush

### DIFF
--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -2437,7 +2437,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
         case WM_ERASEBKGND:
         {
             RECT client_rect;
-            if (GetClientRect(window_imp->mWindowHandle, &client_rect))
+            if (GetClientRect(h_wnd, &client_rect))
             {
                 FillRect((HDC)w_param, &client_rect, (HBRUSH)GetStockObject(BLACK_BRUSH));
             }

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -2434,6 +2434,15 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                 update_width, update_height));
             break;
         }
+        case WM_ERASEBKGND:
+        {
+            RECT client_rect;
+            if (GetClientRect(window_imp->mWindowHandle, &client_rect))
+            {
+                FillRect((HDC)w_param, &client_rect, (HBRUSH)GetStockObject(BLACK_BRUSH));
+            }
+            return 1;
+        }
         case WM_PARENTNOTIFY:
         {
             break;


### PR DESCRIPTION
## Summary

On Windows, after the startup message `Initializing texture cache...`, the viewer hides the splash screen and exposes the main viewer window. During that transition, the client area can be background-erased by Win32 before the first rendered frame is available, producing a visible white flash.

This PR adds a `WM_ERASEBKGND` handler in `LLWindowWin32::mainWindowProc` that fills the client area with a black brush and returns `1` (handled). Eliminates the brief white flash visible on Windows between window creation and the first OpenGL frame.

## File changes

`indra/llwindow/llwindowwin32.cpp` new case in the main window procedure:

```cpp
case WM_ERASEBKGND:
{
    RECT client_rect;
    if (GetClientRect(window_imp->mWindowHandle, &client_rect))
    {
        FillRect((HDC)w_param, &client_rect, (HBRUSH)GetStockObject(BLACK_BRUSH));
    }
    return 1;
}
```

## Why

The window class is registered with `hbrBackground = NULL` in normal (non-headless) operation. The `clearBg` argument plumbed down from `LLViewerWindow::initGLDefaults` is `gHeadlessClient`, which is `false` in any real session, so the `WHITE_BRUSH` branch at the registration site is never taken in production.

With `hbrBackground = NULL`, Windows sends `WM_ERASEBKGND` and `DefWindowProc` does nothing with it. The DWM compositor still needs to display the window before the first `SwapBuffers` call lands, and the uninitialized backing surface shows as white. Result: a one-frame white flash on startup.

Handling `WM_ERASEBKGND` ourselves fills the client area with black before DWM composites, so the gap between window appearing and first GL frame is filled with black instead of white.

The goal is not to eliminate every pixel drawn before the scene appears - that is not possible, the window must show something between `CreateWindowEx` and the first `SwapBuffers`. The goal is to make that "something" blend with what comes next, so the user does not perceive a flash. A flash is only visible because of contrast:

- Before: `white window -> dark GL scene` - high contrast, reads as a flash.
- After: `black window -> dark GL scene` - low contrast, reads as a normal window opening with content already in it.

The black also matches the GL clear color set at context creation (`glClearColor(0.0f, 0.0f, 0.0f, 0.f)` in `llwindowwin32.cpp:1807`), so the sequence `Windows erase (black) -> first glClear (black) -> scene frame` has no visible discontinuity at any step.

### Performance

`WM_ERASEBKGND` is not part of the per-frame path. The viewer renders via `SwapBuffers`, not `WM_PAINT`. The handler runs on window creation, OS-level window resize (dragging the edge, maximize/restore), and show-from-minimize. UI panel resizes inside the viewer are pure GL and do not generate this message. A single `FillRect` with a stock brush in those rare cases is not measurable.

## Alternative considered (Option B): always set `BLACK_BRUSH` at class registration

Replace the conditional brush in `RegisterClass` setup with an unconditional `BLACK_BRUSH`:

```cpp
wc.hbrBackground = (HBRUSH) GetStockObject(BLACK_BRUSH);
```

This would let `DefWindowProc` handle `WM_ERASEBKGND` itself with the black brush, removing the need for a message handler entirely.

### Why not chosen

- It changes registration-time behavior that has existed for a long time, and silently retires the `clearBg` argument that is still plumbed through `LLWindowManager::createWindow` and every platform window implementation (Mac, SDL2, headless). Touching that contract is broader than the bug requires.
- Option A is fully scoped to the Windows code path that actually produces the flash, leaves all other platforms and the `clearBg` plumbing untouched, and is trivially revertible.

## Testing

- Launch the viewer on Windows; confirm no white flash between window appearing and first rendered frame.
- Resize the window by dragging an edge.
- Minimize and restore the viewer window.

## Video
White flash

https://github.com/user-attachments/assets/762f9c21-26af-430a-9228-1abc7840975d

White flash removed

https://github.com/user-attachments/assets/13a3143a-96d2-4585-837f-871327873e53



