### PR TITLE
#6014 Reduce shutdown delays on thread cleanup

### DIFF
--- a/indra/llappearance/llpolymesh.cpp
+++ b/indra/llappearance/llpolymesh.cpp
@@ -862,6 +862,7 @@ LLPolyMesh *LLPolyMesh::getMesh(const std::string &name, LLPolyMesh* reference_m
 //-----------------------------------------------------------------------------
 void LLPolyMesh::freeAllMeshes()
 {
+    LL_PROFILE_ZONE_SCOPED;
         // delete each item in the global lists
         for_each(sGlobalSharedMeshList.begin(), sGlobalSharedMeshList.end(), DeletePairedPointer());
         sGlobalSharedMeshList.clear();

--- a/indra/llcommon/llcoros.cpp
+++ b/indra/llcommon/llcoros.cpp
@@ -252,6 +252,7 @@ void LLCoros::setStackSize(S32 stacksize)
 
 void LLCoros::printActiveCoroutines(const std::string& when)
 {
+    LL_PROFILE_ZONE_SCOPED;
     LL_INFOS("LLCoros") << "Number of active coroutines " << when
                         << ": " << CoroData::instanceCount() << LL_ENDL;
     if (CoroData::instanceCount() > 0)

--- a/indra/llcommon/llqueuedthread.cpp
+++ b/indra/llcommon/llqueuedthread.cpp
@@ -222,6 +222,33 @@ void LLQueuedThread::waitOnPending()
     return;
 }
 
+void LLQueuedThread::waitOnPending(F32 max_time_sec)
+{
+    LLTimer wait_timer;
+    wait_timer.reset();
+    while (1)
+    {
+        update(0);
+
+        if (mIdleThread)
+        {
+            break;
+        }
+
+        if (wait_timer.getElapsedTimeF64() >= max_time_sec)
+        {
+            LL_WARNS() << "waitOnPending() timed out after " << max_time_sec
+                << " seconds in thread: " << mName << LL_ENDL;
+            break;
+        }
+
+        if (mThreaded)
+        {
+            yield();
+        }
+    }
+}
+
 // MAIN thread
 void LLQueuedThread::printQueueStats()
 {

--- a/indra/llcommon/llqueuedthread.h
+++ b/indra/llcommon/llqueuedthread.h
@@ -141,6 +141,7 @@ public:
     size_t updateQueue(F32 max_time_ms);
 
     void waitOnPending();
+    void waitOnPending(F32 max_time_sec);
     void printQueueStats();
 
     virtual size_t getPending();

--- a/indra/llcommon/llthread.cpp
+++ b/indra/llcommon/llthread.cpp
@@ -314,11 +314,13 @@ void LLThread::shutdown()
             // The thread isn't already stopped
             // First, set the flag that indicates that we're ready to die
             setQuitting();
+            if (!isStopped())
+            {
+                // Give the thread a chance to update status.
+                yield();
+            }
 
             //LL_INFOS() << "LLThread::~LLThread() Killing thread " << mName << " Status: " << mStatus << LL_ENDL;
-            // Now wait a bit for the thread to exit
-            // It's unclear whether I should even bother doing this - this destructor
-            // should never get called unless we're already stopped, really...
             S32 counter = 0;
             const S32 MAX_WAIT = 600;
             while (counter < MAX_WAIT)
@@ -327,9 +329,9 @@ void LLThread::shutdown()
                 {
                     break;
                 }
-                // Sleep for a tenth of a second
-                ms_sleep(100);
-                yield();
+                // Sleep for 10ms, 6 seconds total, then give up and kill the thread
+                // Warning: This can be called from the main thread
+                ms_sleep(10);
                 counter++;
             }
         }

--- a/indra/llcommon/llwatchdog.cpp
+++ b/indra/llcommon/llwatchdog.cpp
@@ -236,6 +236,7 @@ void LLWatchdog::shutdown()
 
 void LLWatchdog::cleanup()
 {
+    LL_PROFILE_ZONE_SCOPED;
     if (mTimer)
     {
         mTimer->stop();

--- a/indra/llcommon/llwatchdog.cpp
+++ b/indra/llcommon/llwatchdog.cpp
@@ -51,6 +51,7 @@ public:
     {
         mStopping = true;
         mSleepMsecs = 1;
+        setQuitting();
     }
 
     void run() override
@@ -225,11 +226,20 @@ void LLWatchdog::init(
     mCrashOnFreeze = crash_on_freeze;
 }
 
+void LLWatchdog::shutdown()
+{
+    if (mTimer)
+    {
+        mTimer->stop();
+    }
+}
+
 void LLWatchdog::cleanup()
 {
     if (mTimer)
     {
         mTimer->stop();
+        mTimer->shutdown();
         delete mTimer;
         mTimer = nullptr;
     }

--- a/indra/llcommon/llwatchdog.h
+++ b/indra/llcommon/llwatchdog.h
@@ -107,6 +107,7 @@ public:
         bool crash_on_freeze);
     void run();
     void cleanup();
+    void shutdown();
 
 
 private:

--- a/indra/llfilesystem/lllfsthread.cpp
+++ b/indra/llfilesystem/lllfsthread.cpp
@@ -51,6 +51,7 @@ S32 LLLFSThread::updateClass(U32 ms_elapsed)
 //static
 void LLLFSThread::cleanupClass()
 {
+    LL_PROFILE_ZONE_SCOPED;
     llassert(sLocal != NULL);
     sLocal->setQuitting();
     while (sLocal->getPending())

--- a/indra/llmessage/message.cpp
+++ b/indra/llmessage/message.cpp
@@ -2906,6 +2906,7 @@ void LLMessageSystem::summarizeLogs(std::ostream& str)
 
 void end_messaging_system(bool print_summary)
 {
+    LL_PROFILE_ZONE_SCOPED;
     gTransferManager.cleanup();
     LLTransferTargetVFile::updateQueue(true); // shutdown LLTransferTargetVFile
     if (gMessageSystem)

--- a/indra/llphysicsextensionsos/llphysicsextensions.cpp
+++ b/indra/llphysicsextensionsos/llphysicsextensions.cpp
@@ -72,6 +72,7 @@
 //=============================================================================
 /*static */bool LLPhysicsExtensions::quitSystem()
 {
+    LL_PROFILE_ZONE_SCOPED;
     return LLPhysicsExtensionsImpl::quitSystem();
 }
 //=============================================================================

--- a/indra/llplugin/llpluginclassmedia.cpp
+++ b/indra/llplugin/llpluginclassmedia.cpp
@@ -92,6 +92,7 @@ bool LLPluginClassMedia::init(const std::string &launcher_filename, const std::s
 
 void LLPluginClassMedia::reset()
 {
+    LL_PROFILE_ZONE_SCOPED;
     if(mPlugin)
     {
         mPlugin->requestShutdown();

--- a/indra/llxml/llcontrol.cpp
+++ b/indra/llxml/llcontrol.cpp
@@ -407,6 +407,7 @@ static bool compareRoutine(settings_pair_t lhs, settings_pair_t rhs)
 
 void LLControlGroup::cleanup()
 {
+    LL_PROFILE_ZONE_SCOPED;
     if(mSettingsProfile && getCount.size() != 0)
     {
         std::string file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, SETTINGS_PROFILE);
@@ -982,6 +983,7 @@ U32 LLControlGroup::loadFromFileLegacy(const std::string& filename, bool require
 
 U32 LLControlGroup::saveToFile(const std::string& filename, bool nondefault_only)
 {
+    LL_PROFILE_ZONE_SCOPED;
     LLSD settings;
     int num_saved = 0;
     for (ctrl_name_table_t::iterator iter = mNameTable.begin();

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -1750,6 +1750,14 @@ bool LLAppViewer::cleanup()
     LLPluginProcessParent::shutdown();
 
     disconnectViewer();
+
+    if (LLWatchdog::instanceExists())
+    {
+        // Signal a stop early, so that it will be out
+        // of sleep loop by the time we get to clean it.
+        LLWatchdog::getInstance()->shutdown();
+    }
+
     LLViewerCamera::deleteSingleton();
 
     LL_INFOS() << "Viewer disconnected" << LL_ENDL;
@@ -2079,7 +2087,7 @@ bool LLAppViewer::cleanup()
     if (sTextureFetch)
     {
         sTextureFetch->shutdown();
-        sTextureFetch->waitOnPending();
+        sTextureFetch->waitOnPending(10.f);
         delete sTextureFetch;
         sTextureFetch = NULL;
     }
@@ -2124,7 +2132,10 @@ bool LLAppViewer::cleanup()
     gSavedSettings.cleanup();
     LLUIColorTable::instance().clear();
 
-    LLWatchdog::getInstance()->cleanup();
+    if (LLWatchdog::instanceExists())
+    {
+        LLWatchdog::getInstance()->cleanup();
+    }
 
     LLViewerAssetStatsFF::cleanup();
 


### PR DESCRIPTION
Viewer runs a lot of different threads and each one was waiting 100ms on shutdown. Watchdog was waiting for internal sleep to finish.