### PR TITLE
Defer processing AvatarAppearance until after first ObjectUpdate

### DIFF
--- a/indra/llmessage/llpacketbuffer.h
+++ b/indra/llmessage/llpacketbuffer.h
@@ -49,11 +49,18 @@ public:
     void init(S32 hSocket);
     void init(const char* buffer, S32 data_size, const LLHost& host);
 
+    // Whether LLCircuitData::checkPacketInID() has already been run for this
+    // packet (done at socket-read time, before this packet was sorted into
+    // the high/low priority inbound queue).
+    bool    getPacketIDChecked() const          { return mPacketIDChecked; }
+    void    setPacketIDChecked(bool checked)    { mPacketIDChecked = checked; }
+
 protected:
     char    mData[NET_BUFFER_SIZE]; // packet data       /* Flawfinder : ignore */
     S32     mSize;                  // size of buffer in bytes
     LLHost  mHost;                  // source/dest IP and port
     LLHost  mReceivingIF;           // source/dest IP and port
+    bool    mPacketIDChecked = false;
 };
 
 #endif

--- a/indra/llmessage/message.cpp
+++ b/indra/llmessage/message.cpp
@@ -897,7 +897,7 @@ bool LLMessageSystem::isHighPriorityMessage(const LLPacketBuffer& pkt) const
     //
     // AvatarAppearance is "Low 158" which means it is stored in four bytes: 0xff 0xff 0x00 0x9E
     // the last two bytes represent 158 in a BigEndian U16
-    return !(header[1] == 255 && header[2] == 0 && header[3] == 158);
+    return header[1] != 255 && header[2] != 0 && header[3] != 158;
 }
 
 void LLMessageSystem::dropPackets(U32 num_to_drop)
@@ -1070,7 +1070,7 @@ S32 LLMessageSystem::bufferInboundPacket()
             // Skip genuine duplicate resends, same as checkMessages()/logValidMsg()
             // would do further downstream.
             bool recv_resent = (data[0] & LL_RESENT_FLAG) != 0;
-            if (!(recv_resent && cdp->isDuplicateResend(recv_packet_id)))
+            if (!recv_resent || !cdp->isDuplicateResend(recv_packet_id))
             {
                 cdp->checkPacketInID(recv_packet_id, recv_resent);
                 pkt.setPacketIDChecked(true);

--- a/indra/llmessage/message.cpp
+++ b/indra/llmessage/message.cpp
@@ -519,10 +519,11 @@ bool LLMessageSystem::checkMessages(LockMessageChecker&, S64 frame_count )
         bool recv_resent = false;
         S32 num_acks = 0;
         S32 true_rcv_size = 0;
+        bool recv_packet_id_checked = false;
 
         U8* buffer = mTrueReceiveBuffer;
 
-        mTrueReceiveSize = receivePacketOrDrop((char *)mTrueReceiveBuffer);
+        mTrueReceiveSize = receivePacketOrDrop((char *)mTrueReceiveBuffer, recv_packet_id_checked);
         // If you want to dump all received packets into SecondLife.log, uncomment this
         //dumpPacketToLog();
 
@@ -686,7 +687,7 @@ bool LLMessageSystem::checkMessages(LockMessageChecker&, S64 frame_count )
 
             if ( valid_packet )
             {
-                logValidMsg(cdp, host, recv_reliable, recv_resent, num_acks>0 );
+                logValidMsg(cdp, host, recv_reliable, recv_resent, num_acks>0, recv_packet_id_checked );
                 valid_packet = mTemplateMessageReader->readMessage(buffer, host);
             }
 
@@ -909,8 +910,10 @@ void LLMessageSystem::setDropPercentage(F32 percent_to_drop)
     mDropPercentage = percent_to_drop;
 }
 
-S32 LLMessageSystem::receivePacketOrDrop(char* datap)
+S32 LLMessageSystem::receivePacketOrDrop(char* datap, bool& packet_id_already_checked)
 {
+    packet_id_already_checked = false;
+
     if (getNumBufferedPackets() > 0)
     {
         LLHost invalid_host;
@@ -923,6 +926,7 @@ S32 LLMessageSystem::receivePacketOrDrop(char* datap)
         S32 packet_size = pkt.getSize();
         mLastSender      = pkt.getHost();
         mLastReceivingIF = pkt.getReceivingInterface();
+        packet_id_already_checked = pkt.getPacketIDChecked();
 
         if (packet_size > 0)
         {
@@ -931,7 +935,8 @@ S32 LLMessageSystem::receivePacketOrDrop(char* datap)
         return packet_size;
     }
 
-    // Read directly from the socket.
+    // Read directly from the socket. checkPacketInID() has not run yet for
+    // this packet.
     bool drop = computeDrop();
     S32 packet_size = 0;
     if (LLProxy::isSOCKSProxyEnabled())
@@ -1052,10 +1057,24 @@ S32 LLMessageSystem::bufferInboundPacket()
             }
         }
 
-        // ACK inbound reliable packet ASAP
-        if (cdp && (data[0] & LL_RELIABLE_FLAG))
+        if (cdp)
         {
-            cdp->collectRAck(recv_packet_id);
+            // ACK inbound reliable packet ASAP
+            if ((data[0] & LL_RELIABLE_FLAG))
+            {
+                cdp->collectRAck(recv_packet_id);
+            }
+
+            // Check packet sequencing here, in true socket-arrival order, before
+            // this packet is sorted into the high/low priority inbound queue.
+            // Skip genuine duplicate resends, same as checkMessages()/logValidMsg()
+            // would do further downstream.
+            bool recv_resent = (data[0] & LL_RESENT_FLAG) != 0;
+            if (!(recv_resent && cdp->isDuplicateResend(recv_packet_id)))
+            {
+                cdp->checkPacketInID(recv_packet_id, recv_resent);
+                pkt.setPacketIDChecked(true);
+            }
         }
 
         if (isHighPriorityMessage(pkt))
@@ -1686,7 +1705,13 @@ void LLMessageSystem::logTrustedMsgFromUntrustedCircuit( const LLHost& host )
     }
 }
 
