### PR TITLE
#5946 Fix excessive 'allowed to terraform' warning

### DIFF
--- a/indra/newview/lltoolbrush.cpp
+++ b/indra/newview/lltoolbrush.cpp
@@ -685,7 +685,10 @@ bool LLToolBrushLand::canTerraformParcel(LLViewerRegion* regionp) const
     if (selected_parcel)
     {
         bool owner_release = LLViewerParcelMgr::isParcelOwnedByAgent(selected_parcel, GP_LAND_ALLOW_EDIT_LAND);
-        is_terraform_allowed = ( gAgent.canManageEstate() || (selected_parcel->getOwnerID() == regionp->getOwner()) || owner_release);
+        is_terraform_allowed = ( regionp->canManageEstate()
+                                 || (selected_parcel->getOwnerID() == regionp->getOwner())
+                                 || owner_release
+                                 || selected_parcel->getAllowTerraform());
     }
 
     return is_terraform_allowed;


### PR DESCRIPTION
canTerraformParcel appears to only be used for gating alertNoTerraformParcel so this should be safe. PF_ALLOW_TERRAFORM flag  is deprecated, but there are still sims with this setting and it should be respected.