### PR TITLE
#5905 Fix Win32 white flash on startup

### DIFF
--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -1804,10 +1804,10 @@ const   S32   max_format  = (S32)num_formats - 1;
     if (auto_show)
     {
         show();
-        glClearColor(0.0f, 0.0f, 0.0f, 0.f);
-        glClear(GL_COLOR_BUFFER_BIT);
-        swapBuffers();
     }
+    glClearColor(0.0f, 0.0f, 0.0f, 0.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    swapBuffers();
 
     return true;
 }


### PR DESCRIPTION
Clear gl buffer early to avoid 'white flash' on startup.