### PR TITLE
Update Dullahan to v1.31 with CEF 148.0.9 (Chromium-148.0.7778.180)

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" ?>
 <llsd>
 <map>
-    <key>version</key>
-    <string>1.3</string>
-    <key>type</key>
-    <string>autobuild</string>
     <key>installables</key>
     <map>
       <key>SDL</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (C) 1997-2012 Sam Lantinga</string>
+        <key>description</key>
+        <string>Simple DirectMedia Layer is a cross-platform multimedia library designed to provide low level access to audio, keyboard, mouse, joystick, 3D hardware via OpenGL, and 2D video framebuffer.</string>
+        <key>license</key>
+        <string>lgpl</string>
+        <key>license_file</key>
+        <string>LICENSES/SDL.txt</string>
+        <key>name</key>
+        <string>SDL</string>
         <key>platforms</key>
         <map>
           <key>linux64</key>
@@ -24,21 +30,21 @@
             <string>linux64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>lgpl</string>
-        <key>license_file</key>
-        <string>LICENSES/SDL.txt</string>
-        <key>copyright</key>
-        <string>Copyright (C) 1997-2012 Sam Lantinga</string>
         <key>version</key>
         <string>1.2.15</string>
-        <key>name</key>
-        <string>SDL</string>
-        <key>description</key>
-        <string>Simple DirectMedia Layer is a cross-platform multimedia library designed to provide low level access to audio, keyboard, mouse, joystick, 3D hardware via OpenGL, and 2D video framebuffer.</string>
       </map>
       <key>apr_suite</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright © 2012 The Apache Software Foundation, Licensed under the Apache License, Version 2.0.</string>
+        <key>description</key>
+        <string>Apache portable runtime project</string>
+        <key>license</key>
+        <string>apache</string>
+        <key>license_file</key>
+        <string>LICENSES/apr_suite.txt</string>
+        <key>name</key>
+        <string>apr_suite</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -84,21 +90,21 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>apache</string>
-        <key>license_file</key>
-        <string>LICENSES/apr_suite.txt</string>
-        <key>copyright</key>
-        <string>Copyright © 2012 The Apache Software Foundation, Licensed under the Apache License, Version 2.0.</string>
         <key>version</key>
         <string>1.7.5-18696779749</string>
-        <key>name</key>
-        <string>apr_suite</string>
-        <key>description</key>
-        <string>Apache portable runtime project</string>
       </map>
       <key>boost</key>
       <map>
+        <key>copyright</key>
+        <string>(see individual source files)</string>
+        <key>description</key>
+        <string>Boost C++ Libraries</string>
+        <key>license</key>
+        <string>boost 1.0</string>
+        <key>license_file</key>
+        <string>LICENSES/boost.txt</string>
+        <key>name</key>
+        <string>boost</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -144,21 +150,21 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>boost 1.0</string>
-        <key>license_file</key>
-        <string>LICENSES/boost.txt</string>
-        <key>copyright</key>
-        <string>(see individual source files)</string>
         <key>version</key>
         <string>1.90.0-c7a9feb</string>
-        <key>name</key>
-        <string>boost</string>
-        <key>description</key>
-        <string>Boost C++ Libraries</string>
       </map>
       <key>bugsplat</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright 2003-2017, BugSplat</string>
+        <key>description</key>
+        <string>Bugsplat crash reporting package</string>
+        <key>license</key>
+        <string>Proprietary</string>
+        <key>license_file</key>
+        <string>LICENSES/BUGSPLAT_LICENSE.txt</string>
+        <key>name</key>
+        <string>bugsplat</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -190,21 +196,19 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>Proprietary</string>
-        <key>license_file</key>
-        <string>LICENSES/BUGSPLAT_LICENSE.txt</string>
-        <key>copyright</key>
-        <string>Copyright 2003-2017, BugSplat</string>
         <key>version</key>
         <string>5.0.1.0-71fc41e</string>
-        <key>name</key>
-        <string>bugsplat</string>
-        <key>description</key>
-        <string>Bugsplat crash reporting package</string>
       </map>
       <key>colladadom</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright 2006 Sony Computer Entertainment Inc.</string>
+        <key>license</key>
+        <string>SCEA</string>
+        <key>license_file</key>
+        <string>LICENSES/collada.txt</string>
+        <key>name</key>
+        <string>colladadom</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -250,19 +254,19 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>SCEA</string>
-        <key>license_file</key>
-        <string>LICENSES/collada.txt</string>
-        <key>copyright</key>
-        <string>Copyright 2006 Sony Computer Entertainment Inc.</string>
         <key>version</key>
         <string>2.3.0-r11</string>
-        <key>name</key>
-        <string>colladadom</string>
       </map>
       <key>cubemaptoequirectangular</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2017 Jaume Sanchez Elias, http://www.clicktorelease.com</string>
+        <key>license</key>
+        <string>MIT</string>
+        <key>license_file</key>
+        <string>LICENSES/CUBEMAPTOEQUIRECTANGULAR_LICENSE.txt</string>
+        <key>name</key>
+        <string>cubemaptoequirectangular</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -308,19 +312,21 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>MIT</string>
-        <key>license_file</key>
-        <string>LICENSES/CUBEMAPTOEQUIRECTANGULAR_LICENSE.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2017 Jaume Sanchez Elias, http://www.clicktorelease.com</string>
         <key>version</key>
         <string>1.1.0</string>
-        <key>name</key>
-        <string>cubemaptoequirectangular</string>
       </map>
       <key>curl</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 1996 - 2014, Daniel Stenberg, (daniel@haxx.se).</string>
+        <key>description</key>
+        <string>Library for transferring data specified with URL syntax</string>
+        <key>license</key>
+        <string>curl</string>
+        <key>license_file</key>
+        <string>LICENSES/curl.txt</string>
+        <key>name</key>
+        <string>curl</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -366,21 +372,21 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>curl</string>
-        <key>license_file</key>
-        <string>LICENSES/curl.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 1996 - 2014, Daniel Stenberg, (daniel@haxx.se).</string>
         <key>version</key>
         <string>7.54.1-20982000504</string>
-        <key>name</key>
-        <string>curl</string>
-        <key>description</key>
-        <string>Library for transferring data specified with URL syntax</string>
       </map>
       <key>dbus_glib</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (C) Red Hat Inc.</string>
+        <key>description</key>
+        <string>D-Bus bindings for glib</string>
+        <key>license</key>
+        <string>Academic Free License v. 2.1</string>
+        <key>license_file</key>
+        <string>LICENSES/dbus-glib.txt</string>
+        <key>name</key>
+        <string>dbus_glib</string>
         <key>platforms</key>
         <map>
           <key>linux64</key>
@@ -396,21 +402,21 @@
             <string>linux64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>Academic Free License v. 2.1</string>
-        <key>license_file</key>
-        <string>LICENSES/dbus-glib.txt</string>
-        <key>copyright</key>
-        <string>Copyright (C) Red Hat Inc.</string>
         <key>version</key>
         <string>0.76</string>
-        <key>name</key>
-        <string>dbus_glib</string>
-        <key>description</key>
-        <string>D-Bus bindings for glib</string>
       </map>
       <key>dictionaries</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright 2014 Apache OpenOffice software</string>
+        <key>description</key>
+        <string>Spell checking dictionaries to bundled into the viewer</string>
+        <key>license</key>
+        <string>various open source</string>
+        <key>license_file</key>
+        <string>LICENSES/dictionaries.txt</string>
+        <key>name</key>
+        <string>dictionaries</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -428,21 +434,79 @@
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>various open source</string>
-        <key>license_file</key>
-        <string>LICENSES/dictionaries.txt</string>
-        <key>copyright</key>
-        <string>Copyright 2014 Apache OpenOffice software</string>
         <key>version</key>
         <string>1.a01bb6c</string>
-        <key>name</key>
-        <string>dictionaries</string>
+      </map>
+      <key>discord_sdk</key>
+      <map>
+        <key>canonical_repo</key>
+        <string>https://github.com/secondlife/3p-discord-sdk</string>
+        <key>copyright</key>
+        <string>Discord Inc.</string>
         <key>description</key>
-        <string>Spell checking dictionaries to bundled into the viewer</string>
+        <string>Discord Social SDK</string>
+        <key>license</key>
+        <string>discord_sdk</string>
+        <key>license_file</key>
+        <string>LICENSES/discord_sdk.txt</string>
+        <key>name</key>
+        <string>discord_sdk</string>
+        <key>platforms</key>
+        <map>
+          <key>darwin64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>creds</key>
+              <string>github</string>
+              <key>hash</key>
+              <string>dc21df8b051c425163acf3eff8f06e32f407c9e0</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://api.github.com/repos/secondlife/3p-discord-sdk/releases/assets/279333706</string>
+            </map>
+            <key>name</key>
+            <string>darwin64</string>
+          </map>
+          <key>windows64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>creds</key>
+              <string>github</string>
+              <key>hash</key>
+              <string>e11571bf76b27d15c244069988ae372eaa5afae9</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://api.github.com/repos/secondlife/3p-discord-sdk/releases/assets/279333720</string>
+            </map>
+            <key>name</key>
+            <string>windows64</string>
+          </map>
+        </map>
+        <key>vcs_branch</key>
+        <string>main</string>
+        <key>vcs_revision</key>
+        <string>ef5c7c4a490ceac2df2b2f046788b1daf1bbb392</string>
+        <key>vcs_url</key>
+        <string>https://github.com/secondlife/3p-discord-sdk</string>
+        <key>version</key>
+        <string>1.4.9649.16733550144</string>
       </map>
       <key>dullahan</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2017, Linden Research, Inc.</string>
+        <key>description</key>
+        <string>A headless browser SDK that uses the Chromium Embedded Framework (CEF). It is designed to make it easier to write applications that render modern web content directly to a memory buffer, inject synthesized mouse and keyboard events as well as interact with web based features like JavaScript or cookies.</string>
+        <key>license</key>
+        <string>MPL</string>
+        <key>license_file</key>
+        <string>LICENSES/LICENSE.txt</string>
+        <key>name</key>
+        <string>dullahan</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -450,11 +514,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>126e0fa4c16dfd433c9fb7d1d242da98f213d933</string>
+              <string>ed6a224b39df60f48021715802966226da2c04e2</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/dullahan/releases/download/v1.24.0-CEF_139.0.40/dullahan-1.24.0.202510081737_139.0.40_g465474a_chromium-139.0.7258.139-darwin64-18353103947.tar.zst</string>
+              <string>https://github.com/secondlife/dullahan/releases/download/v1.31.0-CEF_148.0.9/dullahan-1.31.0.202606101805_148.0.9_g0d9d52a_chromium-148.0.7778.180-darwin64-27295840708.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -478,31 +542,33 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>20de62c9e57d9e6539c1e2437ec4b46c3ca237bc</string>
+              <string>83400a65243657dbdb817d9056caaf15182b263b</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/dullahan/releases/download/v1.24.0-CEF_139.0.40/dullahan-1.24.0.202510081738_139.0.40_g465474a_chromium-139.0.7258.139-windows64-18353103947.tar.zst</string>
+              <string>https://github.com/secondlife/dullahan/releases/download/v1.31.0-CEF_148.0.9/dullahan-1.31.0.202606101805_148.0.9_g0d9d52a_chromium-148.0.7778.180-windows64-27295840708.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>MPL</string>
-        <key>license_file</key>
-        <string>LICENSES/LICENSE.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2017, Linden Research, Inc.</string>
         <key>version</key>
