### PR TITLE
Fix missing CJK/Indic text on Linux with lazy font fallback

### DIFF
--- a/indra/llrender/llfontfreetype.cpp
+++ b/indra/llrender/llfontfreetype.cpp
@@ -52,6 +52,7 @@
 //#include "imdebug.h"
 #include "llfontbitmapcache.h"
 #include "llgl.h"
+#include "llwindow.h"
 
 #define ENABLE_OT_SVG_SUPPORT
 
@@ -188,7 +189,7 @@ bool LLFontFreetype::loadFace(const std::string& filename, F32 point_size, F32 v
         return false;
 
     openArgs.flags = FT_OPEN_MEMORY;
-    int error = FT_Open_Face( gFTLibrary, &openArgs, 0, &mFTFace );
+    int error = FT_Open_Face( gFTLibrary, &openArgs, face_n, &mFTFace );
 
     if (error)
         return false;
@@ -197,6 +198,9 @@ bool LLFontFreetype::loadFace(const std::string& filename, F32 point_size, F32 v
     mHinting = hinting;
     mFontFlags = flags;
     mWeight = weight;
+    mFaceIndex = face_n;
+    mVertDPI = vert_dpi;
+    mHorzDPI = horz_dpi;
 
     bool variable_font = false;
     if (weight >= 0)
@@ -314,7 +318,7 @@ S32 LLFontFreetype::getNumFaces(const std::string& filename)
 }
 
 void LLFontFreetype::addFallbackFont(const LLPointer<LLFontFreetype>& fallback_font,
-                                     const char_functor_t& functor)
+                                     const char_functor_t& functor) const
 {
     mFallbackFonts.emplace_back(fallback_font, functor);
 }
@@ -419,6 +423,18 @@ bool LLFontFreetype::hasGlyph(llwchar wch) const
     return(mCharGlyphInfoMap.find(wch) != mCharGlyphInfoMap.end());
 }
 