-void LLMessageSystem::logValidMsg(LLCircuitData *cdp, const LLHost& host, bool recv_reliable, bool recv_resent, bool recv_acks )
+void LLMessageSystem::logValidMsg(
+        LLCircuitData *cdp,
+        const LLHost& host,
+        bool recv_reliable,
+        bool recv_resent,
+        bool recv_acks,
+        bool skip_packet_id_check )
 {
     if (mNumMessageCounts >= MAX_MESSAGE_COUNT_NUM)
     {
@@ -1703,8 +1728,13 @@ void LLMessageSystem::logValidMsg(LLCircuitData *cdp, const LLHost& host, bool r
 
     if (cdp)
     {
-        // update circuit packet ID tracking (missing/out of order packets)
-        cdp->checkPacketInID( mCurrentRecvPacketID, recv_resent );
+        if (!skip_packet_id_check)
+        {
+            // update circuit packet ID tracking (missing/out of order packets)
+            // Already done in bufferInboundPacket(), in true socket-arrival
+            // order, if this packet came off the high/low priority queues.
+            cdp->checkPacketInID( mCurrentRecvPacketID, recv_resent );
+        }
         cdp->addBytesIn( (S32Bytes)mTrueReceiveSize );
     }
 

--- a/indra/llmessage/message.cpp
+++ b/indra/llmessage/message.cpp
@@ -866,19 +866,37 @@ bool LLMessageSystem::computeDrop()
 bool LLMessageSystem::isHighPriorityMessage(const LLPacketBuffer& pkt) const
 {
     S32 size = pkt.getSize();
-    if (size < LL_PACKET_ID_SIZE + 1)
+
+    // avoid stepping out of bounds
+    const S32 MIN_VALID_PACKET_SIZE = LL_PACKET_ID_SIZE + 4;
+    if (size < MIN_VALID_PACKET_SIZE)
     {
         return false;
     }
 
-    // We want to prioritize crucial messages use to establish viewer <--> simulator connection,
+    // We want to prioritize crucial messages used to establish viewer <--> simulator connection,
     // which are all low-frequency. A simple approximation is to just prioritize all non high-
     // frequency messages.
     //
-    // High frequency messages use a single byte for message_id whereas all low- and medium-
-    // frequency messages have 255 at the first byte of the message_id (which is after the
-    // LL_PACKET_ID_SIZE bytes of packet_id).
-    return *((const U8*)pkt.getData() + LL_PACKET_ID_SIZE) == 255;
+    // High frequency messages use a single byte for message_id whereas medium- and low-
+    // frequency messages have 255 at the first byte (which is after the LL_PACKET_ID_SIZE
+    // bytes of packet_id).
+    const U8* header = (const U8*)pkt.getData() + LL_PACKET_ID_SIZE;
+    if (header[0] != 255)
+    {
+        // high-frequency message
+        return false;
+    }
+
+    // BUG: The low-frequency AvatarAppearance message will be ignored if its agent is unknown
+    // and the agent is created upon receipt of its first high-frequency ObjectUpdate message.
+    // This race condition will be exacerbated by our default prioritization strategy.
+    //
+    // WORKAROUND: All middle- and low-frequency messages are high-priority except AvatarAppearance
+    //
+    // AvatarAppearance is "Low 158" which means it is stored in four bytes: 0xff 0xff 0x00 0x9E
+    // the last two bytes represent 158 in a BigEndian U16
+    return !(header[1] == 255 && header[2] == 0 && header[3] == 158);
 }
 
 void LLMessageSystem::dropPackets(U32 num_to_drop)

--- a/indra/llmessage/message.h
+++ b/indra/llmessage/message.h
@@ -910,7 +910,7 @@ private:
 
     void        logMsgFromInvalidCircuit( const LLHost& sender, bool recv_reliable );
     void        logTrustedMsgFromUntrustedCircuit( const LLHost& sender );
-    void        logValidMsg(LLCircuitData *cdp, const LLHost& sender, bool recv_reliable, bool recv_resent, bool recv_acks );
+    void        logValidMsg(LLCircuitData *cdp, const LLHost& sender, bool recv_reliable, bool recv_resent, bool recv_acks, bool skip_packet_id_check );
 
     class LLMessageCountInfo
     {
@@ -967,8 +967,10 @@ private:
 
     // Receive one packet: pop from ring if buffered, else read from mSocket.
     // Sets mLastSender and mLastReceivingIF.
+    // Sets packet_id_already_checked to whether checkPacketInID() was already
+    // run for this packet back when it was buffered (see bufferInboundPacket()).
     // Returns packet_size, or 0 if no packet or packet was dropped.
-    S32  receivePacketOrDrop(char* datap);
+    S32  receivePacketOrDrop(char* datap, bool& packet_id_already_checked);
 
     // Read one raw packet from mSocket into inbound message queues
     // Returns packet_size (0 if no packet was available).

--- a/indra/llprimitive/llprimitive.cpp
+++ b/indra/llprimitive/llprimitive.cpp
@@ -1370,6 +1370,12 @@ bool LLPrimitive::packTEMessage(LLDataPacker &dp) const
 
 S32 LLPrimitive::parseTEMessage(LLMessageSystem* mesgsys, char const* block_name, const S32 block_num, LLTEContents& tec)
 {
+    return parseTEMessage(mesgsys, block_name, block_num, tec, getNumTEs());
+}
+
+// static
+S32 LLPrimitive::parseTEMessage(LLMessageSystem* mesgsys, char const* block_name, const S32 block_num, LLTEContents& tec, U8 face_count)
+{
     S32 retval = 0;
     // temp buffer for material ID processing
     // data will end up in tec.material_id[]
@@ -1403,7 +1409,7 @@ S32 LLPrimitive::parseTEMessage(LLMessageSystem* mesgsys, char const* block_name
     tec.packed_buffer[tec.size] = 0x00;
     ++tec.size;
 
-    tec.face_count = llmin((U32)getNumTEs(),(U32)LLTEContents::MAX_TES);
+    tec.face_count = llmin((U32)face_count,(U32)LLTEContents::MAX_TES);
 
     U8 *cur_ptr = tec.packed_buffer;
     LL_DEBUGS("TEXTUREENTRY") << "Texture Entry with buffere sized: " << tec.size << LL_ENDL;

--- a/indra/llprimitive/llprimitive.h
+++ b/indra/llprimitive/llprimitive.h
@@ -502,6 +502,9 @@ public:
     S32 unpackTEMessage(LLMessageSystem* mesgsys, char const* block_name, const S32 block_num); // Variable num of blocks
     S32 unpackTEMessage(LLDataPacker &dp);
     S32 parseTEMessage(LLMessageSystem* mesgsys, char const* block_name, const S32 block_num, LLTEContents& tec);
+    // Same as above, but usable before an instance exists to derive the face count from
+    // (e.g. decoding a message for an object that hasn't been created yet).
+    static S32 parseTEMessage(LLMessageSystem* mesgsys, char const* block_name, const S32 block_num, LLTEContents& tec, U8 face_count);
     S32 applyParsedTEMessage(LLTEContents& tec);
 
 #ifdef CHECK_FOR_FINITE

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -4151,6 +4151,7 @@ void LLAgent::handleTeleportFinished()
     }
     clearTeleportRequest();
     mTeleportCanceled.reset();
+    LLVOAvatar::resetEarlyAppearanceList();
     if (mIsMaturityRatingChangingDuringTeleport)
     {
         // notify user that the maturity preference has been changed

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -4181,14 +4181,18 @@ void process_avatar_appearance(LLMessageSystem *mesgsys, void **user_data)
     if (avatarp)
     {
         avatarp->processAvatarAppearance( mesgsys );
+        return;
+    }
+    // Remember that this avatar needs to see its appearance re-requested when
+    // they will finally be created. HB
+    LLVOAvatar::registerEarlyAppearance(uuid);
+    if (uuid == gAgentID)
+    {
+        LL_WARNS("Messaging") << "AvatarAppearance message received before avatar is created." << LL_ENDL;
     }
     else
     {
-        // WORKAROUND: this can arrive before the ObjectUpdate that creates the avatar (e.g. if
-        // the ObjectUpdate was lost and is being resent). Defer it until the avatar shows up,
-        // instead of dropping it.
-        LL_WARNS("Messaging") << "avatar_appearance sent for unknown avatar " << uuid << "; deferring" << LL_ENDL;
-        LLVOAvatar::addPendingAvatarAppearance(uuid, mesgsys);
+        LL_WARNS("Messaging") << "AvatarAppearance message received for unknown avatar " << uuid << LL_ENDL;
     }
 }
 

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -4183,17 +4183,10 @@ void process_avatar_appearance(LLMessageSystem *mesgsys, void **user_data)
         avatarp->processAvatarAppearance( mesgsys );
         return;
     }
-    // Remember that this avatar needs to see its appearance re-requested when
-    // they will finally be created. HB
+    // The avatar object doesn't exist yet.
+    // We will re-request its appearance data after it is created.
     LLVOAvatar::registerEarlyAppearance(uuid);
-    if (uuid == gAgentID)
-    {
-        LL_WARNS("Messaging") << "AvatarAppearance message received before avatar is created." << LL_ENDL;
-    }
-    else
-    {
-        LL_WARNS("Messaging") << "AvatarAppearance message received for unknown avatar " << uuid << LL_ENDL;
-    }
+    LL_WARNS("Messaging") << "AvatarAppearance received for avatar " << uuid << " before object created" << LL_ENDL;
 }
 
 void process_camera_constraint(LLMessageSystem *mesgsys, void **user_data)

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -4184,7 +4184,11 @@ void process_avatar_appearance(LLMessageSystem *mesgsys, void **user_data)
     }
     else
     {
-        LL_WARNS("Messaging") << "avatar_appearance sent for unknown avatar " << uuid << LL_ENDL;
+        // WORKAROUND: this can arrive before the ObjectUpdate that creates the avatar (e.g. if
+        // the ObjectUpdate was lost and is being resent). Defer it until the avatar shows up,
+        // instead of dropping it.
+        LL_WARNS("Messaging") << "avatar_appearance sent for unknown avatar " << uuid << "; deferring" << LL_ENDL;
+        LLVOAvatar::addPendingAvatarAppearance(uuid, mesgsys);
     }
 }
 

--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -255,6 +255,12 @@ void LLViewerObjectList::processUpdateCore(LLViewerObject* objectp,
     if (just_created)
     {
         gPipeline.addObject(objectp);
+
+        if (objectp->isAvatar())
+        {
+            // Apply any AvatarAppearance message that arrived for this avatar before it existed.
+            LLVOAvatar::applyPendingAvatarAppearance((LLVOAvatar*)objectp);
+        }
     }
 
     // Also sets the approx. pixel area

--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -255,12 +255,6 @@ void LLViewerObjectList::processUpdateCore(LLViewerObject* objectp,
     if (just_created)
     {
         gPipeline.addObject(objectp);
-
-        if (objectp->isAvatar())
-        {
-            // Apply any AvatarAppearance message that arrived for this avatar before it existed.
-            LLVOAvatar::applyPendingAvatarAppearance((LLVOAvatar*)objectp);
-        }
     }
 
     // Also sets the approx. pixel area

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -9717,12 +9717,10 @@ void LLVOAvatar::resolveAppearanceMessageContents(LLAppearanceMessageContents& c
     }
 }
 
-// Time (in microseconds, see totalTime()) a parsed-but-unapplied AvatarAppearance message is
-// kept waiting for its avatar's ObjectUpdate to arrive before being dropped.
-static const U64 AVATAR_APPEARANCE_EXPIRY = 20 * 1000000ULL; // 20 seconds
+static const U64 AVATAR_APPEARANCE_EXPIRY = 20 * USEC_PER_SEC;
 
 std::map<LLUUID, LLPointer<LLAppearanceMessageContents> > LLVOAvatar::sPendingAvatarAppearanceContents;
-std::map<LLUUID, U64>                                     LLVOAvatar::sPendingAvatarAppearanceTimers;
+std::map<LLUUID, U64>                                     LLVOAvatar::sPendingAvatarAppearanceExpiries;
 
 // static
 void LLVOAvatar::addPendingAvatarAppearance(const LLUUID& agent_id, LLMessageSystem* mesgsys)
@@ -9731,7 +9729,7 @@ void LLVOAvatar::addPendingAvatarAppearance(const LLUUID& agent_id, LLMessageSys
     parseAppearanceMessage(mesgsys, agent_id, *contents);
 
     sPendingAvatarAppearanceContents[agent_id] = contents;
-    sPendingAvatarAppearanceTimers[agent_id] = totalTime() + AVATAR_APPEARANCE_EXPIRY;
+    sPendingAvatarAppearanceExpiries[agent_id] = totalTime() + AVATAR_APPEARANCE_EXPIRY;
 }
 
 // static
@@ -9744,7 +9742,7 @@ void LLVOAvatar::applyPendingAvatarAppearance(LLVOAvatar* avatarp)
         {
             LLPointer<LLAppearanceMessageContents> contents = contents_iter->second;
             sPendingAvatarAppearanceContents.erase(contents_iter);
-            sPendingAvatarAppearanceTimers.erase(avatarp->getID());
+            sPendingAvatarAppearanceExpiries.erase(avatarp->getID());
 
             LL_DEBUGS("Messaging") << "Applying deferred AvatarAppearance for " << avatarp->getID() << LL_ENDL;
             avatarp->mLastAppearanceMessageTimer.reset();
@@ -9754,13 +9752,13 @@ void LLVOAvatar::applyPendingAvatarAppearance(LLVOAvatar* avatarp)
 
     // check for expired entries
     U64 now = totalTime();
-    for (auto timer_iter = sPendingAvatarAppearanceTimers.begin(); timer_iter != sPendingAvatarAppearanceTimers.end(); )
+    for (auto timer_iter = sPendingAvatarAppearanceExpiries.begin(); timer_iter != sPendingAvatarAppearanceExpiries.end(); )
     {
         if (now > timer_iter->second)
         {
             LL_WARNS("Messaging") << "Expired AvatarAppearance for agent " << timer_iter->first << LL_ENDL;
             sPendingAvatarAppearanceContents.erase(timer_iter->first);
-            timer_iter = sPendingAvatarAppearanceTimers.erase(timer_iter);
+            timer_iter = sPendingAvatarAppearanceExpiries.erase(timer_iter);
         }
         else
         {

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -785,6 +785,10 @@ LLVOAvatar::LLVOAvatar(const LLUUID& id,
     uuid_list_t::iterator it = sEarlyAppearanceList.find(id);
     if (it != sEarlyAppearanceList.end())
     {
+        // Note: this is the only place where we remove from sEarlyAppearanceList
+        // which means any agent who receives an AvatarAppearance message but is never
+        // actually instantiated will remain on the list.  This is a resource leak
+        // but we expect it to be small enough per-session to not cause problems.
         sEarlyAppearanceList.erase(it);
         LL_INFOS("Avatar") << "Re-requesting AvatarAppearance for new avatar " << id << LL_ENDL;
         LLAvatarPropertiesProcessor::getInstance()->sendAvatarTexturesRequest(getID());

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -785,9 +785,11 @@ LLVOAvatar::LLVOAvatar(const LLUUID& id,
     uuid_list_t::iterator it = sEarlyAppearanceList.find(id);
     if (it != sEarlyAppearanceList.end())
     {
-        // Note: this is the only place where we remove from sEarlyAppearanceList
-        // which means any agent who receives an AvatarAppearance message but is never
-        // actually instantiated will remain on the list.  This is a resource leak
+        // Note: aside from LLVOAvatar::resetEarlyAppearanceList() (called on
+        // teleport), this is the only place where we remove from
+        // sEarlyAppearanceList, which means any agent who receives an
+        // AvatarAppearance message but is never actually instantiated will
+        // remain on the list until the next teleport. This is a resource leak
         // but we expect it to be small enough per-session to not cause problems.
         sEarlyAppearanceList.erase(it);
         LL_INFOS("Avatar") << "Re-requesting AvatarAppearance for new avatar " << id << LL_ENDL;

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -615,7 +615,7 @@ const LLUUID LLVOAvatar::sStepSounds[LL_MCODE_END] =
     SND_RUBBER_RUBBER
 };
 
-uuid_list_t LLVOAvatar::sEarlyApperanceList;
+uuid_list_t LLVOAvatar::sEarlyAppearanceList;
 
 S32 LLVOAvatar::sRenderName = RENDER_NAME_ALWAYS;
 S32 LLVOAvatar::sRenderGroupTitles = RENDER_GROUP_TITLE_ALWAYS;
@@ -782,10 +782,10 @@ LLVOAvatar::LLVOAvatar(const LLUUID& id,
 
     sInstances.push_back(this);
 
-    uuid_list_t::iterator it = sEarlyApperanceList.find(id);
-    if (it != sEarlyApperanceList.end())
+    uuid_list_t::iterator it = sEarlyAppearanceList.find(id);
+    if (it != sEarlyAppearanceList.end())
     {
-        sEarlyApperanceList.erase(it);
+        sEarlyAppearanceList.erase(it);
         LL_INFOS("Avatar") << "Re-requesting AvatarAppearance for new avatar " << id << LL_ENDL;
         LLAvatarPropertiesProcessor::getInstance()->sendAvatarTexturesRequest(getID());
     }

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -261,8 +261,15 @@ struct LLAppearanceMessageContents: public LLRefCount
     S32 mCOFVersion;
     // For future use:
     //U32 appearance_flags = 0;
+    // Raw per-block visual param values as received on the wire, in message order. Avatar-agnostic.
+    // Resolved into mParams/mParamWeights (which require a live avatar instance) by
+    // LLVOAvatar::resolveAppearanceMessageContents().
+    std::vector<U8> mParamRawValues;
     std::vector<F32> mParamWeights;
     std::vector<LLVisualParam*> mParams;
+    // Attachment point data as received on the wire (attachment_id -> attach_point). Avatar-agnostic.
+    // Applied to the live avatar's mSimAttachments by LLVOAvatar::resolveAppearanceMessageContents().
+    std::map<LLUUID, S32> mAttachmentData;
     LLVector3 mHoverOffset;
     bool mHoverOffsetWasSet;
 };
@@ -9556,9 +9563,13 @@ void LLVOAvatar::dumpAppearanceMsgParams( const std::string& dump_prefix,
     apr_file_printf(file, "</textures>\n");
 }
 
-void LLVOAvatar::parseAppearanceMessage(LLMessageSystem* mesgsys, LLAppearanceMessageContents& contents)
+// static
+void LLVOAvatar::parseAppearanceMessage(LLMessageSystem* mesgsys, const LLUUID& agent_id, LLAppearanceMessageContents& contents)
 {
-    parseTEMessage(mesgsys, _PREHASH_ObjectData, -1, contents.mTEContents);
+    // Static/avatar-agnostic: this must remain safe to call before the target avatar object
+    // exists (see addPendingAvatarAppearance() below), so it may only decode wire data into
+    // contents, never touch a specific avatar instance's live state.
+    LLPrimitive::parseTEMessage(mesgsys, _PREHASH_ObjectData, -1, contents.mTEContents, TEX_NUM_INDICES);
 
     // Parse the AppearanceData field, if any.
     if (mesgsys->has(_PREHASH_AppearanceData))
@@ -9578,39 +9589,61 @@ void LLVOAvatar::parseAppearanceMessage(LLMessageSystem* mesgsys, LLAppearanceMe
     {
         LLVector3 hover;
         mesgsys->getVector3Fast(_PREHASH_AppearanceHover, _PREHASH_HoverHeight, hover);
-        //LL_DEBUGS("Avatar") << avString() << " hover received " << hover.mV[ VX ] << "," << hover.mV[ VY ] << "," << hover.mV[ VZ ] << LL_ENDL;
+        //LL_DEBUGS("Avatar") << " hover received " << hover.mV[ VX ] << "," << hover.mV[ VY ] << "," << hover.mV[ VZ ] << LL_ENDL;
         contents.mHoverOffset = hover;
         contents.mHoverOffsetWasSet = true;
     }
 
-    // Get attachment info, if sent
+    // Get attachment info, if sent. Stored raw here; reconciled against the live avatar's
+    // previous attachment set by resolveAppearanceMessageContents(), since that comparison
+    // requires a specific avatar instance.
     LLUUID attachment_id;
     U8     attach_point;
     S32    attach_count = mesgsys->getNumberOfBlocksFast(_PREHASH_AttachmentBlock);
-    LL_DEBUGS("AVAppearanceAttachments") << "Agent " << getID() << " has "
+    LL_DEBUGS("AVAppearanceAttachments") << "Agent " << agent_id << " has "
                                          << attach_count << " attachments" << LL_ENDL;
-    size_t old_size = mSimAttachments.size();
-    mSimAttachments.clear();
     for (S32 attach_i = 0; attach_i < attach_count; attach_i++)
     {
         mesgsys->getUUIDFast(_PREHASH_AttachmentBlock, _PREHASH_ID, attachment_id, attach_i);
         mesgsys->getU8Fast(_PREHASH_AttachmentBlock, _PREHASH_AttachmentPoint, attach_point, attach_i);
-        LL_DEBUGS("AVAppearanceAttachments") << "AV " << getID() << " has attachment " << attach_i << " "
+        LL_DEBUGS("AVAppearanceAttachments") << "AV " << agent_id << " has attachment " << attach_i << " "
             << (attachment_id.isNull() ? "pending" : attachment_id.asString())
             << " on point " << (S32)attach_point << LL_ENDL;
 
         if (attachment_id.notNull())
         {
-            mSimAttachments[attachment_id] = attach_point;
+            contents.mAttachmentData[attachment_id] = attach_point;
         }
         else
         {
             // at the moment viewer is only interested in non-null attachments
-            LL_DEBUGS("AVAppearanceAttachments") << "AV " << getID()
+            LL_DEBUGS("AVAppearanceAttachments") << "AV " << agent_id
                 << " has null attachment on point " << (S32)attach_point
                 << ", discarding" << LL_ENDL;
         }
     }
+
+    // Parse visual params, if any. Only the raw wire values are captured here: matching them to
+    // this avatar's LLVisualParam objects requires a live avatar instance, and happens in
+    // resolveAppearanceMessageContents() instead.
+    S32 num_blocks = mesgsys->getNumberOfBlocksFast(_PREHASH_VisualParam);
+    if (num_blocks > 1)
+    {
+        contents.mParamRawValues.reserve(num_blocks);
+        for (S32 i = 0; i < num_blocks; i++)
+        {
+            U8 value;
+            mesgsys->getU8Fast(_PREHASH_VisualParam, _PREHASH_ParamValue, value, i);
+            contents.mParamRawValues.push_back(value);
+        }
+    }
+}
+
+void LLVOAvatar::resolveAppearanceMessageContents(LLAppearanceMessageContents& contents)
+{
+    // Apply attachment data, now that we have a specific avatar instance to compare against.
+    size_t old_size = mSimAttachments.size();
+    mSimAttachments = contents.mAttachmentData;
 
     // todo? Doesn't detect if attachments were switched
     if (old_size != mSimAttachments.size())
@@ -9623,9 +9656,9 @@ void LLVOAvatar::parseAppearanceMessage(LLMessageSystem* mesgsys, LLAppearanceMe
         }
     }
 
-    // Parse visual params, if any.
-    S32 num_blocks = mesgsys->getNumberOfBlocksFast(_PREHASH_VisualParam);
-    if( num_blocks > 1)
+    // Resolve visual params against this avatar's own tweakable param list.
+    S32 num_blocks = (S32)contents.mParamRawValues.size();
+    if (num_blocks > 1)
     {
         //LL_DEBUGS("Avatar") << avString() << " handle visual params, num_blocks " << num_blocks << LL_ENDL;
 
@@ -9651,9 +9684,7 @@ void LLVOAvatar::parseAppearanceMessage(LLMessageSystem* mesgsys, LLAppearanceMe
                     break;
                 }
 
-                U8 value;
-                mesgsys->getU8Fast(_PREHASH_VisualParam, _PREHASH_ParamValue, value, i);
-                F32 newWeight = U8_to_F32(value, param->getMinWeight(), param->getMaxWeight());
+                F32 newWeight = U8_to_F32(contents.mParamRawValues[i], param->getMinWeight(), param->getMaxWeight());
                 contents.mParamWeights.push_back(newWeight);
                 contents.mParams.push_back(param);
 
@@ -9682,6 +9713,58 @@ void LLVOAvatar::parseAppearanceMessage(LLMessageSystem* mesgsys, LLAppearanceMe
             S32 index = (S32)(it - contents.mParams.begin());
             contents.mParamAppearanceVersion = ll_round(contents.mParamWeights[index]);
             //LL_DEBUGS("Avatar") << "appversion req by appearance_version param: " << contents.mParamAppearanceVersion << LL_ENDL;
+        }
+    }
+}
+
+// Time (in microseconds, see totalTime()) a parsed-but-unapplied AvatarAppearance message is
+// kept waiting for its avatar's ObjectUpdate to arrive before being dropped.
+static const U64 AVATAR_APPEARANCE_EXPIRY = 20 * 1000000ULL; // 20 seconds
+
+std::map<LLUUID, LLPointer<LLAppearanceMessageContents> > LLVOAvatar::sPendingAvatarAppearanceContents;
+std::map<LLUUID, U64>                                     LLVOAvatar::sPendingAvatarAppearanceTimers;
+
+// static
+void LLVOAvatar::addPendingAvatarAppearance(const LLUUID& agent_id, LLMessageSystem* mesgsys)
+{
+    LLPointer<LLAppearanceMessageContents> contents(new LLAppearanceMessageContents);
+    parseAppearanceMessage(mesgsys, agent_id, *contents);
+
+    sPendingAvatarAppearanceContents[agent_id] = contents;
+    sPendingAvatarAppearanceTimers[agent_id] = totalTime() + AVATAR_APPEARANCE_EXPIRY;
+}
+
+// static
+void LLVOAvatar::applyPendingAvatarAppearance(LLVOAvatar* avatarp)
+{
+    if (avatarp)
+    {
+        auto contents_iter = sPendingAvatarAppearanceContents.find(avatarp->getID());
+        if (contents_iter != sPendingAvatarAppearanceContents.end())
+        {
+            LLPointer<LLAppearanceMessageContents> contents = contents_iter->second;
+            sPendingAvatarAppearanceContents.erase(contents_iter);
+            sPendingAvatarAppearanceTimers.erase(avatarp->getID());
+
+            LL_INFOS("Messaging") << "Applying deferred AvatarAppearance for " << avatarp->getID() << LL_ENDL;
+            avatarp->mLastAppearanceMessageTimer.reset();
+            avatarp->processParsedAppearanceMessage(contents);
+        }
+    }
+
+    // check for expired entries
+    U64 now = totalTime();
+    for (auto timer_iter = sPendingAvatarAppearanceTimers.begin(); timer_iter != sPendingAvatarAppearanceTimers.end(); )
+    {
+        if (now > timer_iter->second)
+        {
+            LL_WARNS("Messaging") << "Expired AvatarAppearance for agent " << timer_iter->first << LL_ENDL;
+            sPendingAvatarAppearanceContents.erase(timer_iter->first);
+            timer_iter = sPendingAvatarAppearanceTimers.erase(timer_iter);
+        }
+        else
+        {
+            ++timer_iter;
         }
     }
 }
@@ -9736,11 +9819,20 @@ void LLVOAvatar::processAvatarAppearance( LLMessageSystem* mesgsys )
     mLastAppearanceMessageTimer.reset();
 
     LLPointer<LLAppearanceMessageContents> contents(new LLAppearanceMessageContents);
-    parseAppearanceMessage(mesgsys, *contents);
+    parseAppearanceMessage(mesgsys, getID(), *contents);
     if (enable_verbose_dumps)
     {
         dumpAppearanceMsgParams(dump_prefix + "appearance_msg", *contents);
     }
+
+    processParsedAppearanceMessage(contents);
+}
+
+void LLVOAvatar::processParsedAppearanceMessage(const LLPointer<LLAppearanceMessageContents>& contents)
+{
+    // Resolve the avatar-agnostic parts of contents (raw visual param values, attachment data)
+    // against this avatar's live state now that we know it exists.
+    resolveAppearanceMessageContents(*contents);
 
     S32 appearance_version;
     if (!resolve_appearance_version(*contents, appearance_version))

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -9746,7 +9746,7 @@ void LLVOAvatar::applyPendingAvatarAppearance(LLVOAvatar* avatarp)
             sPendingAvatarAppearanceContents.erase(contents_iter);
             sPendingAvatarAppearanceTimers.erase(avatarp->getID());
 
-            LL_INFOS("Messaging") << "Applying deferred AvatarAppearance for " << avatarp->getID() << LL_ENDL;
+            LL_DEBUGS("Messaging") << "Applying deferred AvatarAppearance for " << avatarp->getID() << LL_ENDL;
             avatarp->mLastAppearanceMessageTimer.reset();
             avatarp->processParsedAppearanceMessage(contents);
         }
@@ -9828,7 +9828,7 @@ void LLVOAvatar::processAvatarAppearance( LLMessageSystem* mesgsys )
     processParsedAppearanceMessage(contents);
 }
 
-void LLVOAvatar::processParsedAppearanceMessage(const LLPointer<LLAppearanceMessageContents>& contents)
+void LLVOAvatar::processParsedAppearanceMessage(LLPointer<LLAppearanceMessageContents>& contents)
 {
     // Resolve the avatar-agnostic parts of contents (raw visual param values, attachment data)
     // against this avatar's live state now that we know it exists.
@@ -10029,7 +10029,7 @@ void LLVOAvatar::applyParsedAppearanceMessage(LLAppearanceMessageContents& conte
         if (visualParamWeightsAreDefault() && mRuthTimer.getElapsedTimeF32() > LOADING_TIMEOUT_SECONDS)
         {
             // re-request appearance, hoping that it comes back with a shape next time
-            LL_INFOS() << "Re-requesting AvatarAppearance for object: "  << getID() << LL_ENDL;
+            LL_INFOS() << "Re-requesting AvatarAppearance for agent: "  << getID() << LL_ENDL;
             LLAvatarPropertiesProcessor::getInstance()->sendAvatarTexturesRequest(getID());
             mRuthTimer.reset();
         }

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -261,15 +261,8 @@ struct LLAppearanceMessageContents: public LLRefCount
     S32 mCOFVersion;
     // For future use:
     //U32 appearance_flags = 0;
-    // Raw per-block visual param values as received on the wire, in message order. Avatar-agnostic.
-    // Resolved into mParams/mParamWeights (which require a live avatar instance) by
-    // LLVOAvatar::resolveAppearanceMessageContents().
-    std::vector<U8> mParamRawValues;
     std::vector<F32> mParamWeights;
     std::vector<LLVisualParam*> mParams;
-    // Attachment point data as received on the wire (attachment_id -> attach_point). Avatar-agnostic.
-    // Applied to the live avatar's mSimAttachments by LLVOAvatar::resolveAppearanceMessageContents().
-    std::map<LLUUID, S32> mAttachmentData;
     LLVector3 mHoverOffset;
     bool mHoverOffsetWasSet;
 };
@@ -622,6 +615,8 @@ const LLUUID LLVOAvatar::sStepSounds[LL_MCODE_END] =
     SND_RUBBER_RUBBER
 };
 
+uuid_list_t LLVOAvatar::sEarlyApperanceList;
+
 S32 LLVOAvatar::sRenderName = RENDER_NAME_ALWAYS;
 S32 LLVOAvatar::sRenderGroupTitles = RENDER_GROUP_TITLE_ALWAYS;
 S32 LLVOAvatar::sNumVisibleChatBubbles = 0;
@@ -786,6 +781,14 @@ LLVOAvatar::LLVOAvatar(const LLUUID& id,
     mVisuallyMuteSetting = LLVOAvatar::VisualMuteSettings(LLRenderMuteList::getInstance()->getSavedVisualMuteSetting(getID()));
 
     sInstances.push_back(this);
+
+    uuid_list_t::iterator it = sEarlyApperanceList.find(id);
+    if (it != sEarlyApperanceList.end())
+    {
+        sEarlyApperanceList.erase(it);
+        LL_INFOS("Avatar") << "Re-requesting AvatarAppearance for new avatar " << id << LL_ENDL;
+        LLAvatarPropertiesProcessor::getInstance()->sendAvatarTexturesRequest(getID());
+    }
 }
 
 std::string LLVOAvatar::avString() const
@@ -9563,13 +9566,9 @@ void LLVOAvatar::dumpAppearanceMsgParams( const std::string& dump_prefix,
     apr_file_printf(file, "</textures>\n");
 }
 
-// static
-void LLVOAvatar::parseAppearanceMessage(LLMessageSystem* mesgsys, const LLUUID& agent_id, LLAppearanceMessageContents& contents)
+void LLVOAvatar::parseAppearanceMessage(LLMessageSystem* mesgsys, LLAppearanceMessageContents& contents)
 {
-    // Static/avatar-agnostic: this must remain safe to call before the target avatar object
-    // exists (see addPendingAvatarAppearance() below), so it may only decode wire data into
-    // contents, never touch a specific avatar instance's live state.
-    LLPrimitive::parseTEMessage(mesgsys, _PREHASH_ObjectData, -1, contents.mTEContents, TEX_NUM_INDICES);
+    parseTEMessage(mesgsys, _PREHASH_ObjectData, -1, contents.mTEContents);
 
     // Parse the AppearanceData field, if any.
     if (mesgsys->has(_PREHASH_AppearanceData))
@@ -9589,61 +9588,39 @@ void LLVOAvatar::parseAppearanceMessage(LLMessageSystem* mesgsys, const LLUUID& 
     {
         LLVector3 hover;
         mesgsys->getVector3Fast(_PREHASH_AppearanceHover, _PREHASH_HoverHeight, hover);
-        //LL_DEBUGS("Avatar") << " hover received " << hover.mV[ VX ] << "," << hover.mV[ VY ] << "," << hover.mV[ VZ ] << LL_ENDL;
+        //LL_DEBUGS("Avatar") << avString() << " hover received " << hover.mV[ VX ] << "," << hover.mV[ VY ] << "," << hover.mV[ VZ ] << LL_ENDL;
         contents.mHoverOffset = hover;
         contents.mHoverOffsetWasSet = true;
     }
 
-    // Get attachment info, if sent. Stored raw here; reconciled against the live avatar's
-    // previous attachment set by resolveAppearanceMessageContents(), since that comparison
-    // requires a specific avatar instance.
+    // Get attachment info, if sent
     LLUUID attachment_id;
     U8     attach_point;
     S32    attach_count = mesgsys->getNumberOfBlocksFast(_PREHASH_AttachmentBlock);
-    LL_DEBUGS("AVAppearanceAttachments") << "Agent " << agent_id << " has "
+    LL_DEBUGS("AVAppearanceAttachments") << "Agent " << getID() << " has "
                                          << attach_count << " attachments" << LL_ENDL;
+    size_t old_size = mSimAttachments.size();
+    mSimAttachments.clear();
     for (S32 attach_i = 0; attach_i < attach_count; attach_i++)
     {
         mesgsys->getUUIDFast(_PREHASH_AttachmentBlock, _PREHASH_ID, attachment_id, attach_i);
         mesgsys->getU8Fast(_PREHASH_AttachmentBlock, _PREHASH_AttachmentPoint, attach_point, attach_i);
-        LL_DEBUGS("AVAppearanceAttachments") << "AV " << agent_id << " has attachment " << attach_i << " "
+        LL_DEBUGS("AVAppearanceAttachments") << "AV " << getID() << " has attachment " << attach_i << " "
             << (attachment_id.isNull() ? "pending" : attachment_id.asString())
             << " on point " << (S32)attach_point << LL_ENDL;
 
         if (attachment_id.notNull())
         {
-            contents.mAttachmentData[attachment_id] = attach_point;
+            mSimAttachments[attachment_id] = attach_point;
         }
         else
         {
             // at the moment viewer is only interested in non-null attachments
-            LL_DEBUGS("AVAppearanceAttachments") << "AV " << agent_id
+            LL_DEBUGS("AVAppearanceAttachments") << "AV " << getID()
                 << " has null attachment on point " << (S32)attach_point
                 << ", discarding" << LL_ENDL;
         }
     }
-
-    // Parse visual params, if any. Only the raw wire values are captured here: matching them to
-    // this avatar's LLVisualParam objects requires a live avatar instance, and happens in
-    // resolveAppearanceMessageContents() instead.
-    S32 num_blocks = mesgsys->getNumberOfBlocksFast(_PREHASH_VisualParam);
-    if (num_blocks > 1)
-    {
-        contents.mParamRawValues.reserve(num_blocks);
-        for (S32 i = 0; i < num_blocks; i++)
-        {
-            U8 value;
-            mesgsys->getU8Fast(_PREHASH_VisualParam, _PREHASH_ParamValue, value, i);
-            contents.mParamRawValues.push_back(value);
-        }
-    }
-}
-
-void LLVOAvatar::resolveAppearanceMessageContents(LLAppearanceMessageContents& contents)
-{
-    // Apply attachment data, now that we have a specific avatar instance to compare against.
-    size_t old_size = mSimAttachments.size();
-    mSimAttachments = contents.mAttachmentData;
 
     // todo? Doesn't detect if attachments were switched
     if (old_size != mSimAttachments.size())
@@ -9656,9 +9633,9 @@ void LLVOAvatar::resolveAppearanceMessageContents(LLAppearanceMessageContents& c
         }
     }
 
-    // Resolve visual params against this avatar's own tweakable param list.
-    S32 num_blocks = (S32)contents.mParamRawValues.size();
-    if (num_blocks > 1)
+    // Parse visual params, if any.
+    S32 num_blocks = mesgsys->getNumberOfBlocksFast(_PREHASH_VisualParam);
+    if( num_blocks > 1)
     {
         //LL_DEBUGS("Avatar") << avString() << " handle visual params, num_blocks " << num_blocks << LL_ENDL;
 
@@ -9684,7 +9661,9 @@ void LLVOAvatar::resolveAppearanceMessageContents(LLAppearanceMessageContents& c
                     break;
                 }
 
-                F32 newWeight = U8_to_F32(contents.mParamRawValues[i], param->getMinWeight(), param->getMaxWeight());
+                U8 value;
+                mesgsys->getU8Fast(_PREHASH_VisualParam, _PREHASH_ParamValue, value, i);
+                F32 newWeight = U8_to_F32(value, param->getMinWeight(), param->getMaxWeight());
                 contents.mParamWeights.push_back(newWeight);
                 contents.mParams.push_back(param);
 
@@ -9713,56 +9692,6 @@ void LLVOAvatar::resolveAppearanceMessageContents(LLAppearanceMessageContents& c
             S32 index = (S32)(it - contents.mParams.begin());
             contents.mParamAppearanceVersion = ll_round(contents.mParamWeights[index]);
             //LL_DEBUGS("Avatar") << "appversion req by appearance_version param: " << contents.mParamAppearanceVersion << LL_ENDL;
-        }
-    }
-}
-
-static const U64 AVATAR_APPEARANCE_EXPIRY = 20 * USEC_PER_SEC;
-
-std::map<LLUUID, LLPointer<LLAppearanceMessageContents> > LLVOAvatar::sPendingAvatarAppearanceContents;
-std::map<LLUUID, U64>                                     LLVOAvatar::sPendingAvatarAppearanceExpiries;
-
-// static
-void LLVOAvatar::addPendingAvatarAppearance(const LLUUID& agent_id, LLMessageSystem* mesgsys)
-{
-    LLPointer<LLAppearanceMessageContents> contents(new LLAppearanceMessageContents);
-    parseAppearanceMessage(mesgsys, agent_id, *contents);
-
-    sPendingAvatarAppearanceContents[agent_id] = contents;
-    sPendingAvatarAppearanceExpiries[agent_id] = totalTime() + AVATAR_APPEARANCE_EXPIRY;
-}
-
-// static
-void LLVOAvatar::applyPendingAvatarAppearance(LLVOAvatar* avatarp)
-{
-    if (avatarp)
-    {
-        auto contents_iter = sPendingAvatarAppearanceContents.find(avatarp->getID());
-        if (contents_iter != sPendingAvatarAppearanceContents.end())
-        {
-            LLPointer<LLAppearanceMessageContents> contents = contents_iter->second;
-            sPendingAvatarAppearanceContents.erase(contents_iter);
-            sPendingAvatarAppearanceExpiries.erase(avatarp->getID());
-
-            LL_DEBUGS("Messaging") << "Applying deferred AvatarAppearance for " << avatarp->getID() << LL_ENDL;
-            avatarp->mLastAppearanceMessageTimer.reset();
-            avatarp->processParsedAppearanceMessage(contents);
-        }
-    }
-
-    // check for expired entries
-    U64 now = totalTime();
-    for (auto timer_iter = sPendingAvatarAppearanceExpiries.begin(); timer_iter != sPendingAvatarAppearanceExpiries.end(); )
-    {
-        if (now > timer_iter->second)
-        {
-            LL_WARNS("Messaging") << "Expired AvatarAppearance for agent " << timer_iter->first << LL_ENDL;
-            sPendingAvatarAppearanceContents.erase(timer_iter->first);
-            timer_iter = sPendingAvatarAppearanceExpiries.erase(timer_iter);
-        }
-        else
-        {
-            ++timer_iter;
         }
     }
 }
@@ -9817,20 +9746,11 @@ void LLVOAvatar::processAvatarAppearance( LLMessageSystem* mesgsys )
     mLastAppearanceMessageTimer.reset();
 
     LLPointer<LLAppearanceMessageContents> contents(new LLAppearanceMessageContents);
-    parseAppearanceMessage(mesgsys, getID(), *contents);
+    parseAppearanceMessage(mesgsys, *contents);
     if (enable_verbose_dumps)
     {
         dumpAppearanceMsgParams(dump_prefix + "appearance_msg", *contents);
     }
-
-    processParsedAppearanceMessage(contents);
-}
-
-void LLVOAvatar::processParsedAppearanceMessage(LLPointer<LLAppearanceMessageContents>& contents)
-{
-    // Resolve the avatar-agnostic parts of contents (raw visual param values, attachment data)
-    // against this avatar's live state now that we know it exists.
-    resolveAppearanceMessageContents(*contents);
 
     S32 appearance_version;
     if (!resolve_appearance_version(*contents, appearance_version))

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -949,27 +949,19 @@ protected:
  **                    APPEARANCE
  **/
 
+public:
+    // Used when an AvatarAppearance UDP message is received before the
+    // corresponding avatar could be created.
+    static void registerEarlyAppearance(const LLUUID& av_id)
+    {
+        sEarlyApperanceList.emplace(av_id);
+    }
+
     LLPointer<LLAppearanceMessageContents>  mLastProcessedAppearance;
 
-public:
-    static void     parseAppearanceMessage(LLMessageSystem* mesgsys, const LLUUID& agent_id, LLAppearanceMessageContents& contents);
-    void            resolveAppearanceMessageContents(LLAppearanceMessageContents& contents);
+    void            parseAppearanceMessage(LLMessageSystem* mesgsys, LLAppearanceMessageContents& msg);
     void            processAvatarAppearance(LLMessageSystem* mesgsys);
-
-    void            processParsedAppearanceMessage(LLPointer<LLAppearanceMessageContents>& contents);
     void            applyParsedAppearanceMessage(LLAppearanceMessageContents& contents, bool slam_params);
-
-    // An AvatarAppearance message can arrive before the ObjectUpdate that creates its avatar.
-    // Rather than drop such a message, store its parsed contents in a map and apply them
-    // when the avatar shows up. Entries older than AVATAR_APPEARANCE_EXPIRY are dropped.
-    static void     addPendingAvatarAppearance(const LLUUID& agent_id, LLMessageSystem* mesgsys);
-    static void     applyPendingAvatarAppearance(LLVOAvatar* avatarp);
-
-private:
-    static std::map<LLUUID, LLPointer<LLAppearanceMessageContents> > sPendingAvatarAppearanceContents;
-    static std::map<LLUUID, U64>                                     sPendingAvatarAppearanceExpiries;
-
-public:
     void            hideHair();
     void            hideSkirt();
     void            startAppearanceAnimation();
@@ -997,6 +989,8 @@ private:
     F32             mLastAppearanceBlendTime;
     bool            mIsEditingAppearance; // flag for if we're actively in appearance editing mode
     bool            mUseLocalAppearance; // flag for if we're using a local composite
+
+    static uuid_list_t  sEarlyApperanceList;
 
     //--------------------------------------------------------------------
     // Visibility

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -952,9 +952,32 @@ protected:
     LLPointer<LLAppearanceMessageContents>  mLastProcessedAppearance;
 
 public:
-    void            parseAppearanceMessage(LLMessageSystem* mesgsys, LLAppearanceMessageContents& msg);
+    // Decodes the wire message into contents. Avatar-agnostic: does not require (and must not
+    // require) a live LLVOAvatar instance, since it also runs for AvatarAppearance messages that
+    // arrive before their avatar's ObjectUpdate has been received.
+    static void     parseAppearanceMessage(LLMessageSystem* mesgsys, const LLUUID& agent_id, LLAppearanceMessageContents& contents);
+    // Resolves the avatar-agnostic parts of contents (raw visual param values, attachment data)
+    // against this avatar's live state, e.g. LLVisualParam pointers. Requires a real avatar instance.
+    void            resolveAppearanceMessageContents(LLAppearanceMessageContents& contents);
     void            processAvatarAppearance(LLMessageSystem* mesgsys);
+
+    // Continuation of processAvatarAppearance() starting from already-parsed contents, shared by
+    // both the normal (avatar already exists) and deferred (see below) paths.
+    void            processParsedAppearanceMessage(const LLPointer<LLAppearanceMessageContents>& contents);
     void            applyParsedAppearanceMessage(LLAppearanceMessageContents& contents, bool slam_params);
+
+    // An AvatarAppearance message can arrive before the ObjectUpdate that creates its avatar.
+    // Rather than drop such a message, store its parsed contents in a map and apply them
+    // when the avatar shows up. Entries older than AVATAR_APPEARANCE_EXPIRY are dropped.
+    static void     addPendingAvatarAppearance(const LLUUID& agent_id, LLMessageSystem* mesgsys);
+    static void     applyPendingAvatarAppearance(LLVOAvatar* avatarp);
+
+private:
+    static std::map<LLUUID, LLPointer<LLAppearanceMessageContents> > sPendingAvatarAppearanceContents;
+    // Value is the totalTime() (microseconds) at which the entry expires.
+    static std::map<LLUUID, U64>                                     sPendingAvatarAppearanceTimers;
+
+public:
     void            hideHair();
     void            hideSkirt();
     void            startAppearanceAnimation();

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -954,7 +954,7 @@ public:
     // corresponding avatar could be created.
     static void registerEarlyAppearance(const LLUUID& av_id)
     {
-        sEarlyApperanceList.emplace(av_id);
+        sEarlyAppearanceList.emplace(av_id);
     }
 
     LLPointer<LLAppearanceMessageContents>  mLastProcessedAppearance;
@@ -990,7 +990,7 @@ private:
     bool            mIsEditingAppearance; // flag for if we're actively in appearance editing mode
     bool            mUseLocalAppearance; // flag for if we're using a local composite
 
-    static uuid_list_t  sEarlyApperanceList;
+    static uuid_list_t  sEarlyAppearanceList;
 
     //--------------------------------------------------------------------
     // Visibility

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -952,17 +952,10 @@ protected:
     LLPointer<LLAppearanceMessageContents>  mLastProcessedAppearance;
 
 public:
-    // Decodes the wire message into contents. Avatar-agnostic: does not require (and must not
-    // require) a live LLVOAvatar instance, since it also runs for AvatarAppearance messages that
-    // arrive before their avatar's ObjectUpdate has been received.
     static void     parseAppearanceMessage(LLMessageSystem* mesgsys, const LLUUID& agent_id, LLAppearanceMessageContents& contents);
-    // Resolves the avatar-agnostic parts of contents (raw visual param values, attachment data)
-    // against this avatar's live state, e.g. LLVisualParam pointers. Requires a real avatar instance.
     void            resolveAppearanceMessageContents(LLAppearanceMessageContents& contents);
     void            processAvatarAppearance(LLMessageSystem* mesgsys);
 
-    // Continuation of processAvatarAppearance() starting from already-parsed contents, shared by
-    // both the normal (avatar already exists) and deferred (see below) paths.
     void            processParsedAppearanceMessage(LLPointer<LLAppearanceMessageContents>& contents);
     void            applyParsedAppearanceMessage(LLAppearanceMessageContents& contents, bool slam_params);
 
@@ -974,8 +967,7 @@ public:
 
 private:
     static std::map<LLUUID, LLPointer<LLAppearanceMessageContents> > sPendingAvatarAppearanceContents;
-    // Value is the totalTime() (microseconds) at which the entry expires.
-    static std::map<LLUUID, U64>                                     sPendingAvatarAppearanceTimers;
+    static std::map<LLUUID, U64>                                     sPendingAvatarAppearanceExpiries;
 
 public:
     void            hideHair();

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -963,7 +963,7 @@ public:
 
     // Continuation of processAvatarAppearance() starting from already-parsed contents, shared by
     // both the normal (avatar already exists) and deferred (see below) paths.
-    void            processParsedAppearanceMessage(const LLPointer<LLAppearanceMessageContents>& contents);
+    void            processParsedAppearanceMessage(LLPointer<LLAppearanceMessageContents>& contents);
     void            applyParsedAppearanceMessage(LLAppearanceMessageContents& contents, bool slam_params);
 
     // An AvatarAppearance message can arrive before the ObjectUpdate that creates its avatar.

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -957,6 +957,16 @@ public:
         sEarlyAppearanceList.emplace(av_id);
     }
 
+    // Entries left behind by agents who never get instantiated (e.g. an
+    // AvatarAppearance message arrives for an avatar we never rez) are a
+    // small resource leak. Teleporting to another region invalidates the
+    // whole list, since it was only ever relevant to avatars in the region
+    // we're leaving, so clear it out at that point to bound the leak.
+    static void resetEarlyAppearanceList()
+    {
+        sEarlyAppearanceList.clear();
+    }
+
     LLPointer<LLAppearanceMessageContents>  mLastProcessedAppearance;
 
     void            parseAppearanceMessage(LLMessageSystem* mesgsys, LLAppearanceMessageContents& msg);


### PR DESCRIPTION
This PR fixes issue #6009 where the high- and low-priority UDP message queue would exacerbate a race condition where the **AvatarAppearance** message would be processed before the agent was created by its first **ObjectUpdate**.  It also changes where the packet sequence ID is processed to reduce the WARNING logs about out-of-order packets caused by asymmetric priority during packet floods.