-        <string>1.24.0.202510081737_139.0.40_g465474a_chromium-139.0.7258.139</string>
-        <key>name</key>
-        <string>dullahan</string>
-        <key>description</key>
-        <string>A headless browser SDK that uses the Chromium Embedded Framework (CEF). It is designed to make it easier to write applications that render modern web content directly to a memory buffer, inject synthesized mouse and keyboard events as well as interact with web based features like JavaScript or cookies.</string>
+        <string>1.31.0.202606101805_148.0.9_g0d9d52a_chromium-148.0.7778.180</string>
       </map>
       <key>emoji_shortcodes</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://github.com/secondlife/3p-emoji-shortcodes</string>
+        <key>copyright</key>
+        <string>Copyright 2017-2019 Miles Johnson.</string>
+        <key>description</key>
+        <string>Emoji shortcodes</string>
+        <key>license</key>
+        <string>MIT</string>
+        <key>license_file</key>
+        <string>LICENSES/emojibase-license.txt</string>
+        <key>name</key>
+        <string>emoji_shortcodes</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -520,23 +586,21 @@
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>MIT</string>
-        <key>license_file</key>
-        <string>LICENSES/emojibase-license.txt</string>
-        <key>copyright</key>
-        <string>Copyright 2017-2019 Miles Johnson.</string>
         <key>version</key>
         <string>15.3.2.10207138275</string>
-        <key>name</key>
-        <string>emoji_shortcodes</string>
-        <key>canonical_repo</key>
-        <string>https://github.com/secondlife/3p-emoji-shortcodes</string>
-        <key>description</key>
-        <string>Emoji shortcodes</string>
       </map>
       <key>expat</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 1998-2000 Thai Open Source Software Center Ltd and Clark Cooper - Copyright (c) 2001-2022 Expat maintainers.</string>
+        <key>description</key>
+        <string>Expat is an XML parser library written in C</string>
+        <key>license</key>
+        <string>expat</string>
+        <key>license_file</key>
+        <string>LICENSES/expat.txt</string>
+        <key>name</key>
+        <string>expat</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -582,21 +646,21 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>expat</string>
-        <key>license_file</key>
-        <string>LICENSES/expat.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 1998-2000 Thai Open Source Software Center Ltd and Clark Cooper - Copyright (c) 2001-2022 Expat maintainers.</string>
         <key>version</key>
         <string>2.6.4-r1</string>
-        <key>name</key>
-        <string>expat</string>
-        <key>description</key>
-        <string>Expat is an XML parser library written in C</string>
       </map>
       <key>fontconfig</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (C) 2000,2001,2002,2003,2004,2006,2007 Keith Packard, 2005 Patrick Lam, 2009 Roozbeh Pournader, 2008,2009 Red Hat, Inc., 2008 Danilo Šegan, 2012 Google, Inc.</string>
+        <key>description</key>
+        <string>Fontconfig is a library for configuring and customizing font access.</string>
+        <key>license</key>
+        <string>bsd</string>
+        <key>license_file</key>
+        <string>LICENSES/fontconfig.txt</string>
+        <key>name</key>
+        <string>fontconfig</string>
         <key>platforms</key>
         <map>
           <key>linux64</key>
@@ -612,21 +676,21 @@
             <string>linux64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>bsd</string>
-        <key>license_file</key>
-        <string>LICENSES/fontconfig.txt</string>
-        <key>copyright</key>
-        <string>Copyright (C) 2000,2001,2002,2003,2004,2006,2007 Keith Packard, 2005 Patrick Lam, 2009 Roozbeh Pournader, 2008,2009 Red Hat, Inc., 2008 Danilo Šegan, 2012 Google, Inc.</string>
         <key>version</key>
         <string>2.11.0</string>
-        <key>name</key>
-        <string>fontconfig</string>
-        <key>description</key>
-        <string>Fontconfig is a library for configuring and customizing font access.</string>
       </map>
       <key>freetype</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright 2006, 2007, 2008, 2009, 2010 by David Turner, Robert Wilhelm, and Werner Lemberg.</string>
+        <key>description</key>
+        <string>Font rendering library</string>
+        <key>license</key>
+        <string>FreeType</string>
+        <key>license_file</key>
+        <string>LICENSES/freetype.txt</string>
+        <key>name</key>
+        <string>freetype</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -672,21 +736,21 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>FreeType</string>
-        <key>license_file</key>
-        <string>LICENSES/freetype.txt</string>
-        <key>copyright</key>
-        <string>Copyright 2006, 2007, 2008, 2009, 2010 by David Turner, Robert Wilhelm, and Werner Lemberg.</string>
         <key>version</key>
         <string>2.13.3-r4</string>
-        <key>name</key>
-        <string>freetype</string>
-        <key>description</key>
-        <string>Font rendering library</string>
       </map>
       <key>glext</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2007-2010 The Khronos Group Inc.</string>
+        <key>description</key>
+        <string>glext headers define function prototypes and constants for OpenGL extensions</string>
+        <key>license</key>
+        <string>Copyright (c) 2007-2010 The Khronos Group Inc.</string>
+        <key>license_file</key>
+        <string>LICENSES/glext.txt</string>
+        <key>name</key>
+        <string>glext</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -704,21 +768,21 @@
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>Copyright (c) 2007-2010 The Khronos Group Inc.</string>
-        <key>license_file</key>
-        <string>LICENSES/glext.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2007-2010 The Khronos Group Inc.</string>
         <key>version</key>
         <string>68</string>
-        <key>name</key>
-        <string>glext</string>
-        <key>description</key>
-        <string>glext headers define function prototypes and constants for OpenGL extensions</string>
       </map>
       <key>glh_linear</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2000 Cass Everitt</string>
+        <key>description</key>
+        <string>glh - is a platform-indepenedent C++ OpenGL helper library</string>
+        <key>license</key>
+        <string>BSD</string>
+        <key>license_file</key>
+        <string>LICENSES/glh-linear.txt</string>
+        <key>name</key>
+        <string>glh_linear</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -736,21 +800,23 @@
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>BSD</string>
-        <key>license_file</key>
-        <string>LICENSES/glh-linear.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2000 Cass Everitt</string>
         <key>version</key>
         <string>1.0.1-dev4</string>
-        <key>name</key>
-        <string>glh_linear</string>
-        <key>description</key>
-        <string>glh - is a platform-indepenedent C++ OpenGL helper library</string>
       </map>
       <key>glm</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://github.com/secondlife/3p-glm</string>
+        <key>copyright</key>
+        <string>Copyright (c) 2005 - G-Truc Creation</string>
+        <key>description</key>
+        <string>OpenGL Mathematics</string>
+        <key>license</key>
+        <string>MIT</string>
+        <key>license_file</key>
+        <string>LICENSES/glm_license.txt</string>
+        <key>name</key>
+        <string>glm</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -768,31 +834,59 @@
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>MIT</string>
-        <key>license_file</key>
-        <string>LICENSES/glm_license.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2005 - G-Truc Creation</string>
-        <key>version</key>
-        <string>v1.0.1</string>
-        <key>name</key>
-        <string>glm</string>
+        <key>source_type</key>
+        <string>git</string>
         <key>vcs_branch</key>
         <string>refs/tags/v1.0.1-r1</string>
         <key>vcs_revision</key>
         <string>399cd5ba57a9267a560ce07e50a0f8c5fe3dc66f</string>
         <key>vcs_url</key>
         <string>git://github.com/secondlife/3p-glm.git</string>