+bool LLFontFreetype::hasFallbackPath(const std::string& path) const
+{
+    for (const fallback_font_t& pair : mFallbackFonts)
+    {
+        if (pair.first->getName() == path)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 LLFontGlyphInfo* LLFontFreetype::addGlyph(llwchar wch, EFontGlyphType glyph_type) const
 {
     if (!mFTFace)
@@ -499,6 +515,31 @@ LLFontGlyphInfo* LLFontFreetype::addGlyph(llwchar wch, EFontGlyphType glyph_type
             {
                 return addGlyphFromFont(pair.first, wch, glyph_index,
                                         glyph_type);
+            }
+        }
+
+        // Nothing above covers this char: ask the OS for a font that does,
+        // load it and attach it.
+        if (mAttemptedFallbackChars.insert(wch).second)
+        {
+            LLFontFallbackMatch match = LLWindow::findFallbackFontForChar(wch);
+            if (!match.mPath.empty() && !hasFallbackPath(match.mPath))
+            {
+                LLPointer<LLFontFreetype> fallback = new LLFontFreetype;
+                if (fallback->loadFace(match.mPath, mPointSize, mVertDPI, mHorzDPI,
+                                       /*weight*/ -1, /*is_fallback*/ true,
+                                       match.mFaceIndex, mHinting, mFontFlags))
+                {
+                    glyph_index = FT_Get_Char_Index(fallback->mFTFace, wch);
+                    if (glyph_index)
+                    {
+                        LL_DEBUGS("Font") << "Lazy OS fallback for U+" << std::hex << (U32)wch << std::dec
+                                          << ": " << match.mPath << " (face " << match.mFaceIndex << ")" << LL_ENDL;
+                        addFallbackFont(fallback, nullptr);
+                        return addGlyphFromFont(fallback, wch, glyph_index, glyph_type);
+                    }
+                    // Matched font doesn't actually cover wch: discard it.
+                }
             }
         }
     }
@@ -728,7 +769,7 @@ void LLFontFreetype::renderGlyph(EFontGlyphType bitmap_type, U32 glyph_index, ll
 void LLFontFreetype::reset(F32 vert_dpi, F32 horz_dpi)
 {
     resetBitmapCache();
-    loadFace(mName, mPointSize, vert_dpi ,horz_dpi, mWeight, mIsFallback, 0, mHinting, mFontFlags);
+    loadFace(mName, mPointSize, vert_dpi ,horz_dpi, mWeight, mIsFallback, mFaceIndex, mHinting, mFontFlags);
     if (!mIsFallback)
     {
         // This is the head of the list - need to rebuild ourself and all fallbacks.

--- a/indra/llrender/llfontfreetype.h
+++ b/indra/llrender/llfontfreetype.h
@@ -34,6 +34,7 @@
 #include "llfontbitmapcache.h"
 
 #include <unordered_map>
+#include <unordered_set>
 
 // Hack.  FT_Face is just a typedef for a pointer to a struct,
 // but there's no simple forward declarations file for FreeType,
@@ -108,7 +109,7 @@ public:
     S32 getNumFaces(const std::string& filename);
 
     typedef std::function<bool(llwchar)> char_functor_t;
-    void addFallbackFont(const LLPointer<LLFontFreetype>& fallback_font, const char_functor_t& functor = nullptr);
+    void addFallbackFont(const LLPointer<LLFontFreetype>& fallback_font, const char_functor_t& functor = nullptr) const;
 
     // Global font metrics - in units of pixels
     F32 getLineHeight() const;
@@ -167,6 +168,7 @@ private:
     bool setSubImageBGRA(U32 x, U32 y, U32 bitmap_num, U16 width, U16 height, const U8* data, U32 stride) const;
     bool setVariationAxis(const std::string& axis_tag, F32 value);
     bool hasGlyph(llwchar wch) const;       // Has a glyph for this character
+    bool hasFallbackPath(const std::string& path) const; // Is a fallback font with this file path already attached?
     LLFontGlyphInfo* addGlyph(llwchar wch, EFontGlyphType glyph_type) const;        // Add a new character to the font if necessary
     LLFontGlyphInfo* addGlyphFromFont(
         const LLFontFreetype *fontp,
@@ -191,9 +193,15 @@ private:
     EFontHinting mHinting;
     S32 mFontFlags;
     S32 mWeight = -1;
+    S32 mFaceIndex = 0; // Face index within the (possibly collection) font file
+    F32 mVertDPI = 0.f; // Kept so lazily-discovered fallback faces can be
+    F32 mHorzDPI = 0.f; // opened at this font's size (see addGlyph)
     typedef std::pair<LLPointer<LLFontFreetype>, char_functor_t> fallback_font_t;
     typedef std::vector<fallback_font_t> fallback_font_vector_t;
-    fallback_font_vector_t mFallbackFonts; // A list of fallback fonts to look for glyphs in (for Unicode chars)
+    // mutable: fallback fonts are also discovered lazily in addGlyph (const)
+    mutable fallback_font_vector_t mFallbackFonts; // A list of fallback fonts to look for glyphs in (for Unicode chars)
+    // Codepoints we've already asked the OS about, so we only query once each
+    mutable std::unordered_set<llwchar> mAttemptedFallbackChars;
 
     // *NOTE: the same glyph can be present with multiple representations (but the pointer is always unique)
     typedef std::unordered_multimap<llwchar, LLFontGlyphInfo*> char_glyph_info_map_t;

--- a/indra/llwindow/llwindow.cpp
+++ b/indra/llwindow/llwindow.cpp
@@ -268,6 +268,20 @@ std::vector<std::string> LLWindow::getDynamicFallbackFontList()
 }
 
 // static
+LLFontFallbackMatch LLWindow::findFallbackFontForChar(llwchar wch)
+{
+#if LL_SDL_WINDOW && !LL_MESA_HEADLESS
+    return LLWindowSDL::findFallbackFontForChar(wch);
+#elif LL_WINDOWS
+    return LLWindowWin32::findFallbackFontForChar(wch);
+#elif LL_DARWIN
+    return LLWindowMacOSX::findFallbackFontForChar(wch);
+#else
+    return LLFontFallbackMatch();
+#endif
+}
+
+// static
 std::vector<std::string> LLWindow::getDisplaysResolutionList()
 {
 #if LL_SDL_WINDOW && !LL_MESA_HEADLESS

--- a/indra/llwindow/llwindow.h
+++ b/indra/llwindow/llwindow.h
@@ -38,6 +38,13 @@ class LLSplashScreen;
 class LLPreeditor;
 class LLWindowCallbacks;
 
+// Result of an OS font-fallback query; empty mPath means no font was found.
+struct LLFontFallbackMatch
+{
+    std::string mPath;
+    S32 mFaceIndex = 0;
+};
+
 // Refer to llwindow_test in test/common/llwindow for usage example
 
 class LLWindow : public LLInstanceTracker<LLWindow>
@@ -182,6 +189,9 @@ public:
     virtual void spawnWebBrowser(const std::string& escaped_url, bool async) {};
 
     static std::vector<std::string> getDynamicFallbackFontList();
+
+    // Ask the OS for a font file covering the given codepoint (lazy fallback).
+    static LLFontFallbackMatch findFallbackFontForChar(llwchar wch);
 
     // Provide native key event data
     virtual LLSD getNativeKeyData() { return LLSD::emptyMap(); }

--- a/indra/llwindow/llwindowmacosx.cpp
+++ b/indra/llwindow/llwindowmacosx.cpp
@@ -2633,6 +2633,12 @@ std::vector<std::string> LLWindowMacOSX::getDynamicFallbackFontList()
     return std::vector<std::string>();
 }
 
+LLFontFallbackMatch LLWindowMacOSX::findFallbackFontForChar(llwchar wch)
+{
+    // Not implemented on macOS; would use CoreText (CTFontCreateForString).
+    return LLFontFallbackMatch();
+}
+
 // static
 MASK LLWindowMacOSX::modifiersToMask(S16 modifiers)
 {

--- a/indra/llwindow/llwindowmacosx.h
+++ b/indra/llwindow/llwindowmacosx.h
@@ -117,6 +117,7 @@ public:
     static std::vector<std::string> getDisplaysResolutionList();
 
     static std::vector<std::string> getDynamicFallbackFontList();
+    static LLFontFallbackMatch findFallbackFontForChar(llwchar wch);
 
     // Provide native key event data
     LLSD getNativeKeyData() override;

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -45,6 +45,8 @@
 #include <glib.h>
 #endif
 
+#include <algorithm>
+
 extern "C" {
 # include "fontconfig/fontconfig.h"
 }
@@ -1879,100 +1881,54 @@ void LLWindowSDL::bringToFront()
 //static
 std::vector<std::string> LLWindowSDL::getDynamicFallbackFontList()
 {
-    std::vector<std::string> rtns;
+    // Lazy-loaded fonts, seeded with fonts.xml
+    return std::vector<std::string>();
+}
+
+LLFontFallbackMatch LLWindowSDL::findFallbackFontForChar(llwchar wch)
+{
+    LLFontFallbackMatch result;
 #if LL_LINUX
-    // Use libfontconfig to find us a nice ordered list of fallback fonts
-    // specific to this system.
-    std::string final_fallback("/usr/share/fonts/truetype/kochi/kochi-gothic.ttf");
-    const int max_font_count_cutoff = 40; // fonts are expensive in the current system, don't enumerate an arbitrary number of them
-    // Our 'ideal' font properties which define the sorting results.
-    // slant=0 means Roman, index=0 means the first face in a font file
-    // (the one we actually use), weight=80 means medium weight,
-    // spacing=0 means proportional spacing.
-    std::string sort_order("slant=0:index=0:weight=80:spacing=0");
-    // elide_unicode_coverage removes fonts from the list whose unicode
-    // range is covered by fonts earlier in the list.  This usually
-    // removes ~90% of the fonts as redundant (which is great because
-    // the font list can be huge), but might unnecessarily reduce the
-    // renderable range if for some reason our FreeType actually fails
-    // to use some of the fonts we want it to.
-    const bool elide_unicode_coverage = true;
-
-    FcFontSet *fs = nullptr;
-    FcPattern *sortpat = nullptr;
-
-    LL_INFOS() << "Getting system font list from FontConfig..." << LL_ENDL;
-
-    // If the user has a system-wide language preference, then favor
-    // fonts from that language group.  This doesn't affect the types
-    // of languages that can be displayed, but ensures that their
-    // preferred language is rendered from a single consistent font where
-    // possible.
-    FL_Locale *locale = nullptr;
-    FL_Success success = FL_FindLocale(&locale, FL_MESSAGES);
-    if (success != 0)
-    {
-        if (success >= 2 && locale->lang) // confident!
-        {
-            LL_INFOS("AppInit") << "Language " << locale->lang << LL_ENDL;
-            LL_INFOS("AppInit") << "Location " << locale->country << LL_ENDL;
-            LL_INFOS("AppInit") << "Variant " << locale->variant << LL_ENDL;
-
-            LL_INFOS() << "Preferring fonts of language: "
-                       << locale->lang
-                       << LL_ENDL;
-            sort_order = "lang=" + std::string(locale->lang) + ":"
-                         + sort_order;
-        }
-    }
-    FL_FreeLocale(&locale);
-
     if (!FcInit())
     {
-        LL_WARNS() << "FontConfig failed to initialize." << LL_ENDL;
-        rtns.push_back(final_fallback);
-        return rtns;
+        LL_WARNS_ONCE() << "FontConfig failed to initialize." << LL_ENDL;
+        return result;
     }
 
-    sortpat = FcNameParse((FcChar8*) sort_order.c_str());
-    if (sortpat)
-    {
-        // Sort the list of system fonts from most-to-least-desirable.
-        FcResult result;
-        fs = FcFontSort(nullptr, sortpat, elide_unicode_coverage, nullptr, &result);
-        FcPatternDestroy(sortpat);
-    }
+    // Ask FontConfig for the best font covering this codepoint.
+    FcCharSet* charset = FcCharSetCreate();
+    FcCharSetAddChar(charset, (FcChar32)wch);
 
-    int found_font_count = 0;
-    if (fs)
+    FcPattern* pat = FcPatternCreate();
+    FcPatternAddCharSet(pat, FC_CHARSET, charset);
+    FcPatternAddBool(pat, FC_SCALABLE, FcTrue);
+
+    FcConfigSubstitute(nullptr, pat, FcMatchPattern);
+    FcDefaultSubstitute(pat);
+
+    FcResult fc_result;
+    FcPattern* match = FcFontMatch(nullptr, pat, &fc_result);
+    if (match)
     {
-        // Get the full pathnames to the fonts, where available,
-        // which is what we really want.
-        found_font_count = fs->nfont;
-        for (int i=0; i<fs->nfont; ++i)
+        FcChar8* filename = nullptr;
+        if (FcResultMatch == FcPatternGetString(match, FC_FILE, 0, &filename) && filename)
         {
-            FcChar8 *filename;
-            if (FcResultMatch == FcPatternGetString(fs->fonts[i], FC_FILE, 0, &filename) && filename)
+            result.mPath = (const char*)filename;
+
+            // .ttc/.otc collections carry several faces; get the right one.
+            int index = 0;
+            if (FcResultMatch == FcPatternGetInteger(match, FC_INDEX, 0, &index))
             {
-                rtns.push_back(std::string((const char*)filename));
-                if (rtns.size() >= max_font_count_cutoff)
-                    break; // hit limit
+                result.mFaceIndex = index;
             }
         }
-        FcFontSetDestroy (fs);
+        FcPatternDestroy(match);
     }
 
-    LL_DEBUGS() << "Using font list: " << LL_ENDL;
-    for (auto it = rtns.begin(); it != rtns.end(); ++it)
-    {
-        LL_DEBUGS() << "  file: " << *it << LL_ENDL;
-    }
-
-    LL_INFOS() << "Using " << rtns.size() << "/" << found_font_count << " system fonts." << LL_ENDL;
-
-    rtns.push_back(final_fallback);
+    FcPatternDestroy(pat);
+    FcCharSetDestroy(charset);
 #endif
-    return rtns;
+    return result;
 }
 
 void LLWindowSDL::setLanguageTextInput(const LLCoordGL& position)

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -45,8 +45,6 @@
 #include <glib.h>
 #endif
 
-#include <algorithm>
-
 extern "C" {
 # include "fontconfig/fontconfig.h"
 }
@@ -1889,7 +1887,10 @@ LLFontFallbackMatch LLWindowSDL::findFallbackFontForChar(llwchar wch)
 {
     LLFontFallbackMatch result;
 #if LL_LINUX
-    if (!FcInit())
+    // FcInit() is idempotent, but this runs per missing codepoint, so only
+    // attempt initialization once.
+    static bool fc_ready = FcInit();
+    if (!fc_ready)
     {
         LL_WARNS_ONCE() << "FontConfig failed to initialize." << LL_ENDL;
         return result;
@@ -1897,9 +1898,16 @@ LLFontFallbackMatch LLWindowSDL::findFallbackFontForChar(llwchar wch)
 
     // Ask FontConfig for the best font covering this codepoint.
     FcCharSet* charset = FcCharSetCreate();
+    FcPattern* pat = FcPatternCreate();
+    if (!charset || !pat)
+    {
+        if (charset) FcCharSetDestroy(charset);
+        if (pat) FcPatternDestroy(pat);
+        return result;
+    }
+
     FcCharSetAddChar(charset, (FcChar32)wch);
 
-    FcPattern* pat = FcPatternCreate();
     FcPatternAddCharSet(pat, FC_CHARSET, charset);
     FcPatternAddBool(pat, FC_SCALABLE, FcTrue);
 

--- a/indra/llwindow/llwindowsdl.h
+++ b/indra/llwindow/llwindowsdl.h
@@ -157,6 +157,7 @@ public:
     void setTitle(const std::string title) override;
 
     static std::vector<std::string> getDynamicFallbackFontList();
+    static LLFontFallbackMatch findFallbackFontForChar(llwchar wch);
 
     void *createSharedContext() override;
     void makeContextCurrent(void *context) override;

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -4736,6 +4736,12 @@ std::vector<std::string> LLWindowWin32::getDynamicFallbackFontList()
     // Fonts previously in getFontListSans() have moved to fonts.xml.
     return std::vector<std::string>();
 }
+
+LLFontFallbackMatch LLWindowWin32::findFallbackFontForChar(llwchar wch)
+{
+    // Not implemented on Windows; would use DirectWrite (IDWriteFontFallback::MapCharacters).
+    return LLFontFallbackMatch();
+}
 #endif // LL_WINDOWS
 
 inline LLWindowWin32::LLWindowWin32Thread::LLWindowWin32Thread()

--- a/indra/llwindow/llwindowwin32.h
+++ b/indra/llwindow/llwindowwin32.h
@@ -127,6 +127,7 @@ public:
     static PROC WINAPI getProcAddress(const char* func);
     static std::vector<std::string> getDisplaysResolutionList();
     static std::vector<std::string> getDynamicFallbackFontList();
+    static LLFontFallbackMatch findFallbackFontForChar(llwchar wch);
     static void setDPIAwareness();
 
     void* getDirectInput8() override;


### PR DESCRIPTION
Resolve fallback fonts per-glyph from FontConfig on demand instead of a truncated static list. This is a general improvement over the prior system, which simply slurped up 40 sorted fonts from the OS, causing missing characters on systems with many fonts. The newer system should result in less fonts being loaded, which is a nice bonus.

Closes #5991

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).
