### PR TITLE
Fix inaccurate "no copy" wording on restricted-permission scripts

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_live_lsleditor.xml
+++ b/indra/newview/skins/default/xui/en/floater_live_lsleditor.xml
@@ -15,7 +15,7 @@
   width="508">
   <floater.string
     name="not_allowed">
-    You can not view or edit this script, since it has been set as &quot;no copy&quot; or &quot;no modify&quot;. You need these permissions to view or edit a script.
+    You can not view or edit this script, since it has been set with restricted permissions. You need copy and modify permissions to view or edit a script.
   </floater.string>
   <floater.string
     name="script_running">

--- a/indra/newview/skins/default/xui/en/panel_script_ed.xml
+++ b/indra/newview/skins/default/xui/en/panel_script_ed.xml
@@ -14,7 +14,7 @@
   </panel.string>
   <panel.string
     name="can_not_view">
-      You can not view or edit this script, since it has been set as &quot;no copy&quot; or &quot;no modify&quot;. You need these permissions to view or edit a script.
+      You can not view or edit this script, since it has been set with restricted permissions. You need copy and modify permissions to view or edit a script.
   </panel.string>
   <panel.string
     name="public_objects_can_not_run">


### PR DESCRIPTION
Fixes #3430.

The error shown when viewing a restricted-permission script said it was set to "no copy" or "no modify" even when the script is +copy, which is inaccurate. This updates the wording to "set with restricted permissions" (matching the phrasing Firestorm uses) and clarifies that copy and modify permissions are required, in both floater_live_lsleditor.xml (not_allowed) and panel_script_ed.xml (can_not_view).