### PR TITLE
Fix audio level ducking of applications when viewer webrtc is enabled.

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2607,11 +2607,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>c70247d7683312ee81149dbae603574c0851e04c</string>
+              <string>95ad8f723f2c83507427611e6c36a23cbd03eacd</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.16/webrtc-m144.7559.06.16.28218655958-darwin64-28218655958.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.17/webrtc-m144.7559.06.17.29445196263-darwin64-29445196263.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -2621,11 +2621,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>d187fd666eec8c14dbef959cdc9a6600a13736c7</string>
+              <string>62474b4c7645760c4e2096df62693293cde04e8b</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.16/webrtc-m144.7559.06.16.28218655958-linux64-28218655958.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.17/webrtc-m144.7559.06.17.29445196263-linux64-29445196263.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -2635,11 +2635,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>47ecfec6deaa775c958fc532d7a43d186ba191f1</string>
+              <string>54edaed250f536eeaaae6706fc1468660efadb15</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.16/webrtc-m144.7559.06.16.28218655958-windows64-28218655958.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.17/webrtc-m144.7559.06.17.29445196263-windows64-29445196263.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -2652,7 +2652,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>copyright</key>
         <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
         <key>version</key>
-        <string>m144.7559.06.16.28218655958</string>
+        <string>m144.7559.06.17.29445196263</string>
         <key>name</key>
         <string>webrtc</string>
         <key>vcs_branch</key>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2607,11 +2607,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>95ad8f723f2c83507427611e6c36a23cbd03eacd</string>
+              <string>c39d041c9b68d9ae477934df9c77c53111d79f65</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.17/webrtc-m144.7559.06.17.29445196263-darwin64-29445196263.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.19/webrtc-m144.7559.06.19.29561257244-darwin64-29561257244.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -2621,11 +2621,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>62474b4c7645760c4e2096df62693293cde04e8b</string>
+              <string>404775fa5ecd1d6eedbc34916df07cb70b8bbfdb</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.17/webrtc-m144.7559.06.17.29445196263-linux64-29445196263.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.19/webrtc-m144.7559.06.19.29561257244-linux64-29561257244.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -2635,11 +2635,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>54edaed250f536eeaaae6706fc1468660efadb15</string>
+              <string>28a8d62165fd9cdf0de921879b88b098c0cb7076</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.17/webrtc-m144.7559.06.17.29445196263-windows64-29445196263.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.19/webrtc-m144.7559.06.19.29561257244-windows64-29561257244.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -2652,7 +2652,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>copyright</key>
         <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
         <key>version</key>
-        <string>m144.7559.06.17.29445196263</string>
+        <string>m144.7559.06.19.29561257244</string>
         <key>name</key>
         <string>webrtc</string>
         <key>vcs_branch</key>

--- a/indra/llwebrtc/CMakeLists.txt
+++ b/indra/llwebrtc/CMakeLists.txt
@@ -47,7 +47,14 @@ if (WINDOWS)
         set_target_properties(llwebrtc PROPERTIES PDB_OUTPUT_DIRECTORY "${SYMBOLS_STAGING_DIR}")
     endif (USE_BUGSPLAT)
 elseif (DARWIN)
-    target_link_libraries(llwebrtc PRIVATE ll::webrtc)
+    target_link_libraries(llwebrtc PRIVATE ll::webrtc
+                                   "-framework AVFoundation"
+                                   "-framework AudioToolbox"
+                                   "-framework CoreAudio"
+                                   "-framework CoreMedia"
+                                   "-framework CoreVideo"
+                                   "-framework Foundation"
+    )
     if (USE_BUGSPLAT)
         set_target_properties(llwebrtc PROPERTIES XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT "dwarf-with-dsym"
                                                   XCODE_ATTRIBUTE_DWARF_DSYM_FOLDER_PATH "${SYMBOLS_STAGING_DIR}/dSYMs")


### PR DESCRIPTION
## Description
When webrtc is enabled, other applications (meet, desktop applications, etc.) as well as viewer media and other sounds got quieter due to the Windows "audio ducking" feature which reduces volume when you use a communication audio device.

We move webrtc to default to the Media audio device, which doesn't do this.


Issue Link: https://github.com/secondlife/viewer-private/issues/666

## Test Guidance
* Bring up a viewer in an area with media and voice https://maps.secondlife.com/secondlife/Hanley/102/75/29
* disable voice
* listen to media
* enable voice
* expect media volume doesn't reduce

* Bring up google meet
* Validate meet voice level doesn't change when toggling viewer voice on or off

* Bring up windows media player with an mp3
* Validate playing media doesn't duck when toggling viewer voice on and off