### PR TITLE
Fix undefined symbol link error in llcorehttp

### DIFF
--- a/indra/llcorehttp/httpcommon.cpp
+++ b/indra/llcorehttp/httpcommon.cpp
@@ -36,9 +36,9 @@
 namespace LLCore
 {
 
-HttpStatus::type_enum_t EXT_CURL_EASY;
-HttpStatus::type_enum_t EXT_CURL_MULTI;
-HttpStatus::type_enum_t LLCORE;
+const HttpStatus::type_enum_t HttpStatus::EXT_CURL_EASY;
+const HttpStatus::type_enum_t HttpStatus::EXT_CURL_MULTI;
+const HttpStatus::type_enum_t HttpStatus::LLCORE;
 
 HttpStatus::operator U32() const
 {


### PR DESCRIPTION
These static consts in `HttpStatus` were not actually defined --fails with a link error periodically on Xcode 26.6 and maybe some other toolchains.