-        <key>canonical_repo</key>
-        <string>https://github.com/secondlife/3p-glm</string>
+        <key>version</key>
+        <string>v1.0.1</string>
+      </map>
+      <key>google-fonts</key>
+      <map>
+        <key>copyright</key>
+        <string>Copyright 2020 The Inter Project Authors (https://github.com/rsms/inter)</string>
         <key>description</key>
-        <string>OpenGL Mathematics</string>
-        <key>source_type</key>
-        <string>git</string>
+        <string>Google fonts</string>
+        <key>license</key>
+        <string>SIL Open Font License, Version 1.1</string>
+        <key>license_file</key>
+        <string>LICENSES/google_inter.txt</string>
+        <key>name</key>
+        <string>google-fonts</string>
+        <key>platforms</key>
+        <map>
+          <key>common</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>8de96fd083783b9f4df1d8d7028c8a713a7d7217</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife/3p-google-fonts/releases/download/v1.0.0-r6/google_fonts-1.0.0.24469773244-common-24469773244.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>common</string>
+          </map>
+        </map>
+        <key>version</key>
+        <string>1.0.0.22606339007</string>
       </map>
       <key>gstreamer</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (C) 2007 Free Software Foundation, Inc. &lt;http://fsf.org/&gt;</string>
+        <key>license</key>
+        <string>LGPL</string>
+        <key>license_file</key>
+        <string>LICENSES/gstreamer.txt</string>
+        <key>name</key>
+        <string>gstreamer</string>
         <key>platforms</key>
         <map>
           <key>linux64</key>
@@ -808,19 +902,19 @@
             <string>linux64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>LGPL</string>
-        <key>license_file</key>
-        <string>LICENSES/gstreamer.txt</string>
-        <key>copyright</key>
-        <string>Copyright (C) 2007 Free Software Foundation, Inc. &lt;http://fsf.org/&gt;</string>
         <key>version</key>
         <string>0.10.6.314267</string>
-        <key>name</key>
-        <string>gstreamer</string>
       </map>
       <key>gtk-atk-pango-glib</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (various, see sources)</string>
+        <key>license</key>
+        <string>lgpl</string>
+        <key>license_file</key>
+        <string>LICENSES/gtk-atk-pango-glib.txt</string>
+        <key>name</key>
+        <string>gtk-atk-pango-glib</string>
         <key>platforms</key>
         <map>
           <key>linux64</key>
@@ -836,19 +930,21 @@
             <string>linux64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>lgpl</string>
-        <key>license_file</key>
-        <string>LICENSES/gtk-atk-pango-glib.txt</string>
-        <key>copyright</key>
-        <string>Copyright (various, see sources)</string>
         <key>version</key>
         <string>0.1</string>
-        <key>name</key>
-        <string>gtk-atk-pango-glib</string>
       </map>
       <key>havok-source</key>
       <map>
+        <key>copyright</key>
+        <string>Uses Havok (TM) Physics. (c)Copyright 1999-2010 Havok.com Inc. (and its Licensors). All Rights Reserved. See www.havok.com for details.</string>
+        <key>description</key>
+        <string>Havok source code for libs and demos</string>
+        <key>license</key>
+        <string>havok</string>
+        <key>license_file</key>
+        <string>LICENSES/havok.txt</string>
+        <key>name</key>
+        <string>havok-source</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -896,21 +992,19 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>havok</string>
-        <key>license_file</key>
-        <string>LICENSES/havok.txt</string>
-        <key>copyright</key>
-        <string>Uses Havok (TM) Physics. (c)Copyright 1999-2010 Havok.com Inc. (and its Licensors). All Rights Reserved. See www.havok.com for details.</string>
         <key>version</key>
         <string>2012.1-2</string>
-        <key>name</key>
-        <string>havok-source</string>
-        <key>description</key>
-        <string>Havok source code for libs and demos</string>
       </map>
       <key>jpegencoderbasic</key>
       <map>
+        <key>copyright</key>
+        <string>Andreas Ritter, www.bytestrom.eu, 11/2009</string>
+        <key>license</key>
+        <string>NONE</string>
+        <key>license_file</key>
+        <string>LICENSES/JPEG_ENCODER_BASIC_LICENSE.txt</string>
+        <key>name</key>
+        <string>jpegencoderbasic</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -956,81 +1050,21 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>NONE</string>
-        <key>license_file</key>
-        <string>LICENSES/JPEG_ENCODER_BASIC_LICENSE.txt</string>
-        <key>copyright</key>
-        <string>Andreas Ritter, www.bytestrom.eu, 11/2009</string>
         <key>version</key>
         <string>1.0</string>
-        <key>name</key>
-        <string>jpegencoderbasic</string>
-      </map>
-      <key>libjpeg-turbo</key>
-      <map>
-        <key>platforms</key>
-        <map>
-          <key>windows64</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>10f14875ce5c7f5028217c8b7468733190fd333d</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://github.com/secondlife/3p-libjpeg-turbo/releases/download/v3.0.4-r1/libjpeg_turbo-3.0.4-r1-windows64-11968659895.tar.zst</string>
-            </map>
-            <key>name</key>
-            <string>windows64</string>
-          </map>
-          <key>linux64</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>d3b1b0fde28c8cf0c33fed167dba87bba5c6cc64</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://github.com/secondlife/3p-libjpeg-turbo/releases/download/v3.0.4-r1/libjpeg_turbo-3.0.4-r1-linux64-11968659895.tar.zst</string>
-            </map>
-            <key>name</key>
-            <string>linux64</string>
-          </map>
-          <key>darwin64</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>79e78cbaaec9a99c0ae4a5cdd4a98535c8fa3c6d</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://github.com/secondlife/3p-libjpeg-turbo/releases/download/v3.0.4-r1/libjpeg_turbo-3.0.4-r1-darwin64-11968659895.tar.zst</string>
-            </map>
-            <key>name</key>
-            <string>darwin64</string>
-          </map>
-        </map>
-        <key>license</key>
-        <string>libjpeg-turbo</string>
-        <key>license_file</key>
-        <string>LICENSES/libjpeg-turbo.txt</string>
-        <key>copyright</key>
-        <string>Copyright (C)2009-2024 D. R. Commander. All Rights Reserved. Copyright (C)2015 Viktor Szathmáry. All Rights Reserved.</string>
-        <key>version</key>
-        <string>3.0.4-r1</string>
-        <key>name</key>
-        <string>libjpeg-turbo</string>
-        <key>canonical_repo</key>
-        <string>https://github.com/secondlife/3p-libjpeg-turbo</string>
-        <key>description</key>
-        <string>JPEG encoding, decoding library</string>
       </map>
       <key>kdu</key>
       <map>
+        <key>copyright</key>
+        <string>Kakadu software</string>
+        <key>description</key>
+        <string>JPEG2000 library by Kakadu</string>
+        <key>license</key>
+        <string>Kakadu</string>
+        <key>license_file</key>
+        <string>LICENSES/kdu.txt</string>
+        <key>name</key>
+        <string>kdu</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1048,6 +1082,22 @@
             </map>
             <key>name</key>
             <string>darwin64</string>
+          </map>
+          <key>linux</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>creds</key>
+              <string>github</string>
+              <key>hash</key>
+              <string>85e294becce8b2ac5d2e5e052b0e21ff865d1108</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://api.github.com/repos/secondlife/3p-kdu/releases/assets/208381806</string>
+            </map>
+            <key>name</key>
+            <string>linux</string>
           </map>
           <key>linux64</key>
           <map>
@@ -1081,38 +1131,22 @@
             <key>name</key>
             <string>windows64</string>
           </map>
-          <key>linux</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>creds</key>
-              <string>github</string>
-              <key>hash</key>
-              <string>85e294becce8b2ac5d2e5e052b0e21ff865d1108</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-kdu/releases/assets/208381806</string>
-            </map>
-            <key>name</key>
-            <string>linux</string>
-          </map>
         </map>
-        <key>license</key>
-        <string>Kakadu</string>
-        <key>license_file</key>
-        <string>LICENSES/kdu.txt</string>
-        <key>copyright</key>
-        <string>Kakadu software</string>
         <key>version</key>
         <string>8.4.1.11976899217</string>
-        <key>name</key>
-        <string>kdu</string>
-        <key>description</key>
-        <string>JPEG2000 library by Kakadu</string>
       </map>
       <key>libhunspell</key>
       <map>
+        <key>copyright</key>
+        <string>LGPL 2.1</string>
+        <key>description</key>
+        <string>Spell checking library</string>
+        <key>license</key>
+        <string>LGPL</string>
+        <key>license_file</key>
+        <string>LICENSES/hunspell.txt</string>
+        <key>name</key>
+        <string>libhunspell</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1158,21 +1192,83 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>LGPL</string>
-        <key>license_file</key>
-        <string>LICENSES/hunspell.txt</string>
-        <key>copyright</key>
-        <string>LGPL 2.1</string>
         <key>version</key>
         <string>1.7.2.11968900321</string>
-        <key>name</key>
-        <string>libhunspell</string>
+      </map>
+      <key>libjpeg-turbo</key>
+      <map>
+        <key>canonical_repo</key>
+        <string>https://github.com/secondlife/3p-libjpeg-turbo</string>
+        <key>copyright</key>
+        <string>Copyright (C)2009-2024 D. R. Commander. All Rights Reserved. Copyright (C)2015 Viktor Szathmáry. All Rights Reserved.</string>
         <key>description</key>
-        <string>Spell checking library</string>
+        <string>JPEG encoding, decoding library</string>
+        <key>license</key>
+        <string>libjpeg-turbo</string>
+        <key>license_file</key>
+        <string>LICENSES/libjpeg-turbo.txt</string>
+        <key>name</key>
+        <string>libjpeg-turbo</string>
+        <key>platforms</key>
+        <map>
+          <key>darwin64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>79e78cbaaec9a99c0ae4a5cdd4a98535c8fa3c6d</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife/3p-libjpeg-turbo/releases/download/v3.0.4-r1/libjpeg_turbo-3.0.4-r1-darwin64-11968659895.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>darwin64</string>
+          </map>
+          <key>linux64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>d3b1b0fde28c8cf0c33fed167dba87bba5c6cc64</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife/3p-libjpeg-turbo/releases/download/v3.0.4-r1/libjpeg_turbo-3.0.4-r1-linux64-11968659895.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>linux64</string>
+          </map>
+          <key>windows64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>10f14875ce5c7f5028217c8b7468733190fd333d</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife/3p-libjpeg-turbo/releases/download/v3.0.4-r1/libjpeg_turbo-3.0.4-r1-windows64-11968659895.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>windows64</string>
+          </map>
+        </map>
+        <key>version</key>
+        <string>3.0.4-r1</string>
       </map>
       <key>libndofdev</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2007, 3Dconnexion, Inc. - All rights reserved.</string>
+        <key>description</key>
+        <string>3DConnexion SDK</string>
+        <key>license</key>
+        <string>BSD</string>
+        <key>license_file</key>
+        <string>LICENSES/libndofdev.txt</string>
+        <key>name</key>
+        <string>libndofdev</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1204,21 +1300,21 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>BSD</string>
-        <key>license_file</key>
-        <string>LICENSES/libndofdev.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2007, 3Dconnexion, Inc. - All rights reserved.</string>
         <key>version</key>
         <string>0.1.11968678219</string>
-        <key>name</key>
-        <string>libndofdev</string>
-        <key>description</key>
-        <string>3DConnexion SDK</string>
       </map>
       <key>libpng</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2004, 2006-2013 Glenn Randers-Pehrson</string>
+        <key>description</key>
+        <string>PNG Reference library</string>
+        <key>license</key>
+        <string>libpng</string>
+        <key>license_file</key>
+        <string>LICENSES/libpng.txt</string>
+        <key>name</key>
+        <string>libpng</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1264,21 +1360,21 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>libpng</string>
-        <key>license_file</key>
-        <string>LICENSES/libpng.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2004, 2006-2013 Glenn Randers-Pehrson</string>
         <key>version</key>
         <string>1.6.53-eea12b7</string>
-        <key>name</key>
-        <string>libpng</string>
-        <key>description</key>
-        <string>PNG Reference library</string>
       </map>
       <key>libuuid</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2004-2008 The OSSP Project &lt;http://www.ossp.org/&gt;</string>
+        <key>description</key>
+        <string>OSSP uuid is a ISO-C:1999 application programming interface (API) and corresponding command line interface (CLI) for the generation of DCE 1.1, ISO/IEC 11578:1996 and RFC 4122 compliant Universally Unique Identifier (UUID). </string>
+        <key>license</key>
+        <string>UUID</string>
+        <key>license_file</key>
+        <string>LICENSES/uuid.txt</string>
+        <key>name</key>
+        <string>libuuid</string>
         <key>platforms</key>
         <map>
           <key>linux64</key>
@@ -1294,21 +1390,21 @@
             <string>linux64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>UUID</string>
-        <key>license_file</key>
-        <string>LICENSES/uuid.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2004-2008 The OSSP Project &lt;http://www.ossp.org/&gt;</string>
         <key>version</key>
         <string>1.6.2</string>
-        <key>name</key>
-        <string>libuuid</string>
-        <key>description</key>
-        <string>OSSP uuid is a ISO-C:1999 application programming interface (API) and corresponding command line interface (CLI) for the generation of DCE 1.1, ISO/IEC 11578:1996 and RFC 4122 compliant Universally Unique Identifier (UUID). </string>
       </map>
       <key>libxml2</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (C) 1998-2012 Daniel Veillard.  All Rights Reserved.</string>
+        <key>description</key>
+        <string>Libxml2 is the XML C parser and toolkit developed for the Gnome project.</string>
+        <key>license</key>
+        <string>mit</string>
+        <key>license_file</key>
+        <string>LICENSES/libxml2.txt</string>
+        <key>name</key>
+        <string>libxml2</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1354,21 +1450,21 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>mit</string>
-        <key>license_file</key>
-        <string>LICENSES/libxml2.txt</string>
-        <key>copyright</key>
-        <string>Copyright (C) 1998-2012 Daniel Veillard.  All Rights Reserved.</string>
         <key>version</key>
         <string>2.13.9-d53cd6f</string>
-        <key>name</key>
-        <string>libxml2</string>
-        <key>description</key>
-        <string>Libxml2 is the XML C parser and toolkit developed for the Gnome project.</string>
       </map>
       <key>llappearance_utility</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2000-2012, Linden Research, Inc.</string>
+        <key>description</key>
+        <string>Linden Lab appearance utility for server-side avatar baking services.</string>
+        <key>license</key>
+        <string>Proprietary</string>
+        <key>license_file</key>
+        <string>LICENSES/llappearanceutility.txt</string>
+        <key>name</key>
+        <string>llappearance_utility</string>
         <key>platforms</key>
         <map>
           <key>linux</key>
@@ -1384,21 +1480,20 @@
             <string>linux</string>
           </map>
         </map>
-        <key>license</key>
-        <string>Proprietary</string>
-        <key>license_file</key>
-        <string>LICENSES/llappearanceutility.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2000-2012, Linden Research, Inc.</string>
         <key>version</key>
         <string>0.0.1</string>
-        <key>name</key>
-        <string>llappearance_utility</string>
-        <key>description</key>
-        <string>Linden Lab appearance utility for server-side avatar baking services.</string>
       </map>
       <key>llca</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2016, Linden Research, Inc.; data provided by the Mozilla NSS Project.
+      </string>
+        <key>license</key>
+        <string>mit</string>
+        <key>license_file</key>
+        <string>LICENSES/ca-license.txt</string>
+        <key>name</key>
+        <string>llca</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -1416,20 +1511,19 @@
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>mit</string>
-        <key>license_file</key>
-        <string>LICENSES/ca-license.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2016, Linden Research, Inc.; data provided by the Mozilla NSS Project.
-      </string>
         <key>version</key>
         <string>202407221423.0</string>
-        <key>name</key>
-        <string>llca</string>
       </map>
       <key>llphysicsextensions_source</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2010, Linden Research, Inc.</string>
+        <key>license</key>
+        <string>internal</string>
+        <key>license_file</key>
+        <string>LICENSES/llphysicsextensions.txt</string>
+        <key>name</key>
+        <string>llphysicsextensions_source</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -1449,19 +1543,19 @@
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>internal</string>
-        <key>license_file</key>
-        <string>LICENSES/llphysicsextensions.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2010, Linden Research, Inc.</string>
         <key>version</key>
         <string>1.0.11137145495</string>
-        <key>name</key>
-        <string>llphysicsextensions_source</string>
       </map>
       <key>llphysicsextensions_tpv</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2010, Linden Research, Inc.</string>
+        <key>license</key>
+        <string>internal</string>
+        <key>license_file</key>
+        <string>LICENSES/HavokSublicense.pdf</string>
+        <key>name</key>
+        <string>llphysicsextensions_tpv</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1501,19 +1595,17 @@
             <string>windows</string>
           </map>
         </map>
-        <key>license</key>
-        <string>internal</string>
-        <key>license_file</key>
-        <string>LICENSES/HavokSublicense.pdf</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2010, Linden Research, Inc.</string>
         <key>version</key>
         <string>1.0.561752</string>
-        <key>name</key>
-        <string>llphysicsextensions_tpv</string>
       </map>
       <key>mesa</key>
       <map>
+        <key>license</key>
+        <string>mesa</string>
+        <key>license_file</key>
+        <string>LICENSES/mesa.txt</string>
+        <key>name</key>
+        <string>mesa</string>
         <key>platforms</key>
         <map>
           <key>linux</key>
@@ -1529,17 +1621,23 @@
             <string>linux</string>
           </map>
         </map>
-        <key>license</key>
-        <string>mesa</string>
-        <key>license_file</key>
-        <string>LICENSES/mesa.txt</string>
         <key>version</key>
         <string>7.11.1.297294</string>
-        <key>name</key>
-        <string>mesa</string>
       </map>
       <key>meshoptimizer</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://bitbucket.org/lindenlab/3p-meshoptimizer</string>
+        <key>copyright</key>
+        <string>Copyright (c) 2016-2021 Arseny Kapoulkine</string>
+        <key>description</key>
+        <string>Meshoptimizer. Mesh optimization library.</string>
+        <key>license</key>
+        <string>meshoptimizer</string>
+        <key>license_file</key>
+        <string>LICENSES/meshoptimizer.txt</string>
+        <key>name</key>
+        <string>meshoptimizer</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1585,23 +1683,23 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>meshoptimizer</string>
-        <key>license_file</key>
-        <string>LICENSES/meshoptimizer.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2016-2021 Arseny Kapoulkine</string>
         <key>version</key>
         <string>220.0.0-r1</string>
-        <key>name</key>
-        <string>meshoptimizer</string>
-        <key>canonical_repo</key>
-        <string>https://bitbucket.org/lindenlab/3p-meshoptimizer</string>
-        <key>description</key>
-        <string>Meshoptimizer. Mesh optimization library.</string>
       </map>
       <key>mikktspace</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://bitbucket.org/lindenlab/3p-mikktspace</string>
+        <key>copyright</key>
+        <string>Copyright (C) 2011 by Morten S. Mikkelsen, Copyright (C) 2022 Blender Authors</string>
+        <key>description</key>
+        <string>Mikktspace Tangent Generator</string>
+        <key>license</key>
+        <string>Apache 2.0</string>
+        <key>license_file</key>
+        <string>mikktspace.txt</string>
+        <key>name</key>
+        <string>mikktspace</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1647,23 +1745,23 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>Apache 2.0</string>
-        <key>license_file</key>
-        <string>mikktspace.txt</string>
-        <key>copyright</key>
-        <string>Copyright (C) 2011 by Morten S. Mikkelsen, Copyright (C) 2022 Blender Authors</string>
         <key>version</key>
         <string>1</string>
-        <key>name</key>
-        <string>mikktspace</string>
-        <key>canonical_repo</key>
-        <string>https://bitbucket.org/lindenlab/3p-mikktspace</string>
-        <key>description</key>
-        <string>Mikktspace Tangent Generator</string>
       </map>
       <key>minizip-ng</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://bitbucket.org/lindenlab/3p-minizip-ng</string>
+        <key>copyright</key>
+        <string>This project uses the zlib license. Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler</string>
+        <key>description</key>
+        <string>minizip-ng is a zip manipulation library. Based on work of Gilles Vollant.</string>
+        <key>license</key>
+        <string>minizip-ng</string>
+        <key>license_file</key>
+        <string>LICENSES/minizip-ng.txt</string>
+        <key>name</key>
+        <string>minizip-ng</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1709,23 +1807,23 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>minizip-ng</string>
-        <key>license_file</key>
-        <string>LICENSES/minizip-ng.txt</string>
-        <key>copyright</key>
-        <string>This project uses the zlib license. Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler</string>
         <key>version</key>
         <string>4.0.7-r4</string>
-        <key>name</key>
-        <string>minizip-ng</string>
-        <key>canonical_repo</key>
-        <string>https://bitbucket.org/lindenlab/3p-minizip-ng</string>
-        <key>description</key>
-        <string>minizip-ng is a zip manipulation library. Based on work of Gilles Vollant.</string>
       </map>
       <key>nanosvg</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://bitbucket.org/lindenlab/3p-nanosvg</string>
+        <key>copyright</key>
+        <string>Copyright (c) 2013-14 Mikko Mononen</string>
+        <key>description</key>
+        <string>NanoSVG is a simple single-header-file SVG parser and rasterizer</string>
+        <key>license</key>
+        <string>Zlib</string>
+        <key>license_file</key>
+        <string>LICENSES/nanosvg.txt</string>
+        <key>name</key>
+        <string>nanosvg</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1765,23 +1863,22 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>Zlib</string>
-        <key>license_file</key>
-        <string>LICENSES/nanosvg.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2013-14 Mikko Mononen</string>
         <key>version</key>
         <string>2022.09.27</string>
-        <key>name</key>
-        <string>nanosvg</string>
-        <key>canonical_repo</key>
-        <string>https://bitbucket.org/lindenlab/3p-nanosvg</string>
-        <key>description</key>
-        <string>NanoSVG is a simple single-header-file SVG parser and rasterizer</string>
       </map>
       <key>nghttp2</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2012, 2014, 2015, 2016 Tatsuhiro Tsujikawa
+Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
+        <key>description</key>
+        <string>Library providing HTTP 2 support for libcurl</string>
+        <key>license</key>
+        <string>MIT</string>
+        <key>license_file</key>
+        <string>LICENSES/nghttp2.txt</string>
+        <key>name</key>
+        <string>nghttp2</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1827,24 +1924,23 @@
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>MIT</string>
-        <key>license_file</key>
-        <string>LICENSES/nghttp2.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2012, 2014, 2015, 2016 Tatsuhiro Tsujikawa
-Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
-        <key>version</key>
-        <string>1.64.0-r1</string>
-        <key>name</key>
-        <string>nghttp2</string>
-        <key>description</key>
-        <string>Library providing HTTP 2 support for libcurl</string>
         <key>source_type</key>
         <string>hg</string>
+        <key>version</key>
+        <string>1.64.0-r1</string>
       </map>
       <key>nvapi</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2024 NVIDIA CORPORATION and AFFILIATES. All rights reserved.</string>
+        <key>description</key>
+        <string>NVAPI provides an interface to NVIDIA devices.</string>
+        <key>license</key>
+        <string>MIT</string>
+        <key>license_file</key>
+        <string>LICENSES/nvapi.txt</string>
+        <key>name</key>
+        <string>nvapi</string>
         <key>platforms</key>
         <map>
           <key>windows64</key>
@@ -1862,21 +1958,21 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>MIT</string>
-        <key>license_file</key>
-        <string>LICENSES/nvapi.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2024 NVIDIA CORPORATION and AFFILIATES. All rights reserved.</string>
         <key>version</key>
         <string>560.0.0-r1</string>
-        <key>name</key>
-        <string>nvapi</string>
-        <key>description</key>
-        <string>NVAPI provides an interface to NVIDIA devices.</string>
       </map>
       <key>ogg_vorbis</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2002, Xiph.org Foundation</string>
+        <key>description</key>
+        <string>Audio encoding library</string>
+        <key>license</key>
+        <string>ogg-vorbis</string>
+        <key>license_file</key>
+        <string>LICENSES/ogg-vorbis.txt</string>
+        <key>name</key>
+        <string>ogg_vorbis</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1922,36 +2018,36 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>ogg-vorbis</string>
-        <key>license_file</key>
-        <string>LICENSES/ogg-vorbis.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2002, Xiph.org Foundation</string>
         <key>version</key>
         <string>1.3.5-1.3.7.11968798109</string>
-        <key>name</key>
-        <string>ogg_vorbis</string>
-        <key>description</key>
-        <string>Audio encoding library</string>
       </map>
       <key>open-libndofdev</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2008, Jan Ciger (jan.ciger (at) gmail.com)</string>
+        <key>description</key>
+        <string>Open Source replacement for 3DConnection SDK</string>
         <key>license</key>
         <string>BSD</string>
         <key>license_file</key>
         <string>LICENSES/libndofdev.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2008, Jan Ciger (jan.ciger (at) gmail.com)</string>
-        <key>version</key>
-        <string>0.14.11968684513</string>
         <key>name</key>
         <string>open-libndofdev</string>
-        <key>description</key>
-        <string>Open Source replacement for 3DConnection SDK</string>
+        <key>version</key>
+        <string>0.14.11968684513</string>
       </map>
       <key>openal</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (C) 1999-2007 by authors.</string>
+        <key>description</key>
+        <string>OpenAL Soft is a software implementation of the OpenAL 3D audio API.</string>
+        <key>license</key>
+        <string>LGPL2</string>
+        <key>license_file</key>
+        <string>LICENSES/openal-soft.txt</string>
+        <key>name</key>
+        <string>openal</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1997,21 +2093,21 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>LGPL2</string>
-        <key>license_file</key>
-        <string>LICENSES/openal-soft.txt</string>
-        <key>copyright</key>
-        <string>Copyright (C) 1999-2007 by authors.</string>
         <key>version</key>
         <string>1.24.2-r1</string>
-        <key>name</key>
-        <string>openal</string>
-        <key>description</key>
-        <string>OpenAL Soft is a software implementation of the OpenAL 3D audio API.</string>
       </map>
       <key>openjpeg</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2002-2007, Communications and Remote Sensing Laboratory, Universite catholique de Louvain (UCL), Belgium; Copyright (c) 2002-2007, Professor Benoit Macq; Copyright (c) 2001-2003, David Janssens; Copyright (c) 2002-2003, Yannick Verschueren; Copyright (c) 2003-2007, Francois-Olivier Devaux and Antonin Descampe; Copyright (c) 2005, Herve Drolon, FreeImage Team; Copyright (c) 2006-2007, Parvatha Elangovan; Copyright (c) 2008, Jerome Fimes, Communications &amp; Systemes &lt;jerome.fimes@c-s.fr&gt;; Copyright (c) 2010-2011, Kaori Hagihara; Copyright (c) 2011-2012, Centre National d'Etudes Spatiales (CNES), France; Copyright (c) 2012, CS Systemes d'Information, France;</string>
+        <key>description</key>
+        <string>The OpenJPEG library is an open-source JPEG 2000 codec written in C language.</string>
+        <key>license</key>
+        <string>BSD</string>
+        <key>license_file</key>
+        <string>LICENSES/openjpeg.txt</string>
+        <key>name</key>
+        <string>openjpeg</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -2057,21 +2153,21 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>BSD</string>
-        <key>license_file</key>
-        <string>LICENSES/openjpeg.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2002-2007, Communications and Remote Sensing Laboratory, Universite catholique de Louvain (UCL), Belgium; Copyright (c) 2002-2007, Professor Benoit Macq; Copyright (c) 2001-2003, David Janssens; Copyright (c) 2002-2003, Yannick Verschueren; Copyright (c) 2003-2007, Francois-Olivier Devaux and Antonin Descampe; Copyright (c) 2005, Herve Drolon, FreeImage Team; Copyright (c) 2006-2007, Parvatha Elangovan; Copyright (c) 2008, Jerome Fimes, Communications &amp; Systemes &lt;jerome.fimes@c-s.fr&gt;; Copyright (c) 2010-2011, Kaori Hagihara; Copyright (c) 2011-2012, Centre National d'Etudes Spatiales (CNES), France; Copyright (c) 2012, CS Systemes d'Information, France;</string>
         <key>version</key>
         <string>2.5.3.15590356935</string>
-        <key>name</key>
-        <string>openjpeg</string>
-        <key>description</key>
-        <string>The OpenJPEG library is an open-source JPEG 2000 codec written in C language.</string>
       </map>
       <key>openssl</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 1998-2011 The OpenSSL Project.  All rights reserved; Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)</string>
