### PR TITLE
#5962 Optimize writeWearablesToAvatar

### DIFF
--- a/indra/llappearance/llwearable.cpp
+++ b/indra/llappearance/llwearable.cpp
@@ -727,17 +727,22 @@ void LLWearable::writeToAvatar(LLAvatarAppearance* avatarp)
     if (!avatarp) return;
 
     // Pull params
-    for( const LLVisualParam* param = avatarp->getFirstVisualParam(); param; param = avatarp->getNextVisualParam() )
+    // Iterate over wearable's params first since they should be fewer than avatar params.
+    // Wearables are cloned from avatar params by mType, so they should be always be a
+    // subset of the avatar's params and a situation where mType param doesn't exist in
+    // a wearable yet exist in the avatar should not happen.
+    for (const visual_param_index_map_t::value_type& vp_pair : mVisualParamIndexMap)
     {
+        LLVisualParam* wearable_param = vp_pair.second;
+
         // cross-wearable parameters are not authoritative, as they are driven by a different wearable. So don't copy the values to the
         // avatar object if cross wearable. Cross wearable params get their values from the avatar, they shouldn't write the other way.
-        if( (((LLViewerVisualParam*)param)->getWearableType() == mType) && (!((LLViewerVisualParam*)param)->getCrossWearable()) )
-        {
-            S32 param_id = param->getID();
-            F32 weight = getVisualParamWeight(param_id);
+        if (((LLViewerVisualParam*)wearable_param)->getCrossWearable())
+            continue;
 
-            avatarp->setVisualParamWeight( param_id, weight);
-        }
+        F32 weight = wearable_param->getWeight();
+        // Silently fails if param was not found
+        avatarp->setVisualParamWeight(vp_pair.first, mType, weight);
     }
 }
 

--- a/indra/llcharacter/llcharacter.cpp
+++ b/indra/llcharacter/llcharacter.cpp
@@ -307,6 +307,31 @@ bool LLCharacter::setVisualParamWeight(S32 index, F32 weight)
 }
 
 //-----------------------------------------------------------------------------
+// setVisualParamWeight()
+//-----------------------------------------------------------------------------
+bool LLCharacter::setVisualParamWeight(S32 index, S32 type, F32 weight)
+{
+    visual_param_index_map_t::iterator index_iter = mVisualParamIndexMap.find(index);
+    if (index_iter != mVisualParamIndexMap.end())
+    {
+        LLVisualParam* param = index_iter->second;
+        if (param->getWearableType() == type)
+        {
+            param->setWeight(weight);
+            return true;
+        }
+        else
+        {
+            // setVisualParamWeight at the moment is only used in writeToAvatar.
+            // The type is supposed to match since wearable is a subset of avatar by type.
+            llassert(false);
+            LL_WARNS() << "Visual param index " << index << " is not of type " << type << LL_ENDL;
+        }
+    }
+    return false;
+}
+
+//-----------------------------------------------------------------------------
 // getVisualParamWeight()
 //-----------------------------------------------------------------------------
 F32 LLCharacter::getVisualParamWeight(LLVisualParam *which_param)

--- a/indra/llcharacter/llcharacter.h
+++ b/indra/llcharacter/llcharacter.h
@@ -195,6 +195,7 @@ public:
     virtual bool setVisualParamWeight(const LLVisualParam *which_param, F32 weight);
     virtual bool setVisualParamWeight(const char* param_name, F32 weight);
     virtual bool setVisualParamWeight(S32 index, F32 weight);
+    virtual bool setVisualParamWeight(S32 index, S32 type, F32 weight);
 
     // get visual param weight by param or name
     F32 getVisualParamWeight(LLVisualParam *distortion);

--- a/indra/llcharacter/llvisualparam.h
+++ b/indra/llcharacter/llvisualparam.h
@@ -120,6 +120,7 @@ public:
     //  Pure virtuals
     //virtual bool          parseData( LLXmlTreeNode *node ) = 0;
     virtual void            apply( ESex avatar_sex ) = 0;
+    virtual S32             getWearableType() const = 0;
     //  Default functions
     virtual void            setWeight(F32 weight);
     virtual void            setAnimationTarget( F32 target_value);

