### PR TITLE
#5995 Fix azure translation not accepting large keys

### DIFF
--- a/indra/newview/lltranslate.cpp
+++ b/indra/newview/lltranslate.cpp
@@ -807,17 +807,7 @@ LLSD LLAzureTranslationHandler::sendMessageAndSuspend(LLCoreHttpUtil::HttpCorout
     LLCore::BufferArray::ptr_t rawbody(new LLCore::BufferArray);
     LLCore::BufferArrayStream outs(rawbody.get());
 
-    // Azure Translator API expects UTF-8 encoded JSON with properly escaped special characters
-    std::string json_escaped_msg = msg;
-    LLStringUtil::replaceString(json_escaped_msg, "\\", "\\\\");  // Escape backslashes first
-    LLStringUtil::replaceString(json_escaped_msg, "\"", "\\\"");  // Escape quotes
-    LLStringUtil::replaceString(json_escaped_msg, "\n", "\\n");   // Escape newlines
-    LLStringUtil::replaceString(json_escaped_msg, "\r", "\\r");   // Escape carriage returns
-    LLStringUtil::replaceString(json_escaped_msg, "\t", "\\t");   // Escape tabs
-
-    outs << "[{\"text\":\"";
-    outs << json_escaped_msg;
-    outs << "\"}]";
+    outs << boost::json::serialize(boost::json::array{ boost::json::object{{ "text", msg }} });
 
     return adapter->postRawAndSuspend(request, url, rawbody, options, headers);
 }

--- a/indra/newview/lltranslate.cpp
+++ b/indra/newview/lltranslate.cpp
@@ -155,7 +155,7 @@ void LLTranslationAPIHandler::verifyKeyCoro(LLTranslate::EService service, LLSD 
 {
     LLCore::HttpRequest::policy_t httpPolicy(LLCore::HttpRequest::DEFAULT_POLICY_ID);
     LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t
-        httpAdapter = std::make_shared<LLCoreHttpUtil::HttpCoroutineAdapter>("getMerchantStatusCoro", httpPolicy);
+        httpAdapter = std::make_shared<LLCoreHttpUtil::HttpCoroutineAdapter>("verifyKeyCoro", httpPolicy);
     LLCore::HttpRequest::ptr_t httpRequest = std::make_shared<LLCore::HttpRequest>();
     LLCore::HttpOptions::ptr_t httpOpts = std::make_shared<LLCore::HttpOptions>();
     LLCore::HttpHeaders::ptr_t httpHeaders = std::make_shared<LLCore::HttpHeaders>();
@@ -807,12 +807,16 @@ LLSD LLAzureTranslationHandler::sendMessageAndSuspend(LLCoreHttpUtil::HttpCorout
     LLCore::BufferArray::ptr_t rawbody(new LLCore::BufferArray);
     LLCore::BufferArrayStream outs(rawbody.get());
 
-    static const std::string allowed_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz "
-                                             "0123456789"
-                                             "-._~";
+    // Azure Translator API expects UTF-8 encoded JSON with properly escaped special characters
+    std::string json_escaped_msg = msg;
+    LLStringUtil::replaceString(json_escaped_msg, "\\", "\\\\");  // Escape backslashes first
+    LLStringUtil::replaceString(json_escaped_msg, "\"", "\\\"");  // Escape quotes
+    LLStringUtil::replaceString(json_escaped_msg, "\n", "\\n");   // Escape newlines
+    LLStringUtil::replaceString(json_escaped_msg, "\r", "\\r");   // Escape carriage returns
+    LLStringUtil::replaceString(json_escaped_msg, "\t", "\\t");   // Escape tabs
 
     outs << "[{\"text\":\"";
-    outs << LLURI::escape(msg, allowed_chars);
+    outs << json_escaped_msg;
     outs << "\"}]";
 
     return adapter->postRawAndSuspend(request, url, rawbody, options, headers);

--- a/indra/newview/skins/default/xui/en/floater_translation_settings.xml
+++ b/indra/newview/skins/default/xui/en/floater_translation_settings.xml
@@ -228,7 +228,7 @@
   height="20"
   layout="topleft"
   left_pad="10"
-  max_length_chars="50"
+  max_length_chars="100"
   top_delta="-4"
   name="azure_api_key"
   width="210" />


### PR DESCRIPTION
- Fix azure translation not accepting large keys, kays are now of varried length and can go at least to 80 characters.
- Fix escaping, this is json data, not url. It was preventing emojis from comming through.

P.S. wasn't able to retrieve azure keys (I think I used a temporary one before?), someone will need to verify this works.