+        <key>description</key>
+        <string>Secure Sockets Layer (SSL v2/v3) and Transport Layer Security (TLS v1) Library</string>
+        <key>license</key>
+        <string>openssl</string>
+        <key>license_file</key>
+        <string>LICENSES/openssl.txt</string>
+        <key>name</key>
+        <string>openssl</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -2117,36 +2213,38 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>openssl</string>
-        <key>license_file</key>
-        <string>LICENSES/openssl.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 1998-2011 The OpenSSL Project.  All rights reserved; Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)</string>
         <key>version</key>
         <string>1.1.1w-r4</string>
-        <key>name</key>
-        <string>openssl</string>
-        <key>description</key>
-        <string>Secure Sockets Layer (SSL v2/v3) and Transport Layer Security (TLS v1) Library</string>
       </map>
       <key>openxr</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://github.com/secondlife/3p-openxr</string>
+        <key>copyright</key>
+        <string>Copyright 2017-2024, The Khronos Group Inc.</string>
+        <key>description</key>
+        <string>Generated headers and sources for OpenXR loader.</string>
+        <key>license</key>
+        <string>Apache 2.0</string>
+        <key>license_file</key>
+        <string>LICENSES/openxr.txt</string>
+        <key>name</key>
+        <string>openxr</string>
         <key>platforms</key>
         <map>