--- a/indra/llrender/llvertexbuffer.cpp
+++ b/indra/llrender/llvertexbuffer.cpp
@@ -939,12 +939,14 @@ void LLVertexBuffer::initClass(LLWindow* window)
 {
     llassert(sVBOPool == nullptr);
 
+#if LL_DARWIN || LL_ARM64
     if (gGLManager.mIsApple)
     {
         LL_INFOS() << "VBO Pooling Disabled" << LL_ENDL;
         sVBOPool = new LLAppleVBOPool();
     }
     else
+#endif
     {
         LL_INFOS() << "VBO Pooling Enabled" << LL_ENDL;
         sVBOPool = new LLDefaultVBOPool();
@@ -1282,7 +1284,12 @@ U8* LLVertexBuffer::mapVertexBuffer(LLVertexBuffer::AttributeType type, U32 inde
         count = mNumVerts - index;
     }
 
+#if LL_DARWIN || LL_ARM64
+    // Region tracking not needed on apple silicon - it recreates entire buffer
+    // While mIsApple can be encountered under windows, this is a
+    // macOS OpenGL behavior workaround. LL_ARM64 check might be not needed
     if (!gGLManager.mIsApple)
+#endif
     {
         U32 start = mOffsets[type] + sTypeSize[type] * index;
         U32 end = start + sTypeSize[type] * count-1;
@@ -1319,7 +1326,9 @@ U8* LLVertexBuffer::mapIndexBuffer(U32 index, S32 count)
         count = mNumIndices-index;
     }
 
+#if LL_DARWIN || LL_ARM64
     if (!gGLManager.mIsApple)
+#endif
     {
         U32 start = sizeof(U16) * index;
         U32 end = start + sizeof(U16) * count-1;
@@ -1354,6 +1363,7 @@ U8* LLVertexBuffer::mapIndexBuffer(U32 index, S32 count)
 //  dst -- mMappedData or mMappedIndexData
 void LLVertexBuffer::flush_vbo(GLenum target, U32 start, U32 end, void* data, U8* dst)
 {
+#if LL_DARWIN || LL_ARM64
     if (gGLManager.mIsApple)
     {
         // on OS X, flush_vbo doesn't actually write to the GL buffer, so be sure to call
@@ -1365,6 +1375,7 @@ void LLVertexBuffer::flush_vbo(GLenum target, U32 start, U32 end, void* data, U8
         memcpy(dst+start, data, end-start+1);
     }
     else
+#endif
     {
         llassert(target == GL_ARRAY_BUFFER ? sGLRenderBuffer == mGLBuffer : sGLRenderIndices == mGLIndices);
 
@@ -1420,6 +1431,7 @@ void LLVertexBuffer::_unmapBuffer()
         }
     };
 
+#if LL_DARWIN || LL_ARM64
     if (gGLManager.mIsApple)
     {
         STOP_GLERROR;
@@ -1462,6 +1474,7 @@ void LLVertexBuffer::_unmapBuffer()
         STOP_GLERROR;
     }
     else
+#endif // LL_DARWIN || LL_ARM64
     {
         if (!mMappedVertexRegions.empty())
         {

--- a/indra/newview/llvoavatarself.cpp
+++ b/indra/newview/llvoavatarself.cpp
@@ -754,6 +754,27 @@ bool LLVOAvatarSelf::setVisualParamWeight(S32 index, F32 weight)
     return setParamWeight(param,weight);
 }
 
+bool LLVOAvatarSelf::setVisualParamWeight(S32 index, S32 type, F32 weight)
+{
+    LLViewerVisualParam* param = (LLViewerVisualParam*)LLCharacter::getVisualParam(index);
+    if (!param)
+    {
+        return false;
+    }
+    if (param->getWearableType() == type)
+    {
+        return setParamWeight(param, weight);
+    }
+    else
+    {
+        // setVisualParamWeight at the moment is only used in writeToAvatar.
+        // The type is supposed to match since wearable is a subset of avatar by type.
+        llassert(false);
+        LL_WARNS() << "Visual param index " << index << " is not of type " << type << LL_ENDL;
+    }
+    return false;
+}
+
 bool LLVOAvatarSelf::setParamWeight(const LLViewerVisualParam *param, F32 weight)
 {
     if (!param)

--- a/indra/newview/llvoavatarself.h
+++ b/indra/newview/llvoavatarself.h
@@ -97,6 +97,7 @@ public:
     /*virtual*/ bool setVisualParamWeight(const LLVisualParam *which_param, F32 weight);
     /*virtual*/ bool setVisualParamWeight(const char* param_name, F32 weight);
     /*virtual*/ bool setVisualParamWeight(S32 index, F32 weight);
+    /*virtual*/ bool setVisualParamWeight(S32 index, S32 type, F32 weight);
     /*virtual*/ void updateVisualParams();
     void writeWearablesToAvatar();
     /*virtual*/ void idleUpdateAppearanceAnimation();


### PR DESCRIPTION
Avatar has hundreds of params, werables usually have significantly less and is a subset of an avatar, don't do pointless checks over every param when we are only interested in ones matching current wearable.

Testing shows ~90mks instead of ~160mks for an outfit with 6 wearables in a 3ms frame. Result can warry greatly but the more wearables the bigger the win in mks.