### PR TITLE
p#604 Fix draw range fluctuations #2

### DIFF
--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -217,9 +217,10 @@ void display_update_camera()
     {
         final_far *= 0.5f;
     }
-    else if (LLViewerTexture::sDesiredDiscardBias > 2.f)
+    // When system memory is critically low or recovering, shrink draw distance.
+    else if (LLViewerTexture::getSystemMemoryBudgetFactor() > 1.f)
     {
-        final_far = llmax(32.f, final_far / (LLViewerTexture::sDesiredDiscardBias - 1.f));
+        final_far = llmax(32.f, final_far / LLViewerTexture::getSystemMemoryBudgetFactor());
     }
     LLViewerCamera::getInstance()->setFar(final_far);
     LLVOAvatar::sRenderDistance = llclamp(final_far, 16.f, 256.f);

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -713,7 +713,7 @@ void LLViewerTexture::updateClass()
         else
         {
             // Slowly ramp up factor to free memory (increasing factor decreases draw range)
-            constexpr F32 MAX_INCREMENT = 0.05;
+            constexpr F32 MAX_INCREMENT = 0.05f;
             F32 increment = MAX_INCREMENT * llmax(-(F32)sys_budget_debt / (F32)budget_target, 0.f);
             sSysMemoryFactor += increment * gFrameIntervalSeconds;
         }
@@ -730,7 +730,7 @@ void LLViewerTexture::updateClass()
         if (free_sys_mem > MEM_THRESHOLD && sSysMemoryFactor > 1.f)
         {
             // Ramp down factor over time.
-            constexpr F32 DECREMENT = 0.02;
+            constexpr F32 DECREMENT = 0.02f;
             sSysMemoryFactor -= DECREMENT * gFrameIntervalSeconds;
             sSysMemoryFactor = llclamp(sSysMemoryFactor, 1.f, 2.f);
         }


### PR DESCRIPTION
Follow up on https://github.com/secondlife/viewer/commit/1d456767fe47773d9dadcaa456b0af31dc6060e5
Missed one use case that was hoocked into bias instead of memory and adjusted variable to not trip VS2026.