-          <key>windows64</key>
+          <key>darwin64</key>
           <map>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>3cccc3e3f3137066c286270b35abc00ee0c0bb0c</string>
+              <string>a9bfabec63a987bd34bcfdc295b928bd0696e1d7</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-openxr/releases/download/v1.1.40-r1/openxr-1.1.40-r1-windows64-10710818432.tar.zst</string>
+              <string>https://github.com/secondlife/3p-openxr/releases/download/v1.1.40-r1/openxr-1.1.40-r1-darwin64-10710818432.tar.zst</string>
             </map>
             <key>name</key>
-            <string>windows64</string>
+            <string>darwin64</string>
           </map>
           <key>linux64</key>
           <map>
@@ -2162,38 +2260,38 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>name</key>
             <string>linux64</string>
           </map>
-          <key>darwin64</key>
+          <key>windows64</key>
           <map>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>a9bfabec63a987bd34bcfdc295b928bd0696e1d7</string>
+              <string>3cccc3e3f3137066c286270b35abc00ee0c0bb0c</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-openxr/releases/download/v1.1.40-r1/openxr-1.1.40-r1-darwin64-10710818432.tar.zst</string>
+              <string>https://github.com/secondlife/3p-openxr/releases/download/v1.1.40-r1/openxr-1.1.40-r1-windows64-10710818432.tar.zst</string>
             </map>
             <key>name</key>
-            <string>darwin64</string>
+            <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>Apache 2.0</string>
-        <key>license_file</key>
-        <string>LICENSES/openxr.txt</string>
-        <key>copyright</key>
-        <string>Copyright 2017-2024, The Khronos Group Inc.</string>
         <key>version</key>
         <string>1.1.40-r1</string>
-        <key>name</key>
-        <string>openxr</string>
-        <key>canonical_repo</key>
-        <string>https://github.com/secondlife/3p-openxr</string>
-        <key>description</key>
-        <string>Generated headers and sources for OpenXR loader.</string>
       </map>
       <key>sse2neon</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://github.com/secondlife/3p-sse2neon</string>
+        <key>copyright</key>
+        <string>Copyright (c) 2015-2024 SSE2NEON Contributors.</string>
+        <key>description</key>
+        <string>A translator from Intel SSE intrinsics to Arm/Aarch64 NEON implementation</string>
+        <key>license</key>
+        <string>MIT</string>
+        <key>license_file</key>
+        <string>LICENSES/sse2neon.txt</string>
+        <key>name</key>
+        <string>sse2neon</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -2211,23 +2309,19 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>MIT</string>
-        <key>license_file</key>
-        <string>LICENSES/sse2neon.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2015-2024 SSE2NEON Contributors.</string>
         <key>version</key>
         <string>1.8.0</string>
-        <key>name</key>
-        <string>sse2neon</string>
-        <key>canonical_repo</key>
-        <string>https://github.com/secondlife/3p-sse2neon</string>
-        <key>description</key>
-        <string>A translator from Intel SSE intrinsics to Arm/Aarch64 NEON implementation</string>
       </map>
       <key>threejs</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright © 2010-2021 three.js authors</string>
+        <key>license</key>
+        <string>MIT</string>
+        <key>license_file</key>
+        <string>LICENSES/THREEJS_LICENSE.txt</string>
+        <key>name</key>
+        <string>threejs</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -2245,19 +2339,63 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>MIT</string>
-        <key>license_file</key>
-        <string>LICENSES/THREEJS_LICENSE.txt</string>
-        <key>copyright</key>
-        <string>Copyright © 2010-2021 three.js authors</string>
         <key>version</key>
         <string>0.132.2</string>
+      </map>
+      <key>tinyexr</key>
+      <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2014 - 2021, Syoyo Fujita and many contributors.</string>
+        <key>description</key>
+        <string>tinyexr import library</string>
+        <key>license</key>
+        <string>3-clause BSD</string>
+        <key>license_file</key>
+        <string>LICENSES/tinyexr_license.txt</string>
         <key>name</key>
-        <string>threejs</string>
+        <string>tinyexr</string>
+        <key>platforms</key>
+        <map>
+          <key>common</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>a9649f85e20c0b83acfd7b02ca19c1dcdd15f01e</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife/3p-tinyexr/releases/download/v1.0.9-5e8947c/tinyexr-1.0.9-5e8947c-common-10475846787.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>common</string>
+          </map>
+        </map>
+        <key>source_type</key>
+        <string>git</string>
+        <key>vcs_branch</key>
+        <string>dependabot/github_actions/secondlife/action-autobuild-4</string>
+        <key>vcs_revision</key>
+        <string>4dc4d1d90d82a22843e2adf5130f9ecb5ee5769e</string>
+        <key>vcs_url</key>
+        <string>https://github.com/secondlife/3p-tinyexr</string>
+        <key>version</key>
+        <string>1.0.9-5e8947c</string>
       </map>
       <key>tinygltf</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://bitbucket.org/lindenlab/3p-tinygltf</string>
+        <key>copyright</key>
+        <string>// Copyright (c) 2015 - Present Syoyo Fujita, Aurélien Chatelain and many contributors.</string>
+        <key>description</key>
+        <string>tinygltf import library</string>
+        <key>license</key>
+        <string>MIT</string>
+        <key>license_file</key>
+        <string>LICENSES/tinygltf_license.txt</string>
+        <key>name</key>
+        <string>tinygltf</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -2275,27 +2413,27 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>MIT</string>
-        <key>license_file</key>
-        <string>LICENSES/tinygltf_license.txt</string>
-        <key>copyright</key>
-        <string>// Copyright (c) 2015 - Present Syoyo Fujita, Aurélien Chatelain and many contributors.</string>
-        <key>version</key>
-        <string>2.9.3-r1</string>
-        <key>name</key>
-        <string>tinygltf</string>
-        <key>canonical_repo</key>
-        <string>https://bitbucket.org/lindenlab/3p-tinygltf</string>
-        <key>description</key>
-        <string>tinygltf import library</string>
         <key>source</key>
         <string>https://bitbucket.org/lindenlab/3p-tinygltf</string>
         <key>source_type</key>
         <string>git</string>
+        <key>version</key>
+        <string>2.9.3-r1</string>
       </map>
       <key>tracy</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://bitbucket.org/lindenlab/3p-tracy</string>
+        <key>copyright</key>
+        <string>Copyright (c) 2017-2024, Bartosz Taudul (wolf@nereid.pl)</string>
+        <key>description</key>
+        <string>Tracy Profiler Library</string>
+        <key>license</key>
+        <string>bsd</string>
+        <key>license_file</key>
+        <string>LICENSES/tracy_license.txt</string>
+        <key>name</key>
+        <string>tracy</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -2312,20 +2450,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>name</key>
             <string>darwin64</string>
           </map>
-          <key>windows64</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>b46cef5646a8d0471ab6256fe5119220fa238772</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://github.com/secondlife/3p-tracy/releases/download/v0.11.1-r1/tracy-v0.11.1.11706699176-windows64-11706699176.tar.zst</string>
-            </map>
-            <key>name</key>
-            <string>windows64</string>
-          </map>
           <key>linux64</key>
           <map>
             <key>archive</key>
