### PR TITLE
Clean up feedback on #5918 and #5919

### DIFF
--- a/indra/llui/llflatlistview.cpp
+++ b/indra/llui/llflatlistview.cpp
@@ -486,8 +486,8 @@ LLFlatListView::LLFlatListView(const LLFlatListView::Params& p)
   , mFocusOnItemClicked(true)
   , mAllowReorder(p.allow_reorder)
   , mIsReordering(false)
-  , mReorderDragPair(NULL)
-  , mDeferredSelectPair(NULL)
+  , mReorderDragPair(nullptr)
+  , mDeferredSelectPair(nullptr)
   , mReorderMouseDownX(0)
   , mReorderMouseDownY(0)
   , mReorderInsertIndex(-1)
@@ -785,7 +785,7 @@ void LLFlatListView::onItemRightMouseClick(item_pair_t* item_pair, MASK mask)
     onItemMouseClick(item_pair, mask, CLICK_RIGHT);
 }
 
-static const S32 REORDER_DRAG_THRESHOLD = 5;
+static constexpr S32 REORDER_DRAG_THRESHOLD = 5;
 
 void LLFlatListView::armReorderDrag(item_pair_t* item_pair)
 {
@@ -811,7 +811,7 @@ void LLFlatListView::armReorderDrag(item_pair_t* item_pair)
 
     mReorderDragPair = item_pair;
     mReorderDragGroup.clear();
-    mDeferredSelectPair = NULL;
+    mDeferredSelectPair = nullptr;
     mIsReordering = false;
     mReorderInsertIndex = -1;
 
@@ -821,7 +821,8 @@ void LLFlatListView::armReorderDrag(item_pair_t* item_pair)
 
 void LLFlatListView::updateReorderDrag(S32 x, S32 y)
 {
-    if (!mReorderDragPair) return;
+    if (!mReorderDragPair)
+        return;
 
     if (!mIsReordering)
     {
@@ -845,7 +846,8 @@ void LLFlatListView::buildReorderGroup()
 
     for (item_pair_t* pair : mItemPairs)
     {
-        if (!pair->first->getVisible()) continue;
+        if (!pair->first->getVisible())
+            continue;
 
         if (pair == mReorderDragPair)
         {
@@ -870,7 +872,8 @@ void LLFlatListView::getReorderRemaining(pairs_list_t& remaining) const
     remaining.clear();
     for (item_pair_t* pair : mItemPairs)
     {
-        if (!pair->first->getVisible() || isInReorderGroup(pair)) continue;
+        if (!pair->first->getVisible() || isInReorderGroup(pair))
+            continue;
         remaining.push_back(pair);
     }
 }
@@ -882,12 +885,16 @@ void LLFlatListView::finishReorderDrag()
         pairs_list_t remaining;
         getReorderRemaining(remaining);
 
-        // Resolve the drop boundary to the remaining row it lands before (NULL = append).
-        item_pair_t* anchor = NULL;
+        // Resolve the drop boundary to the remaining row it lands before (nullptr = append).
+        item_pair_t* anchor = nullptr;
         S32 cur = 0;
         for (item_pair_t* pair : remaining)
         {
-            if (cur == mReorderInsertIndex) { anchor = pair; break; }
+            if (cur == mReorderInsertIndex)
+            {
+                anchor = pair;
+                break;
+            }
             ++cur;
         }
 
@@ -898,7 +905,7 @@ void LLFlatListView::finishReorderDrag()
             mItemPairs.remove(pair);
         }
 
-        pairs_iterator_t it = (anchor != NULL)
+        pairs_iterator_t it = (anchor != nullptr)
             ? std::find(mItemPairs.begin(), mItemPairs.end(), anchor)
             : mItemPairs.end();
         for (item_pair_t* pair : mReorderDragGroup)
@@ -913,8 +920,10 @@ void LLFlatListView::finishReorderDrag()
             S32 visible_index = 0;
             for (item_pair_t* pair : mItemPairs)
             {
-                if (!pair->first->getVisible()) continue;
-                if (pair == mReorderDragPair) break;
+                if (!pair->first->getVisible())
+                    continue;
+                if (pair == mReorderDragPair)
+                    break;
                 ++visible_index;
             }
 
@@ -929,7 +938,7 @@ void LLFlatListView::cancelReorderDrag()
 {
     if (hasMouseCapture())
     {
-        gFocusMgr.setMouseCapture(NULL);
+        gFocusMgr.setMouseCapture(nullptr);
     }
 
     clearReorderDragState();
@@ -942,11 +951,11 @@ void LLFlatListView::clearReorderDragState()
         getWindow()->setCursor(UI_CURSOR_ARROW);
     }
 
-    bool was_armed = (mReorderDragPair != NULL);
+    bool was_armed = (mReorderDragPair != nullptr);
 
-    mReorderDragPair = NULL;
+    mReorderDragPair = nullptr;
     mReorderDragGroup.clear();
-    mDeferredSelectPair = NULL;
+    mDeferredSelectPair = nullptr;
     mIsReordering = false;
     mReorderInsertIndex = -1;
 
@@ -981,7 +990,8 @@ S32 LLFlatListView::getInsertIndexAt(S32 x, S32 y) const
     S32 index = 0;
     for (item_pair_t* pair : mItemPairs)
     {
-        if (!pair->first->getVisible() || isInReorderGroup(pair)) continue;
+        if (!pair->first->getVisible() || isInReorderGroup(pair))
+            continue;
 
         if (pair->first->getRect().getCenterY() > panel_y)
         {
@@ -998,7 +1008,8 @@ LLFlatListView::item_pair_t* LLFlatListView::getReorderPairAt(S32 x, S32 y) cons
 
     for (item_pair_t* pair : mItemPairs)
     {
-        if (!pair->first->getVisible()) continue;
+        if (!pair->first->getVisible())
+            continue;
 
         // Claim the padding above each row so gap presses still resolve to a row.
         LLRect rc = pair->first->getRect();
@@ -1008,12 +1019,13 @@ LLFlatListView::item_pair_t* LLFlatListView::getReorderPairAt(S32 x, S32 y) cons
             return pair;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 S32 LLFlatListView::constrainInsertIndex(S32 dest_index) const
 {
-    if (!mReorderValidateCallback) return dest_index;
+    if (!mReorderValidateCallback)
+        return dest_index;
 
     // Clamp the boundary to the contiguous run of remaining rows that share the
     // grabbed row's group, so a drag can't leave its group.
@@ -1028,16 +1040,20 @@ S32 LLFlatListView::constrainInsertIndex(S32 dest_index) const
     {
         if (mReorderValidateCallback(dragged, pair->second))
         {
-            if (first_valid < 0) first_valid = i;
+            if (first_valid < 0)
+                first_valid = i;
             last_valid = i;
         }
         ++i;
     }
 
-    if (first_valid < 0) return -1; // no valid neighbour (whole group is being dragged)
+    if (first_valid < 0)
+        return -1; // no valid neighbour (whole group is being dragged)
 
-    if (dest_index < first_valid) return first_valid;
-    if (dest_index > last_valid + 1) return last_valid + 1;
+    if (dest_index < first_valid)
+        return first_valid;
+    if (dest_index > last_valid + 1)
+        return last_valid + 1;
     return dest_index;
 }
 
@@ -1045,7 +1061,8 @@ void LLFlatListView::drawReorderIndicator()
 {
     pairs_list_t remaining;
     getReorderRemaining(remaining);
-    if (remaining.empty()) return;
+    if (remaining.empty())
+        return;
 
     const LLRect& panel_rc = mItemsPanel->getRect();
     const LLColor4& color = mDragIndicatorColor.get();
@@ -1064,21 +1081,27 @@ void LLFlatListView::drawReorderIndicator()
     bool at_end = mReorderInsertIndex >= count;
     S32 anchor_idx = at_end ? count - 1 : mReorderInsertIndex;
 
-    item_pair_t* anchor = NULL;
+    item_pair_t* anchor = nullptr;
     S32 cur = 0;
     for (item_pair_t* pair : remaining)
     {
-        if (cur == anchor_idx) { anchor = pair; break; }
+        if (cur == anchor_idx)
+        {
+            anchor = pair;
+            break;
+        }
         ++cur;
     }
-    if (!anchor) return;
+    if (!anchor)
+        return;
 
     const LLRect& item_rc = anchor->first->getRect();
     S32 left = panel_rc.mLeft + item_rc.mLeft;
     S32 right = panel_rc.mLeft + item_rc.mRight;
     S32 line_y = panel_rc.mBottom + (at_end ? item_rc.mBottom : item_rc.mTop);
 
-    if (line_y < 0 || line_y > getRect().getHeight()) return;
+    if (line_y < 0 || line_y > getRect().getHeight())
+        return;
 
     gl_rect_2d(left, line_y, right, line_y - 1, color, true);
 }
@@ -1112,7 +1135,7 @@ bool LLFlatListView::handleMouseDown(S32 x, S32 y, MASK mask)
         }
     }
 
-    return handled || (mReorderDragPair != NULL);
+    return handled || (mReorderDragPair != nullptr);
 }
 
 bool LLFlatListView::handleMouseUp(S32 x, S32 y, MASK mask)
@@ -1121,7 +1144,7 @@ bool LLFlatListView::handleMouseUp(S32 x, S32 y, MASK mask)
     {
         bool was_reordering = mIsReordering;
         item_pair_t* deferred = mDeferredSelectPair;
-        mDeferredSelectPair = NULL;
+        mDeferredSelectPair = nullptr;
 
         finishReorderDrag();
 
@@ -1518,7 +1541,7 @@ bool LLFlatListView::removeItemPair(item_pair_t* item_pair, bool rearrange)
     }
     if (item_pair == mDeferredSelectPair)
     {
-        mDeferredSelectPair = NULL;
+        mDeferredSelectPair = nullptr;
     }
 
     bool deleted = false;

--- a/indra/llui/llgestureautocompletehelper.cpp
+++ b/indra/llui/llgestureautocompletehelper.cpp
@@ -43,7 +43,6 @@ void LLGestureAutocompleteHelper::showHelper(
     LLUICtrl* host_ctrl,
     const std::vector<Row>& rows,
     size_t total,
-    const std::string& empty_text,
     std::function<void(std::string)> commit_cb)
 {
     if (mHelperHandle.isDead())
@@ -57,7 +56,6 @@ void LLGestureAutocompleteHelper::showHelper(
     setHostCtrl(host_ctrl);
     mRows = rows;
     mTotal = total;
-    mEmptyText = empty_text;
     mGestureCommitCb = commit_cb;
 
     S32 floater_x, floater_y;
@@ -135,7 +133,6 @@ void LLGestureAutocompleteHelper::setHostCtrl(LLUICtrl* host_ctrl)
         mHostHandle.markDead();
         mGestureCommitCb = {};
         mRows.clear();
-        mEmptyText.clear();
         mTotal = 0;
 
         if (!mHelperHandle.isDead())

--- a/indra/llui/llgestureautocompletehelper.h
+++ b/indra/llui/llgestureautocompletehelper.h
@@ -54,7 +54,6 @@ public:
         LLUICtrl* host_ctrl,
         const std::vector<Row>& rows,
         size_t total,
-        const std::string& empty_text,
         std::function<void(std::string)> commit_cb);
     void hideHelper(const LLUICtrl* ctrl = nullptr);
     bool handleKey(const LLUICtrl* ctrl, KEY key, MASK mask);
@@ -62,7 +61,6 @@ public:
 
     const std::vector<Row>& rows() const { return mRows; }
     size_t total() const { return mTotal; }
-    const std::string& emptyText() const { return mEmptyText; }
 
 protected:
     void setHostCtrl(LLUICtrl* host_ctrl);
@@ -78,6 +76,5 @@ private:
     std::function<void(std::string)> mGestureCommitCb;
 
     std::vector<Row> mRows;
-    std::string mEmptyText;
     size_t mTotal = 0;
 };

--- a/indra/newview/llfloatergestureautocompletepicker.cpp
+++ b/indra/newview/llfloatergestureautocompletepicker.cpp
@@ -66,17 +66,6 @@ void LLFloaterGestureAutocompletePicker::onOpen(const LLSD& key)
         mGestureList->addElement(element);
     }
 
-    if (rows.empty() && !helper.emptyText().empty())
-    {
-        LLSD element;
-        element["enabled"] = false;
-        element["columns"][0]["column"] = "trigger";
-        element["columns"][0]["value"] = helper.emptyText();
-        element["columns"][1]["column"] = "name";
-        element["columns"][1]["value"] = LLStringUtil::null;
-        mGestureList->addElement(element);
-    }
-
     if (helper.total() > rows.size())
     {
         LLSD element;

--- a/indra/newview/llfloaterimnearbychat.cpp
+++ b/indra/newview/llfloaterimnearbychat.cpp
@@ -87,12 +87,10 @@ namespace
 bool buildGestureAutocompleteRows(
     const std::string& prefix,
     std::vector<LLGestureAutocompleteHelper::Row>& rows,
-    size_t& total,
-    std::string& empty_text)
+    size_t& total)
 {
     rows.clear();
     total = 0;
-    empty_text.clear();
 
     // Wait for at least one character after the slash before offering matches.
     if (prefix.size() < 2 || prefix[0] != '/' || prefix.find_first_of(" \t") != std::string::npos)
@@ -128,20 +126,17 @@ bool buildGestureAutocompleteRows(
             gesture->mName);
     }
 
-    for (const auto& gesture : unique)
+    for (const auto& [trigger, name] : unique)
     {
-        ++total;
-
-        if (rows.size() < MAX_GESTURE_AUTOCOMPLETE_ROWS)
+        if (rows.size() >= MAX_GESTURE_AUTOCOMPLETE_ROWS)
         {
-            rows.push_back({ gesture.first, gesture.first, gesture.second });
+            break;
         }
+
+        rows.push_back({ trigger, trigger, name });
     }
 
-    if (rows.empty())
-    {
-        empty_text = "No matching gestures";
-    }
+    total = unique.size();
 
     return total > 0;
 }
@@ -576,16 +571,14 @@ void LLFloaterIMNearbyChat::onChatBoxKeystroke()
     {
         std::vector<LLGestureAutocompleteHelper::Row> rows;
         size_t total = 0;
-        std::string empty_text;
         const std::string utf8_trigger = wstring_to_utf8str(raw_text);
 
-        if (buildGestureAutocompleteRows(utf8_trigger, rows, total, empty_text))
+        if (buildGestureAutocompleteRows(utf8_trigger, rows, total))
         {
             LLGestureAutocompleteHelper::instance().showHelper(
                 mInputEditor,
                 rows,
                 total,
-                empty_text,
                 [this](std::string trigger)
                 {
                     mInputEditor->setText(trigger + " ");


### PR DESCRIPTION
Quick follow up on #5918 and #5919, from some post-merge feedback that @Ansariel gave on the commits for my earlier clothing layer reorder and gesture autocomplete PRs.

Clothing layer reorder `llflatlistview`

- Formatting adjustments on new code
- `NULL` to `nullptr` in the new code
- `REORDER_DRAG_THRESHOLD` made `constexpr`

Gesture autocomplete `llfloaterimnearbychat`

- Tidied the row-building loop
- Remove `empty_text` code path, since it's unreachable (rather than add locales)