@@ -2340,28 +2464,40 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>name</key>
             <string>linux64</string>
           </map>
+          <key>windows64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>b46cef5646a8d0471ab6256fe5119220fa238772</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife/3p-tracy/releases/download/v0.11.1-r1/tracy-v0.11.1.11706699176-windows64-11706699176.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>windows64</string>
+          </map>
         </map>
-        <key>license</key>
-        <string>bsd</string>
-        <key>license_file</key>
-        <string>LICENSES/tracy_license.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2017-2024, Bartosz Taudul (wolf@nereid.pl)</string>
-        <key>version</key>
-        <string>v0.11.1.11706699176</string>
-        <key>name</key>
-        <string>tracy</string>
-        <key>canonical_repo</key>
-        <string>https://bitbucket.org/lindenlab/3p-tracy</string>
-        <key>description</key>
-        <string>Tracy Profiler Library</string>
         <key>source</key>
         <string>https://bitbucket.org/lindenlab/3p-tracy</string>
         <key>source_type</key>
         <string>git</string>
+        <key>version</key>
+        <string>v0.11.1.11706699176</string>
       </map>
       <key>tut</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright 2002-2006 Vladimir Dyuzhev, Copyright 2007 Denis Kononenko, Copyright 2008-2009 Michał Rzechonek</string>
+        <key>description</key>
+        <string>TUT is a small and portable unit test framework for C++.</string>
+        <key>license</key>
+        <string>bsd</string>
+        <key>license_file</key>
+        <string>LICENSES/tut.txt</string>
+        <key>name</key>
+        <string>tut</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -2379,21 +2515,99 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>bsd</string>
-        <key>license_file</key>
-        <string>LICENSES/tut.txt</string>
-        <key>copyright</key>
-        <string>Copyright 2002-2006 Vladimir Dyuzhev, Copyright 2007 Denis Kononenko, Copyright 2008-2009 Michał Rzechonek</string>
         <key>version</key>
         <string>2008.11.30</string>
-        <key>name</key>
-        <string>tut</string>
+      </map>
+      <key>velopack</key>
+      <map>
+        <key>copyright</key>
+        <string>Velopack Ltd.</string>
         <key>description</key>
-        <string>TUT is a small and portable unit test framework for C++.</string>
+        <string>Velopack C/C++ Library</string>
+        <key>license</key>
+        <string>MIT</string>
+        <key>license_file</key>
+        <string>LICENSES/velopack.txt</string>
+        <key>name</key>
+        <string>velopack</string>
+        <key>platforms</key>
+        <map>
+          <key>darwin64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>ead94386d7b9a143824d7ccedc86433127028a91</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife-3p/3p-velopack/releases/download/v0.0.1535-r2/velopack-40232ef.24685318450-darwin64-24685318450.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>darwin64</string>
+          </map>
+          <key>windows64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>df2260187110aa51c20101183e18a55f86e71090</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife-3p/3p-velopack/releases/download/v0.0.1535-r2/velopack-40232ef.24685318450-windows64-24685318450.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>windows64</string>
+          </map>
+        </map>
+        <key>version</key>
+        <string>40232ef.24685318450</string>
+      </map>
+      <key>vhacd</key>
+      <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2011, Khaled Mamou</string>
+        <key>description</key>
+        <string>Voxelized Hierarchical Approximate Convex Decomposition</string>
+        <key>license</key>
+        <string>BSD</string>
+        <key>license_file</key>
+        <string>LICENSES/vhacd.txt</string>
+        <key>name</key>
+        <string>vhacd</string>
+        <key>platforms</key>
+        <map>
+          <key>common</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>140d8fc952a10edb5f2d72ab405336019ef32cadfa64f0cfce76c9de4bc6268cbc87cc8cd89d3417fb78b531d441701afc8d016bafe4bd275df2707f7daf1387</string>
+              <key>hash_algorithm</key>
+              <string>blake2b</string>
+              <key>url</key>
+              <string>https://github.com/AlchemyViewer/3p-vhacd/releases/download/v4.1.0-r2/vhacd-4.1.0-r2-common-18166921729.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>common</string>
+          </map>
+        </map>
+        <key>version</key>
+        <string>4.1.0-r2</string>
       </map>
       <key>viewer-fonts</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright 2016-2022 Brad Erickson CC-BY-4.0/MIT, Copyright 2016-2022 Twitter, Inc. CC-BY-4.0, Copyright 2013 Joe Loughry and Terence Eden MIT, Copyright (c) 2003 by Bitstream, Inc., Copyright (c) 2006 by Tavmjong Bah.</string>
+        <key>description</key>
+        <string>Viewer fonts</string>
+        <key>license</key>
+        <string>Various open source</string>
+        <key>license_file</key>
+        <string>LICENSES/fonts.txt</string>
+        <key>name</key>
+        <string>viewer-fonts</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -2411,53 +2625,21 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>Various open source</string>
-        <key>license_file</key>
-        <string>LICENSES/fonts.txt</string>
-        <key>copyright</key>
-        <string>Copyright 2016-2022 Brad Erickson CC-BY-4.0/MIT, Copyright 2016-2022 Twitter, Inc. CC-BY-4.0, Copyright 2013 Joe Loughry and Terence Eden MIT, Copyright (c) 2003 by Bitstream, Inc., Copyright (c) 2006 by Tavmjong Bah.</string>
         <key>version</key>
         <string>1.0.0.25128287087</string>
-        <key>name</key>
-        <string>viewer-fonts</string>
-        <key>description</key>
-        <string>Viewer fonts</string>
-      </map>
-      <key>google-fonts</key>
-      <map>
-        <key>platforms</key>
-        <map>
-          <key>common</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>8de96fd083783b9f4df1d8d7028c8a713a7d7217</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://github.com/secondlife/3p-google-fonts/releases/download/v1.0.0-r6/google_fonts-1.0.0.24469773244-common-24469773244.tar.zst</string>
-            </map>
-            <key>name</key>
-            <string>common</string>
-          </map>
-        </map>
-        <key>license</key>
-        <string>SIL Open Font License, Version 1.1</string>
-        <key>license_file</key>
-        <string>LICENSES/google_inter.txt</string>
-        <key>copyright</key>
-        <string>Copyright 2020 The Inter Project Authors (https://github.com/rsms/inter)</string>
-        <key>version</key>
-        <string>1.0.0.22606339007</string>
-        <key>name</key>
-        <string>google-fonts</string>
-        <key>description</key>
-        <string>Google fonts</string>
       </map>
       <key>viewer-manager</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2000-2012, Linden Research, Inc.</string>
+        <key>description</key>
+        <string>Linden Lab Viewer Management Process suite.</string>
+        <key>license</key>
+        <string>viewerlgpl</string>
+        <key>license_file</key>
+        <string>LICENSE</string>
+        <key>name</key>
+        <string>viewer-manager</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -2503,25 +2685,23 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>viewerlgpl</string>
-        <key>license_file</key>
-        <string>LICENSE</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2000-2012, Linden Research, Inc.</string>
-        <key>version</key>
-        <string>3.0-f14b5ec</string>
-        <key>name</key>
-        <string>viewer-manager</string>
-        <key>description</key>
-        <string>Linden Lab Viewer Management Process suite.</string>
         <key>source</key>
         <string>https://bitbucket.org/lindenlab/vmp-standalone</string>
         <key>source_type</key>
         <string>hg</string>
+        <key>version</key>
+        <string>3.0-f14b5ec</string>
       </map>
       <key>vlc-bin</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (C) 1998-2016 VLC authors and VideoLAN</string>
+        <key>license</key>
+        <string>GPL2</string>
+        <key>license_file</key>
+        <string>LICENSES/vlc.txt</string>
+        <key>name</key>
+        <string>vlc-bin</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -2553,19 +2733,23 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>GPL2</string>
-        <key>license_file</key>
-        <string>LICENSES/vlc.txt</string>
-        <key>copyright</key>
-        <string>Copyright (C) 1998-2016 VLC authors and VideoLAN</string>
         <key>version</key>
         <string>3.0.21.11968962952</string>
-        <key>name</key>
-        <string>vlc-bin</string>
       </map>
       <key>vulkan_gltf</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://bitbucket.org/lindenlab/3p-vulkan-gltf-pbr</string>
+        <key>copyright</key>
+        <string>Copyright (c) 2018 Sascha Willems</string>
+        <key>description</key>
+        <string>Vulkan GLTF Sample Implementation</string>
+        <key>license</key>
+        <string>Copyright (c) 2018 Sascha Willems</string>
+        <key>license_file</key>
+        <string>vulkan_gltf.txt</string>
+        <key>name</key>
+        <string>vulkan_gltf</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -2583,23 +2767,21 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>Copyright (c) 2018 Sascha Willems</string>
-        <key>license_file</key>
-        <string>vulkan_gltf.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2018 Sascha Willems</string>
         <key>version</key>
         <string>1.0.0</string>
-        <key>name</key>
-        <string>vulkan_gltf</string>
-        <key>canonical_repo</key>
-        <string>https://bitbucket.org/lindenlab/3p-vulkan-gltf-pbr</string>
-        <key>description</key>
-        <string>Vulkan GLTF Sample Implementation</string>
       </map>
       <key>webrtc</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://github.com/secondlife/3p-webrtc-build</string>
+        <key>copyright</key>
+        <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
+        <key>license</key>
+        <string>MIT</string>
+        <key>license_file</key>
+        <string>LICENSES/webrtc-license.txt</string>
+        <key>name</key>
+        <string>webrtc</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -2645,27 +2827,27 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>MIT</string>
-        <key>license_file</key>
-        <string>LICENSES/webrtc-license.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
-        <key>version</key>
-        <string>m137.7151.04.22.21966754211</string>
-        <key>name</key>
-        <string>webrtc</string>
         <key>vcs_branch</key>
         <string>secondlife</string>
         <key>vcs_revision</key>
         <string>d3f62d32bac8694d3c7423c731ae30c113bf6a11</string>
         <key>vcs_url</key>
         <string>https://github.com/secondlife/3p-webrtc-build</string>
-        <key>canonical_repo</key>
-        <string>https://github.com/secondlife/3p-webrtc-build</string>
+        <key>version</key>
+        <string>m137.7151.04.22.21966754211</string>
       </map>
       <key>xxhash</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2012-2021 Yann Collet</string>
+        <key>description</key>
+        <string>xxHash Library</string>
+        <key>license</key>
+        <string>xxhash</string>
+        <key>license_file</key>
+        <string>LICENSES/xxhash.txt</string>
+        <key>name</key>
+        <string>xxhash</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -2683,21 +2865,23 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>common</string>
           </map>
         </map>
-        <key>license</key>
-        <string>xxhash</string>
-        <key>license_file</key>
-        <string>LICENSES/xxhash.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2012-2021 Yann Collet</string>
         <key>version</key>
         <string>0.8.2-10285735820</string>
-        <key>name</key>
-        <string>xxhash</string>
-        <key>description</key>
-        <string>xxHash Library</string>
       </map>
       <key>zlib-ng</key>
       <map>
+        <key>canonical_repo</key>
+        <string>https://bitbucket.org/lindenlab/3p-zlib-ng</string>
+        <key>copyright</key>
+        <string>Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler</string>
+        <key>description</key>
+        <string>zlib data compression library for the next generation systems</string>
+        <key>license</key>
+        <string>zlib-ng</string>
+        <key>license_file</key>
+        <string>LICENSES/zlib-ng.txt</string>
+        <key>name</key>
+        <string>zlib-ng</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -2743,200 +2927,24 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>zlib-ng</string>
-        <key>license_file</key>
-        <string>LICENSES/zlib-ng.txt</string>
-        <key>copyright</key>
-        <string>Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler</string>
         <key>version</key>
         <string>2.2.5-0d88d03</string>
-        <key>name</key>
-        <string>zlib-ng</string>
-        <key>canonical_repo</key>
-        <string>https://bitbucket.org/lindenlab/3p-zlib-ng</string>
-        <key>description</key>
-        <string>zlib data compression library for the next generation systems</string>
-      </map>
-      <key>tinyexr</key>
-      <map>
-        <key>platforms</key>
-        <map>
-          <key>common</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>a9649f85e20c0b83acfd7b02ca19c1dcdd15f01e</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://github.com/secondlife/3p-tinyexr/releases/download/v1.0.9-5e8947c/tinyexr-1.0.9-5e8947c-common-10475846787.tar.zst</string>
-            </map>
-            <key>name</key>
-            <string>common</string>
-          </map>
-        </map>
-        <key>license</key>
-        <string>3-clause BSD</string>
-        <key>license_file</key>
-        <string>LICENSES/tinyexr_license.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2014 - 2021, Syoyo Fujita and many contributors.</string>
-        <key>version</key>
-        <string>1.0.9-5e8947c</string>
-        <key>name</key>
-        <string>tinyexr</string>
-        <key>vcs_branch</key>
-        <string>dependabot/github_actions/secondlife/action-autobuild-4</string>
-        <key>vcs_revision</key>
-        <string>4dc4d1d90d82a22843e2adf5130f9ecb5ee5769e</string>
-        <key>vcs_url</key>
-        <string>https://github.com/secondlife/3p-tinyexr</string>
-        <key>description</key>
-        <string>tinyexr import library</string>
-        <key>source_type</key>
-        <string>git</string>
-      </map>
-      <key>discord_sdk</key>
-      <map>
-        <key>platforms</key>
-        <map>
-          <key>windows64</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>creds</key>
-              <string>github</string>
-              <key>hash</key>
-              <string>e11571bf76b27d15c244069988ae372eaa5afae9</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-discord-sdk/releases/assets/279333720</string>
-            </map>
-            <key>name</key>
-            <string>windows64</string>
-          </map>
-          <key>darwin64</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>creds</key>
-              <string>github</string>
-              <key>hash</key>
-              <string>dc21df8b051c425163acf3eff8f06e32f407c9e0</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-discord-sdk/releases/assets/279333706</string>
-            </map>
-            <key>name</key>
-            <string>darwin64</string>
-          </map>
-        </map>
-        <key>license</key>
-        <string>discord_sdk</string>
-        <key>license_file</key>
-        <string>LICENSES/discord_sdk.txt</string>
-        <key>copyright</key>
-        <string>Discord Inc.</string>
-        <key>version</key>
-        <string>1.4.9649.16733550144</string>
-        <key>name</key>
-        <string>discord_sdk</string>
-        <key>vcs_branch</key>
-        <string>main</string>
-        <key>vcs_revision</key>
-        <string>ef5c7c4a490ceac2df2b2f046788b1daf1bbb392</string>
-        <key>vcs_url</key>
-        <string>https://github.com/secondlife/3p-discord-sdk</string>
-        <key>canonical_repo</key>
-        <string>https://github.com/secondlife/3p-discord-sdk</string>
-        <key>description</key>
-        <string>Discord Social SDK</string>
-      </map>
-      <key>vhacd</key>
-      <map>
-        <key>platforms</key>
-        <map>
-          <key>common</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>140d8fc952a10edb5f2d72ab405336019ef32cadfa64f0cfce76c9de4bc6268cbc87cc8cd89d3417fb78b531d441701afc8d016bafe4bd275df2707f7daf1387</string>
-              <key>hash_algorithm</key>
-              <string>blake2b</string>
-              <key>url</key>
-              <string>https://github.com/AlchemyViewer/3p-vhacd/releases/download/v4.1.0-r2/vhacd-4.1.0-r2-common-18166921729.tar.zst</string>
-            </map>
-            <key>name</key>
-            <string>common</string>
-          </map>
-        </map>
-        <key>license</key>
-        <string>BSD</string>
-        <key>license_file</key>
-        <string>LICENSES/vhacd.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2011, Khaled Mamou</string>
-        <key>version</key>
-        <string>4.1.0-r2</string>
-        <key>name</key>
-        <string>vhacd</string>
-        <key>description</key>
-        <string>Voxelized Hierarchical Approximate Convex Decomposition</string>
-      </map>
-      <key>velopack</key>
-      <map>
-        <key>platforms</key>
-        <map>
-          <key>windows64</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>df2260187110aa51c20101183e18a55f86e71090</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://github.com/secondlife-3p/3p-velopack/releases/download/v0.0.1535-r2/velopack-40232ef.24685318450-windows64-24685318450.tar.zst</string>
-            </map>
-            <key>name</key>
-            <string>windows64</string>
-          </map>
-          <key>darwin64</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>ead94386d7b9a143824d7ccedc86433127028a91</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://github.com/secondlife-3p/3p-velopack/releases/download/v0.0.1535-r2/velopack-40232ef.24685318450-darwin64-24685318450.tar.zst</string>
-            </map>
-            <key>name</key>
-            <string>darwin64</string>
-          </map>
-        </map>
-        <key>license</key>
-        <string>MIT</string>
-        <key>license_file</key>
-        <string>LICENSES/velopack.txt</string>
-        <key>copyright</key>
-        <string>Velopack Ltd.</string>
-        <key>version</key>
-        <string>40232ef.24685318450</string>
-        <key>name</key>
-        <string>velopack</string>
-        <key>description</key>
-        <string>Velopack C/C++ Library</string>
       </map>
     </map>
     <key>package_description</key>
     <map>
+      <key>canonical_repo</key>
+      <string>https://github.com/secondlife/viewer</string>
+      <key>copyright</key>
+      <string>Copyright (c) 2026, Linden Research, Inc.</string>
+      <key>description</key>
+      <string>Second Life Viewer</string>
+      <key>license</key>
+      <string>LGPL</string>
+      <key>license_file</key>
+      <string>docs/LICENSE-source.txt</string>
+      <key>name</key>
+      <string>Second Life Viewer</string>
       <key>platforms</key>
       <map>
         <key>common</key>
@@ -2945,6 +2953,9 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
           <map>
             <key>RelWithDebInfo</key>
             <map>
+              <key>build</key>
+              <map>
+              </map>
               <key>configure</key>
               <map>
                 <key>command</key>
@@ -2957,9 +2968,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>-DINSTALL_PROPRIETARY=TRUE</string>
                   <string>-DUSE_OPENAL:BOOL=ON</string>
                 </array>
-              </map>
-              <key>build</key>
-              <map>
               </map>
               <key>name</key>
               <string>RelWithDebInfo</string>
@@ -2968,6 +2976,10 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <map>
               <key>configure</key>
               <map>
+                <key>arguments</key>
+                <array>
+                  <string>../indra</string>
+                </array>
                 <key>command</key>
                 <string>cmake</string>
                 <key>options</key>
@@ -2977,16 +2989,15 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>-DROOT_PROJECT_NAME:STRING=SecondLife</string>
                   <string>-DINSTALL_PROPRIETARY=FALSE</string>
                 </array>
-                <key>arguments</key>
-                <array>
-                  <string>../indra</string>
-                </array>
               </map>
               <key>name</key>
               <string>RelWithDebInfoOS</string>
             </map>
             <key>Release</key>
             <map>
+              <key>build</key>
+              <map>
+              </map>
               <key>configure</key>
               <map>
                 <key>command</key>
@@ -3000,9 +3011,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>-DUSE_OPENAL:BOOL=ON</string>
                 </array>
               </map>
-              <key>build</key>
-              <map>
-              </map>
               <key>name</key>
               <string>Release</string>
             </map>
@@ -3010,6 +3018,10 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <map>
               <key>configure</key>
               <map>
+                <key>arguments</key>
+                <array>
+                  <string>../indra</string>
+                </array>
                 <key>command</key>
                 <string>cmake</string>
                 <key>options</key>
@@ -3018,10 +3030,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>-DADDRESS_SIZE:STRING=$AUTOBUILD_ADDRSIZE</string>
                   <string>-DROOT_PROJECT_NAME:STRING=SecondLife</string>
                   <string>-DINSTALL_PROPRIETARY=FALSE</string>
-                </array>
-                <key>arguments</key>
-                <array>
-                  <string>../indra</string>
                 </array>
               </map>
               <key>name</key>
@@ -3033,22 +3041,12 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         </map>
         <key>darwin64</key>
         <map>
+          <key>build_directory</key>
+          <string>build-darwin-universal</string>
           <key>configurations</key>
           <map>
             <key>RelWithDebInfo</key>
             <map>
-              <key>configure</key>
-              <map>
-                <key>options</key>
-                <array>
-                  <string>-G</string>
-                  <string>Xcode</string>
-                </array>
-                <key>arguments</key>
-                <array>
-                  <string>../indra</string>
-                </array>
-              </map>
               <key>build</key>
               <map>
                 <key>command</key>
@@ -3061,6 +3059,18 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>RelWithDebInfo</string>
                   <string>--parallel</string>
                   <string>$AUTOBUILD_CPU_COUNT</string>
+                </array>
+              </map>
+              <key>configure</key>
+              <map>
+                <key>arguments</key>
+                <array>
+                  <string>../indra</string>
+                </array>
+                <key>options</key>
+                <array>
+                  <string>-G</string>
+                  <string>Xcode</string>
                 </array>
               </map>
               <key>default</key>
@@ -3070,14 +3080,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             </map>
             <key>RelWithDebInfoOS</key>
             <map>
-              <key>configure</key>
-              <map>
-                <key>options</key>
-                <array>
-                  <string>-G</string>
-                  <string>Xcode</string>
-                </array>
-              </map>
               <key>build</key>
               <map>
                 <key>command</key>
@@ -3092,11 +3094,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>$AUTOBUILD_CPU_COUNT</string>
                 </array>
               </map>
-              <key>name</key>
-              <string>RelWithDebInfoOS</string>
-            </map>
-            <key>Release</key>
-            <map>
               <key>configure</key>
               <map>
                 <key>options</key>
@@ -3104,11 +3101,12 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>-G</string>
                   <string>Xcode</string>
                 </array>
-                <key>arguments</key>
-                <array>
-                  <string>../indra</string>
-                </array>
               </map>
+              <key>name</key>
+              <string>RelWithDebInfoOS</string>
+            </map>
+            <key>Release</key>
+            <map>
               <key>build</key>
               <map>
                 <key>command</key>
@@ -3121,6 +3119,18 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>Release</string>
                   <string>--parallel</string>
                   <string>$AUTOBUILD_CPU_COUNT</string>
+                </array>
+              </map>
+              <key>configure</key>
+              <map>
+                <key>arguments</key>
+                <array>
+                  <string>../indra</string>
+                </array>
+                <key>options</key>
+                <array>
+                  <string>-G</string>
+                  <string>Xcode</string>
                 </array>
               </map>
               <key>name</key>
@@ -3128,14 +3138,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             </map>
             <key>ReleaseOS</key>
             <map>
-              <key>configure</key>
-              <map>
-                <key>options</key>
-                <array>
-                  <string>-G</string>
-                  <string>Xcode</string>
-                </array>
-              </map>
               <key>build</key>
               <map>
                 <key>command</key>
@@ -3150,38 +3152,46 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>$AUTOBUILD_CPU_COUNT</string>
                 </array>
               </map>
+              <key>configure</key>
+              <map>
+                <key>options</key>
+                <array>
+                  <string>-G</string>
+                  <string>Xcode</string>
+                </array>
+              </map>
               <key>name</key>
               <string>ReleaseOS</string>
             </map>
           </map>
-          <key>build_directory</key>
-          <string>build-darwin-universal</string>
           <key>name</key>
           <string>darwin64</string>
         </map>
         <key>linux64</key>
         <map>
+          <key>build_directory</key>
+          <string>build-linux-x86_64</string>
           <key>configurations</key>
           <map>
             <key>Release</key>
             <map>
+              <key>build</key>
+              <map>
+                <key>command</key>
+                <string>ninja</string>
+              </map>
               <key>configure</key>
               <map>
+                <key>arguments</key>
+                <array>
+                  <string>../indra</string>
+                </array>
                 <key>options</key>
                 <array>
                   <string>-G</string>
                   <string>Ninja</string>
                   <string>-DLL_TESTS=Off</string>
                 </array>
-                <key>arguments</key>
-                <array>
-                  <string>../indra</string>
-                </array>
-              </map>
-              <key>build</key>
-              <map>
-                <key>command</key>
-                <string>ninja</string>
               </map>
               <key>default</key>
               <string>True</string>
@@ -3190,6 +3200,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             </map>
             <key>ReleaseOS</key>
             <map>
+              <key>build</key>
+              <map>
+                <key>command</key>
+                <string>ninja</string>
+              </map>
               <key>configure</key>
               <map>
                 <key>options</key>
@@ -3198,11 +3213,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>Ninja</string>
                   <string>-DLL_TESTS=Off</string>
                 </array>
-              </map>
-              <key>build</key>
-              <map>
-                <key>command</key>
-                <string>ninja</string>
               </map>
               <key>name</key>
               <string>ReleaseOS</string>
@@ -3216,33 +3226,23 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
               <string>default</string>
             </map>
           </map>
-          <key>build_directory</key>
-          <string>build-linux-x86_64</string>
           <key>name</key>
           <string>linux64</string>
         </map>
         <key>windows</key>
         <map>
+          <key>build_directory</key>
+          <string>build-vc${AUTOBUILD_VSVER|170}-$AUTOBUILD_ADDRSIZE</string>
           <key>configurations</key>
           <map>
             <key>RelWithDebInfo</key>
             <map>
-              <key>configure</key>
-              <map>
-                <key>options</key>
-                <array>
-                  <string>-G</string>
-                  <string>${AUTOBUILD_WIN_CMAKE_GEN|NOTWIN}</string>
-                  <string>-A</string>
-                  <string>${AUTOBUILD_WIN_VSPLATFORM|NOTWIN}</string>
-                </array>
-                <key>arguments</key>
-                <array>
-                  <string>..\indra</string>
-                </array>
-              </map>
               <key>build</key>
               <map>
+                <key>arguments</key>
+                <array>
+                  <string>SecondLife.sln</string>
+                </array>
                 <key>command</key>
                 <string>devenv</string>
                 <key>options</key>
@@ -3250,9 +3250,19 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>/build</string>
                   <string>RelWithDebInfo|${AUTOBUILD_WIN_VSPLATFORM|NOTWIN}</string>
                 </array>
+              </map>
+              <key>configure</key>
+              <map>
                 <key>arguments</key>
                 <array>
-                  <string>SecondLife.sln</string>
+                  <string>..\indra</string>
+                </array>
+                <key>options</key>
+                <array>
+                  <string>-G</string>
+                  <string>${AUTOBUILD_WIN_CMAKE_GEN|NOTWIN}</string>
+                  <string>-A</string>
+                  <string>${AUTOBUILD_WIN_VSPLATFORM|NOTWIN}</string>
                 </array>
               </map>
               <key>default</key>
@@ -3262,25 +3272,12 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             </map>
             <key>RelWithDebInfoOS</key>
             <map>
-              <key>configure</key>
-              <map>
-                <key>options</key>
-                <array>
-                  <string>-G</string>
-                  <string>${AUTOBUILD_WIN_CMAKE_GEN|NOTWIN}</string>
-                  <string>-A</string>
-                  <string>${AUTOBUILD_WIN_VSPLATFORM|NOTWIN}</string>
-                  <string>-DINSTALL_PROPRIETARY=FALSE</string>
-                  <string>-DUSE_KDU=FALSE</string>
-                  <string>-DUSE_OPENAL:BOOL=ON</string>
-                </array>
-                <key>arguments</key>
-                <array>
-                  <string>..\indra</string>
-                </array>
-              </map>
               <key>build</key>
               <map>
+                <key>arguments</key>
+                <array>
+                  <string>SecondLife.sln</string>
+                </array>
                 <key>command</key>
                 <string>msbuild.exe</string>
                 <key>options</key>
@@ -3292,9 +3289,22 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>/verbosity:minimal</string>
                   <string>/p:VCBuildAdditionalOptions= /incremental</string>
                 </array>
+              </map>
+              <key>configure</key>
+              <map>
                 <key>arguments</key>
                 <array>
-                  <string>SecondLife.sln</string>
+                  <string>..\indra</string>
+                </array>
+                <key>options</key>
+                <array>
+                  <string>-G</string>
+                  <string>${AUTOBUILD_WIN_CMAKE_GEN|NOTWIN}</string>
+                  <string>-A</string>
+                  <string>${AUTOBUILD_WIN_VSPLATFORM|NOTWIN}</string>
+                  <string>-DINSTALL_PROPRIETARY=FALSE</string>
+                  <string>-DUSE_KDU=FALSE</string>
+                  <string>-DUSE_OPENAL:BOOL=ON</string>
                 </array>
               </map>
               <key>name</key>
@@ -3302,22 +3312,12 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             </map>
             <key>Release</key>
             <map>
-              <key>configure</key>
-              <map>
-                <key>options</key>
-                <array>
-                  <string>-G</string>
-                  <string>${AUTOBUILD_WIN_CMAKE_GEN|NOTWIN}</string>
-                  <string>-A</string>
-                  <string>${AUTOBUILD_WIN_VSPLATFORM|NOTWIN}</string>
-                </array>
-                <key>arguments</key>
-                <array>
-                  <string>..\indra</string>
-                </array>
-              </map>
               <key>build</key>
               <map>
+                <key>arguments</key>
+                <array>
+                  <string>SecondLife.sln</string>
+                </array>
                 <key>command</key>
                 <string>devenv</string>
                 <key>options</key>
@@ -3325,9 +3325,19 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>/build</string>
                   <string>Release|${AUTOBUILD_WIN_VSPLATFORM|NOTWIN}</string>
                 </array>
+              </map>
+              <key>configure</key>
+              <map>
                 <key>arguments</key>
                 <array>
-                  <string>SecondLife.sln</string>
+                  <string>..\indra</string>
+                </array>
+                <key>options</key>
+                <array>
+                  <string>-G</string>
+                  <string>${AUTOBUILD_WIN_CMAKE_GEN|NOTWIN}</string>
+                  <string>-A</string>
+                  <string>${AUTOBUILD_WIN_VSPLATFORM|NOTWIN}</string>
                 </array>
               </map>
               <key>name</key>
@@ -3335,26 +3345,12 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             </map>
             <key>ReleaseOS</key>
             <map>
-              <key>configure</key>
-              <map>
-                <key>options</key>
-                <array>
-                  <string>-G</string>
-                  <string>${AUTOBUILD_WIN_CMAKE_GEN|NOTWIN}</string>
-                  <string>-A</string>
-                  <string>${AUTOBUILD_WIN_VSPLATFORM|NOTWIN}</string>
-                  <string>-DUNATTENDED:BOOL=ON</string>
-                  <string>-DINSTALL_PROPRIETARY=FALSE</string>
-                  <string>-DUSE_KDU=FALSE</string>
-                  <string>-DUSE_OPENAL:BOOL=ON</string>
-                </array>
-                <key>arguments</key>
-                <array>
-                  <string>..\indra</string>
-                </array>
-              </map>
               <key>build</key>
               <map>
+                <key>arguments</key>
+                <array>
+                  <string>SecondLife.sln</string>
+                </array>
                 <key>command</key>
                 <string>msbuild.exe</string>
                 <key>options</key>
@@ -3366,35 +3362,39 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>/verbosity:minimal</string>
                   <string>/p:VCBuildAdditionalOptions= /incremental</string>
                 </array>
+              </map>
+              <key>configure</key>
+              <map>
                 <key>arguments</key>
                 <array>
-                  <string>SecondLife.sln</string>
+                  <string>..\indra</string>
+                </array>
+                <key>options</key>
+                <array>
+                  <string>-G</string>
+                  <string>${AUTOBUILD_WIN_CMAKE_GEN|NOTWIN}</string>
+                  <string>-A</string>
+                  <string>${AUTOBUILD_WIN_VSPLATFORM|NOTWIN}</string>
+                  <string>-DUNATTENDED:BOOL=ON</string>
+                  <string>-DINSTALL_PROPRIETARY=FALSE</string>
+                  <string>-DUSE_KDU=FALSE</string>
+                  <string>-DUSE_OPENAL:BOOL=ON</string>
                 </array>
               </map>
               <key>name</key>
               <string>ReleaseOS</string>
             </map>
           </map>
-          <key>build_directory</key>
-          <string>build-vc${AUTOBUILD_VSVER|170}-$AUTOBUILD_ADDRSIZE</string>
           <key>name</key>
           <string>windows</string>
         </map>
       </map>
-      <key>license</key>
-      <string>LGPL</string>
-      <key>license_file</key>
-      <string>docs/LICENSE-source.txt</string>
-      <key>copyright</key>
-      <string>Copyright (c) 2026, Linden Research, Inc.</string>
       <key>version_file</key>
       <string>newview/viewer_version.txt</string>
-      <key>name</key>
-      <string>Second Life Viewer</string>
-      <key>canonical_repo</key>
-      <string>https://github.com/secondlife/viewer</string>
-      <key>description</key>
-      <string>Second Life Viewer</string>
     </map>
+    <key>type</key>
+    <string>autobuild</string>
+    <key>version</key>
+    <string>1.3</string>
   </map>
 </llsd>


### PR DESCRIPTION
Update Dullahan to v1.31 with CEF 148.0.9 (Chromium-148.0.7778.180) for Windows and macOS - Linux to follow.

No code changes to Dullahan or Viewer required.