### PR TITLE
Move back to using culling states for texture streaming GC.

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -12179,6 +12179,17 @@
         <key>Value</key>
         <real>1.0</real>
     </map>
+    <key>TextureStreamDebugText</key>
+    <map>
+      <key>Comment</key>
+      <string>Show per-texture streaming diagnostics as floating debug text on objects: current&gt;desired discard, held/full dims, measured coverage (px^2), behindness, off-screen flag, frames since last confirmed visible.</string>
+      <key>Persist</key>
+      <integer>0</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
     <key>TextureUnloadDwellSeconds</key>
     <map>
       <key>Comment</key>
@@ -12189,6 +12200,17 @@
       <string>F32</string>
       <key>Value</key>
       <real>1.0</real>
+    </map>
+    <key>TextureVRAMReserve</key>
+    <map>
+      <key>Comment</key>
+      <string>Fraction of the texture VRAM budget held in reserve for other applications. Applied before the pressure watermarks. 0..0.9.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>0.2</real>
     </map>
     <key>ThreadPoolSizes</key>
     <map>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -8038,7 +8038,7 @@
   <key>RenderTextureQuality</key>
   <map>
     <key>Comment</key>
-    <string>Texture quality preset: 0=Low, 1=Medium, 2=High, 3=Ultra. Drives RenderMaxTextureResolution, TexturePixelToTexelRatio, TexturePressureTightenRate, TexturePressureRelaxRate, and TextureChannelRatio* (Normal/BaseColor/Specular/Emissive). The pressure water marks (TexturePressureHighWater/LowWater) are constant across tiers.</string>
+    <string>Texture quality preset: 0=Low, 1=Medium, 2=High, 3=Ultra. Drives RenderMaxTextureResolution, TexturePixelToTexelRatio, TexturePressureTightenRate, TexturePressureRelaxRate, TextureChannelRatio* (Normal/BaseColor/Specular/Emissive), TextureOffscreenUnloadBias, TextureGCStepSeconds, TextureCooldownStepSeconds, and TextureUpRezMargin. The pressure water marks (TexturePressureHighWater/LowWater) are constant across tiers.</string>
     <key>Persist</key>
     <integer>1</integer>
     <key>Type</key>
@@ -11970,21 +11970,21 @@
       <key>Value</key>
       <real>5.0</real>
     </map>
-    <key>TextureGCStepFrames</key>
+    <key>TextureGCStepSeconds</key>
     <map>
       <key>Comment</key>
-      <string>Foreground GC cooldown, in rendered frames. For every this many frames a texture goes without being drawn, its mip drops by TextureGCStepMips. Resets when the texture is drawn again.</string>
+      <string>Wall-clock seconds per unload step once TextureUnloadDwellSeconds has elapsed: every this many seconds of continued off-screen/occlusion staleness drops the mip by TextureGCStepMips. Driven by the RenderTextureQuality preset.</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>
-      <string>U32</string>
+      <string>F32</string>
       <key>Value</key>
-      <integer>5</integer>
+      <real>2.0</real>
     </map>
     <key>TextureGCStepMips</key>
     <map>
       <key>Comment</key>
-      <string>Mip levels dropped each time a TextureGCStepFrames cooldown elapses. 1 is gentlest; higher sheds VRAM faster in coarser jumps.</string>
+      <string>Mip levels dropped each time a TextureGCStepSeconds cooldown elapses. 1 is gentlest; higher sheds VRAM faster in coarser jumps.</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>
@@ -12024,17 +12024,6 @@
       <string>U32</string>
       <key>Value</key>
       <integer>2</integer>
-    </map>
-    <key>TextureFrustumAllowance</key>
-    <map>
-      <key>Comment</key>
-      <string>Falloff width for out-of-frustum texture resolution, as a fraction of screen size. Content grazing the screen edge keeps full resolution; content this far past the edge reaches the deepest mip, lerped between. Keeps barely-out-of-view textures resident so panning back doesn't refetch them.</string>
-      <key>Persist</key>
-      <integer>1</integer>
-      <key>Type</key>
-      <string>F32</string>
-      <key>Value</key>
-      <real>0.5</real>
     </map>
     <key>TextureDecodeDisabled</key>
     <map>
@@ -12178,6 +12167,28 @@
         <string>F32</string>
         <key>Value</key>
         <real>0.25</real>
+    </map>
+    <key>TextureOffscreenUnloadBias</key>
+    <map>
+        <key>Comment</key>
+        <string>How far out of frustum content must be before angle-driven unload reaches full depth, in behindness units (0 = frustum edge, 1 = directly behind). Unload fraction ramps linearly from the frustum edge to this point. Below 1 = full unload nearer the frustum edge (aggressive); above 1 = even directly-behind content never fully unloads (protective); 0 disables angle-driven unload.</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>F32</string>
+        <key>Value</key>
+        <real>1.0</real>
+    </map>
+    <key>TextureUnloadDwellSeconds</key>
+    <map>
+      <key>Comment</key>
+      <string>Seconds a texture must be continuously off-screen, occlusion-stale, or unmeasured before its first unload step; later steps follow TextureGCStepSeconds. Wall-clock, independent of frame rate. Damps evict/refetch cycling from glances away, occlusion flap, and geometry rebuilds.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>1.0</real>
     </map>
     <key>ThreadPoolSizes</key>
     <map>

--- a/indra/newview/llface.cpp
+++ b/indra/newview/llface.cpp
@@ -2454,19 +2454,25 @@ bool LLFace::calcPixelArea(F32& cos_angle_to_view_dir, F32& radius)
         mImportanceToCamera = LLFace::calcImportanceToCamera(cos_angle_to_view_dir, dist) ;
     }
 
-    // On-screen test: does the face's projected disc overlap the screen disc?
-    // (Same construction as adjustPartialOverlapPixelArea.) Behind-camera faces
-    // get acos(cos) near pi and fall out; the generous screen radius errs toward
-    // "on screen" so fetch admission never starves edge content. mFrustumOverflow
-    // is how far past the boundary the disc sits, as a fraction of screen size -
-    // 0 on screen, 0.1 = 10% of a screen out - and feeds the frustum allowance
-    // falloff in computeDesiredDiscard.
+    // Screen-disc overlap -> mInFrustum; angular off-screen-ness ->
+    // mBehindness (0 = on screen, 1 = directly behind). Feeds fetch
+    // admission and the off-screen falloff in computeDesiredDiscard.
     {
         F32 center_px = acosf(llclamp(cos_angle_to_view_dir, -1.f, 1.f)) * LLDrawable::sCurPixelAngle;
         F32 screen_radius = (F32)llmax(gViewerWindow->getWindowWidthRaw(), gViewerWindow->getWindowHeightRaw());
         F32 past_edge = center_px - radius - screen_radius;
         mInFrustum = past_edge <= 5.f;
-        mFrustumOverflow = llmax(past_edge - 5.f, 0.f) / screen_radius;
+
+        // Two boundaries on purpose: mInFrustum stays generous (fetch
+        // admission errs open); mBehindness starts at the circumscribed disc
+        // (~the real frustum edge) so everything outside the view belongs to
+        // the angular policy, never the GC.
+        F32 w = (F32)gViewerWindow->getWindowWidthRaw();
+        F32 h = (F32)gViewerWindow->getWindowHeightRaw();
+        F32 screen_half_diag = 0.5f * sqrtf(w * w + h * h);
+        F32 ang = acosf(llclamp(cos_angle_to_view_dir, -1.f, 1.f));
+        F32 edge_ang = (radius + screen_half_diag + 5.f) / LLDrawable::sCurPixelAngle;
+        mBehindness = llclamp((ang - edge_ang) / llmax(F_PI - edge_ang, 0.001f), 0.f, 1.f);
     }
 
     mLastCosAngleToViewDir = cos_angle_to_view_dir;

--- a/indra/newview/llface.h
+++ b/indra/newview/llface.h
@@ -273,10 +273,11 @@ public:
     // by calcPixelArea() (sticky between its throttled updates). Drives per-texture
     // fetch admission (LLViewerTextureList::updateImageDecodePriority -> mOnScreen).
     bool mInFrustum = false;
-    // How far past the screen boundary the projected disc sits, as a fraction of
-    // screen size (0 = on screen). Feeds the frustum-allowance falloff so barely
-    // out-of-view content keeps its resolution. Maintained with mInFrustum.
-    F32 mFrustumOverflow = 0.f;
+    // Angular off-screen-ness of the face: 0 = projected disc overlaps the screen
+    // (or ahead), 1 = directly behind the camera. Maintained with mInFrustum by
+    // calcPixelArea (sticky between throttled updates); drives the off-screen
+    // unload falloff.
+    F32 mBehindness = 0.f;
     // value of gFrameCount the last time the face was touched by LLViewerTextureList::updateImageDecodePriority
     U32 mLastTextureUpdate = 0;
     // Cached per-channel streaming coverage (repeat-adjusted screen pixels),

--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -128,6 +128,10 @@ namespace
         F32 channel_ratio_basecolor;    // TextureChannelRatioBaseColor
         F32 channel_ratio_specular;     // TextureChannelRatioSpecular
         F32 channel_ratio_emissive;     // TextureChannelRatioEmissive
+        F32 offscreen_unload_bias;      // TextureOffscreenUnloadBias
+        F32 gc_step_seconds;            // TextureGCStepSeconds  (wall-clock)
+        F32 cooldown_step_seconds;      // TextureCooldownStepSeconds
+        F32 uprez_margin;               // TextureUpRezMargin
     };
 
     // Tier values: Low (2-4GB), Medium (4-8GB), High (8-16GB), Ultra (16+GB).
@@ -138,15 +142,19 @@ namespace
     //    floor (down to 0 = deepest mips), so there is no per-tier minimum.
     //  - the channel ratios coarsen specular/emissive/normal relative to base
     //    color (each is a multiplier on the global ratio).
+    //  - offscreen_unload_bias (UB) is the behindness (0 = frustum edge,
+    //    1 = directly behind) at which out-of-frustum content reaches full
+    //    unload: lower tiers slam sooner; High/Ultra (1.0) only reach full
+    //    unload directly behind the camera.
     // The pressure water marks (TexturePressureHighWater/LowWater) are NOT tiered - they're a
     // physical "crossed the budget" threshold (0.90 / 0.70), constant across
     // tiers. Lower tiers start blurrier (lower R_max) and tighten faster.
-    //                            max_res  Rmax   tight  relax  N      BC     S      E
+    //                            max_res  Rmax   tight  relax  N      BC     S      E       UB     GC     CD     UR
     static constexpr TexturePreset TEXTURE_PRESETS[4] = {
-        /* 0 Low    */ { "Low",    1024,   0.10f, 0.50f, 0.05f, 0.50f, 1.00f, 0.25f, 0.25f },
-        /* 1 Medium */ { "Medium", 2048,   0.40f, 0.35f, 0.08f, 1.00f, 1.00f, 0.50f, 0.50f },
-        /* 2 High   */ { "High",   2048,   0.80f, 0.25f, 0.10f, 1.00f, 1.00f, 0.50f, 1.00f },
-        /* 3 Ultra  */ { "Ultra",  2048,   1.00f, 0.15f, 0.12f, 1.00f, 1.00f, 1.00f, 1.00f },
+        /* 0 Low    */ { "Low",    1024,   0.10f, 0.50f, 0.05f, 0.50f, 1.00f, 0.25f, 0.25f,  0.25f,  1.0f,  5.0f,  0.2f },
+        /* 1 Medium */ { "Medium", 2048,   0.40f, 0.35f, 0.08f, 1.00f, 1.00f, 0.50f, 0.50f,  0.50f,  1.0f,  5.0f,  0.2f },
+        /* 2 High   */ { "High",   2048,   0.80f, 0.25f, 0.10f, 1.00f, 1.00f, 0.50f, 1.00f,  1.00f,  2.0f,  5.0f,  0.2f },
+        /* 3 Ultra  */ { "Ultra",  2048,   1.00f, 0.15f, 0.12f, 1.00f, 1.00f, 1.00f, 1.00f,  1.00f,  2.0f,  5.0f,  0.2f },
     };
 }
 
@@ -164,6 +172,10 @@ static bool handleRenderTextureQualityChanged(const LLSD& newvalue)
     gSavedSettings.setF32("TextureChannelRatioBaseColor",   p.channel_ratio_basecolor);
     gSavedSettings.setF32("TextureChannelRatioSpecular",    p.channel_ratio_specular);
     gSavedSettings.setF32("TextureChannelRatioEmissive",    p.channel_ratio_emissive);
+    gSavedSettings.setF32("TextureOffscreenUnloadBias",     p.offscreen_unload_bias);
+    gSavedSettings.setF32("TextureGCStepSeconds",           p.gc_step_seconds);
+    gSavedSettings.setF32("TextureCooldownStepSeconds",     p.cooldown_step_seconds);
+    gSavedSettings.setF32("TextureUpRezMargin",             p.uprez_margin);
 
     LL_INFOS("TextureStream") << "Applied texture quality preset: " << p.name << LL_ENDL;
     return true;

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -520,12 +520,13 @@ void LLViewerTexture::updateClass()
     // -Geenz 2025-03-21
     F32 vram_budget = max_vram_budget == 0 ? llmax(1024, (F32)gGLManager.mVRAM / tex_vram_divisor) : (F32)max_vram_budget;
 
-    // Try to leave at least half a GB for everyone else and for bias,
-    // but keep at least 768MB for ourselves
-    // Viewer can 'overshoot' target when scene changes, if viewer goes over budget it
-    // can negatively impact performance, so leave 20% of a breathing room for
-    // 'bias' calculation to kick in.
-    F32 vram_target = llmax(llmin(vram_budget - 512.f, vram_budget * 0.8f), MIN_VRAM_BUDGET);
+    // Leave VRAM in reserve for other applications. Applied before the
+    // watermarks.
+    static LLCachedControl<F32> vram_reserve(gSavedSettings, "TextureVRAMReserve", 0.2f);
+    vram_budget *= 1.f - llclamp((F32)vram_reserve, 0.f, 0.9f);
+
+    // Keep at least half a GB for everyone else, but at least 768MB for us.
+    F32 vram_target = llmax(vram_budget - 512.f, MIN_VRAM_BUDGET);
     sFreeVRAMMegabytes = vram_target - vram_used;
 
     // VRAM pressure controller for the global pixel:texel ratio. Tightens above
@@ -564,11 +565,17 @@ void LLViewerTexture::updateClass()
         }
         else if (vram_used > high)
         {
-            sPixelToTexelRatio -= llmax((F32)tighten_rate, 0.f) * dt;
+            // Proportional, not constant-rate: full speed only when far past
+            // the watermark, tapering to 0 at the band edge. The constant-rate
+            // relay + lagging actuator (instant quantized evict, seconds-slow
+            // refetch) limit-cycled the whole scene between r~0 and r~1.
+            F32 p = llclamp((vram_used - high) / llmax(vram_budget * 0.1f, 1.f), 0.f, 1.f);
+            sPixelToTexelRatio -= llmax((F32)tighten_rate, 0.f) * p * dt;
         }
         else if (vram_used < low)
         {
-            sPixelToTexelRatio += llmax((F32)relax_rate, 0.f) * dt;
+            F32 p = llclamp((low - vram_used) / llmax(vram_budget * 0.1f, 1.f), 0.f, 1.f);
+            sPixelToTexelRatio += llmax((F32)relax_rate, 0.f) * p * dt;
         }
         // else: hold in the hysteresis band.
 
@@ -2080,15 +2087,6 @@ bool LLViewerFetchedTexture::updateFetch()
         LL_PROFILE_ZONE_NAMED_CATEGORY_TEXTURE("vftuf - priority <= 0");
         make_request = false;
     }
-    else if (mDesiredDiscardLevel > (S32)mCodecMaxDiscardLevel &&
-             current_discard >= 0)
-    {
-        // Desired is past codec_max. Only scaleDown can satisfy it.
-        // Applies even when current is also past codec_max (post-scaleDown);
-        // re-fetching at codec_max then scaleDown-ing again is pure thrash.
-        LL_PROFILE_ZONE_NAMED_CATEGORY_TEXTURE("vftuf - desired > codec max");
-        make_request = false;
-    }
     else  if (mNeedsCreateTexture || mIsMissingAsset)
     {
         LL_PROFILE_ZONE_NAMED_CATEGORY_TEXTURE("vftuf - create or missing");
@@ -2116,8 +2114,12 @@ bool LLViewerFetchedTexture::updateFetch()
         }
         else
         {
-            // already at a higher resolution mip, don't discard
-            if (current_discard >= 0 && current_discard <= desired_discard)
+            // Already at-or-finer than POLICY wants - compare against
+            // mDesiredDiscardLevel, not the codec-clamped request level:
+            // when policy wants coarser than the codec encodes, current
+            // settles past codec max via scaleDown, and comparing against
+            // the clamped value refetched data we just scaled away.
+            if (current_discard >= 0 && current_discard <= (S32)mDesiredDiscardLevel)
             {
                 LL_PROFILE_ZONE_NAMED_CATEGORY_TEXTURE("vftuf - current <= desired");
                 make_request = false;
@@ -3086,6 +3088,8 @@ S32 LLViewerLODTexture::computeDesiredDiscard(S32 dim_max_i, bool avatar_bake) c
         // Unmeasured is usually a transient rebuild: hold the current level
         // for a dwell before treating it as unused (this path bypasses the
         // hysteresis, so a premature slam is a full-depth bounce).
+        mDbgIdealPolicy = -1.f;
+        mDbgIdealFinal = -1.f;
         const S32 current_level = getDiscardLevel();
         if (current_level >= 0 && mLastMeasuredFrame > 0
             && (LLFrameTimer::getFrameCount() - mLastMeasuredFrame) <= dwell)
@@ -3095,6 +3099,7 @@ S32 LLViewerLODTexture::computeDesiredDiscard(S32 dim_max_i, bool avatar_bake) c
         return dim_max_i;   // never measured / persistently unmeasured -> coarsest mip
     }
     mLastMeasuredFrame = LLFrameTimer::getFrameCount();
+    mDbgIdealPolicy = ideal;
 
     // Unload lifecycle (avatar bakes exempt): two independent signals, deeper
     // one wins (max, not sum). Angular = out-of-frustum, ramping to full
@@ -3156,6 +3161,7 @@ S32 LLViewerLODTexture::computeDesiredDiscard(S32 dim_max_i, bool avatar_bake) c
     // (a 2048 map can't hit its own resolution on a 1080p screen), which reads
     // as everything being blurry. Pressure still evicts by lowering R_global.
     ideal = llmax(ideal, 0.f);
+    mDbgIdealFinal = ideal;
 
     const S32 target = (S32)floor(ideal);
 

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -1497,14 +1497,20 @@ void LLViewerFetchedTexture::postCreateTexture()
 
     setActive();
 
-    // Start the visibility-GC clock at creation. A texture fetched but never
-    // drawn (occluded, or the camera moved on) would otherwise keep
-    // mLastBindFrame == 0 forever, and the GC skips never-bound textures - it
-    // would hold residency indefinitely. Anchoring here means it ages out on
-    // the normal GC cooldown unless a real draw stamps it first.
+    // Start the GC staleness clocks at creation. A texture fetched but never
+    // drawn (occluded, or the camera moved on) would otherwise keep its clock at
+    // 0 forever, and the GC skips a 0 clock (the > 0 gate) - it would hold
+    // residency indefinitely. Anchoring here means it ages out on the normal GC
+    // cooldown unless a real sweep stamps it first. mLastVisibleFrame is the live
+    // cull-visibility clock the GC now reads; mLastBindFrame is the dormant bind
+    // clock, kept anchored pending its removal.
     if (mGLTexturep.notNull() && mGLTexturep->mLastBindFrame == 0)
     {
         mGLTexturep->mLastBindFrame = LLFrameTimer::getFrameCount();
+    }
+    if (mLastVisibleFrame == 0)
+    {
+        mLastVisibleFrame = LLFrameTimer::getFrameCount();
     }
 
     // rebuild any volumes that are using this texture for sculpts in case their LoD has changed
@@ -1523,6 +1529,12 @@ void LLViewerFetchedTexture::postCreateTexture()
         mNeedsAux = false;
     }
     destroyRawImage(); // will save raw image if needed
+
+    const S32 created_discard = getDiscardLevel();
+    if (created_discard >= 0)
+    {
+        mBestDiscardEver = llmin(mBestDiscardEver, (S8)created_discard);
+    }
 
     mNeedsCreateTexture = false;
 }
@@ -2041,11 +2053,16 @@ bool LLViewerFetchedTexture::updateFetch()
     // nearly free). Without this, seen-before textures (dims known, so the
     // coarse first-fetch fallback never applies) sat blurry for the whole
     // full-file read+decode, then popped. Boosted/pinned content still jumps.
+    // Stepping applies only to the never-before-reached frontier (likely
+    // network bytes); a target we have already held this session is
+    // disk-cache-backed and jumps straight to desired - re-stepping a reload
+    // is pure fetch-queue latency.
     static LLCachedControl<U32> fetch_step(gSavedSettings, "TextureFetchStepMips", 2);
     const S32 step = (S32)fetch_step;
     if (step > 0
         && current_discard >= 0
         && desired_discard < current_discard - step
+        && desired_discard < (S32)mBestDiscardEver
         && mBoostLevel < LLGLTexture::BOOST_HIGH
         && mUseMipMaps
         && !mDontDiscard
@@ -3057,9 +3074,80 @@ S32 LLViewerLODTexture::computeDesiredDiscard(S32 dim_max_i, bool avatar_bake) c
             d = (F32)(log((F64)mTexelsPerImage / (F64)allowed_texels) / log_4);
         ideal = llmin(ideal, d);
     }
+    // Dwell before any unload step so glances/flaps/rebuilds don't cycle
+    // evict/refetch. Clocks stamp frames; thresholds are wall-clock seconds
+    // (frame-denominated thresholds collapse at high FPS).
+    static LLCachedControl<F32> dwell_seconds(gSavedSettings, "TextureUnloadDwellSeconds", 1.f);
+    const F32 frame_secs = llclamp((F32)gFrameIntervalSeconds, 0.001f, 0.1f);
+    const U32 dwell = (U32)(llmax((F32)dwell_seconds, 0.f) / frame_secs);
+
     if (!measured)
     {
-        return dim_max_i;   // off-screen / never measured -> coarsest mip
+        // Unmeasured is usually a transient rebuild: hold the current level
+        // for a dwell before treating it as unused (this path bypasses the
+        // hysteresis, so a premature slam is a full-depth bounce).
+        const S32 current_level = getDiscardLevel();
+        if (current_level >= 0 && mLastMeasuredFrame > 0
+            && (LLFrameTimer::getFrameCount() - mLastMeasuredFrame) <= dwell)
+        {
+            return llclamp(current_level, 0, dim_max_i);
+        }
+        return dim_max_i;   // never measured / persistently unmeasured -> coarsest mip
+    }
+    mLastMeasuredFrame = LLFrameTimer::getFrameCount();
+
+    // Unload lifecycle (avatar bakes exempt): two independent signals, deeper
+    // one wins (max, not sum). Angular = out-of-frustum, ramping to full
+    // unload at behindness == bias. Occlusion GC = in-frustum staleness only
+    // (the sweep stamps the clock for out-of-frustum faces). Both dwell, then
+    // step per GC period, folded into ideal so the dead-band below damps all
+    // movement.
+    if (!avatar_bake)
+    {
+        static LLCachedControl<F32> unload_bias(gSavedSettings, "TextureOffscreenUnloadBias", 1.0f);
+        static LLCachedControl<F32> gc_step_seconds(gSavedSettings, "TextureGCStepSeconds", 2.f);
+        static LLCachedControl<U32> gc_step_mips(gSavedSettings, "TextureGCStepMips", 1);
+        const U32 now = LLFrameTimer::getFrameCount();
+        const U32 cooldown = llmax((U32)(llmax((F32)gc_step_seconds, 0.1f) / frame_secs), 1u);
+        const S32 step_mips = (S32)llmax((U32)gc_step_mips, 1u);
+        // Both signals measure depth from the same policy ideal.
+        const F32 range = llmax((F32)dim_max_i - ideal, 0.f);
+
+        F32 angular_mips = 0.f;
+        if (mBehindness > 0.f)
+        {
+            if (mOffScreenEnterFrame == 0)
+            {
+                mOffScreenEnterFrame = now;   // dwell starts at the on->off transition
+            }
+            // bias = the behindness at which unload reaches full depth;
+            // <= 0 disables angular unload.
+            const F32 bias = (F32)unload_bias;
+            const F32 unload_frac = (bias > 0.f) ? llclamp(mBehindness / bias, 0.f, 1.f) : 0.f;
+            const F32 target_mips = unload_frac * range;
+            const U32 off_frames = now - mOffScreenEnterFrame;
+            const S32 periods = (off_frames > dwell) ? (S32)((off_frames - dwell) / cooldown) + 1 : 0;
+            angular_mips = llclamp((F32)(periods * step_mips), 0.f, target_mips);
+        }
+        else
+        {
+            mOffScreenEnterFrame = 0;   // in frustum - reset the dwell clock
+        }
+
+        F32 gc_mips = 0.f;
+        if (getGLTexture())   // no GL memory = nothing to collect
+        {
+            constexpr U32 GC_RESUME_GRACE_FRAMES = 10;
+            if (mLastVisibleFrame > 0                                    // seen visible, or anchored at creation (postCreateTexture)
+                && now - sGCSuspendedFrame > GC_RESUME_GRACE_FRAMES)     // not just back from background
+            {
+                const U32 stale_frames = now - mLastVisibleFrame;
+                const S32 periods = (stale_frames > dwell) ? (S32)((stale_frames - dwell) / cooldown) + 1 : 0;
+                gc_mips = (F32)(llmax(periods, 0) * step_mips);
+            }
+        }
+
+        ideal += llmax(angular_mips, gc_mips);
     }
 
     // Round toward sharper (floor): a texture stays at a mip level until its
@@ -3068,22 +3156,6 @@ S32 LLViewerLODTexture::computeDesiredDiscard(S32 dim_max_i, bool avatar_bake) c
     // (a 2048 map can't hit its own resolution on a 1080p screen), which reads
     // as everything being blurry. Pressure still evicts by lowering R_global.
     ideal = llmax(ideal, 0.f);
-
-    // Frustum allowance: a falloff on how unloaded out-of-view content gets,
-    // by how far out it is. Grazing the edge keeps full resolution; at
-    // TextureFrustumAllowance (fraction of a screen) past the edge it reaches
-    // the deepest mip, lerped between. Keeps barely-out-of-view textures
-    // resident so a camera swing back doesn't refetch them. Applied to the
-    // continuous ideal so it shares the hysteresis dead-band below - applied
-    // after it, camera motion made desired flap a mip at a time and churned
-    // the fetch/scaleDown queues.
-    static LLCachedControl<F32> frustum_allowance(gSavedSettings, "TextureFrustumAllowance", 0.2f);
-    if (!avatar_bake && mFrustumOverflow > 0.f)
-    {
-        const F32 f = llclamp(mFrustumOverflow / llmax((F32)frustum_allowance, 0.01f), 0.f, 1.f);
-        ideal += f * ((F32)dim_max_i - ideal);
-        mLastOffScreenFrame = LLFrameTimer::getFrameCount();
-    }
 
     const S32 target = (S32)floor(ideal);
 
@@ -3100,7 +3172,9 @@ S32 LLViewerLODTexture::computeDesiredDiscard(S32 dim_max_i, bool avatar_bake) c
     }
     else if (ideal >= (F32)current + 1.f + margin)
     {
-        desired = target;                                   // clearly coarser -> evict
+        // floor(ideal - margin), not floor(ideal): the lifecycle ramps ideal
+        // in whole mips, so floor(ideal) always commits 2 levels at a time.
+        desired = (S32)floor(ideal - margin);               // clearly coarser -> evict
     }
     else if (ideal <= (F32)current - margin)
     {
@@ -3109,42 +3183,6 @@ S32 LLViewerLODTexture::computeDesiredDiscard(S32 dim_max_i, bool avatar_bake) c
     else
     {
         desired = current;                                  // inside the dead-band -> hold
-    }
-
-    // Foreground visibility GC (avatar bakes exempt). Background degradation is
-    // handled by the ratio decay in updateClass, and the GC self-suppresses while
-    // backgrounded via the sGCSuspendedFrame check below, so the two don't fight.
-    //
-    // For every gc_cooldown frames a texture goes without a camera bind, drop its
-    // mip by gc_step, walking gradually toward the deepest mip instead of slamming.
-    // Content drawn within the last cooldown stays full-res, so a fast camera pan
-    // finds it only a step or two coarse on the way back. Resets when drawn again.
-    //
-    // Out-of-frustum content is governed by the frustum allowance above instead
-    // (spatial falloff, not bind staleness) - without this exclusion the GC would
-    // walk barely-out-of-view content to the deepest mip within a second and the
-    // allowance would protect nothing.
-    if (!avatar_bake && mFrustumOverflow <= 0.f)
-    {
-        if (LLImageGL* gli = getGLTexture())
-        {
-            static LLCachedControl<U32> gc_cooldown_frames(gSavedSettings, "TextureGCStepFrames", 5);
-            static LLCachedControl<U32> gc_step_mips(gSavedSettings, "TextureGCStepMips", 1);
-            constexpr U32 GC_RESUME_GRACE_FRAMES = 10;
-            const U32 now = LLFrameTimer::getFrameCount();
-            if (gli->mLastBindFrame > 0                                  // drawn, or anchored at creation (postCreateTexture)
-                && now - sGCSuspendedFrame > GC_RESUME_GRACE_FRAMES      // not just back from background
-                && now - mLastOffScreenFrame > GC_RESUME_GRACE_FRAMES)   // re-entering content gets one grace window to be drawn and re-stamp before staleness is judged
-            {
-                const U32 cooldown = llmax((U32)gc_cooldown_frames, 1u);
-                const S32 periods = (S32)((now - gli->mLastBindFrame) / cooldown);
-                if (periods > 0)
-                {
-                    const S32 step_mips = (S32)llmax((U32)gc_step_mips, 1u);
-                    desired = llclamp(desired + periods * step_mips, desired, dim_max_i);
-                }
-            }
-        }
     }
 
     return llclamp(desired, 0, dim_max_i);

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -221,15 +221,27 @@ protected:
     // never starved.
     bool mOnScreen = true;
 
-    // How far out of frustum the texture's least-out-of-view use sits, as a
-    // fraction of screen size (0 = on screen). Drives the frustum-allowance
-    // falloff in computeDesiredDiscard.
-    F32 mFrustumOverflow = 0.f;
+    // Least-behind use across the faces using this texture, angular: 0 = something
+    // on screen, up to 1 = every use directly behind the camera. Drives the
+    // off-screen unload falloff in computeDesiredDiscard.
+    F32 mBehindness = 0.f;
 
-    // Last frame this texture was out of frustum (mFrustumOverflow > 0). The
-    // GC in computeDesiredDiscard gives re-entering content one grace window to
-    // be drawn and re-stamp mLastBindFrame before its staleness is judged.
-    mutable U32 mLastOffScreenFrame = 0;
+    // Last frame any measured face's object reported visible per the renderer's
+    // cull verdict (frustum + occlusion queries); stamped by the coverage sweep
+    // and anchored at GL-texture creation; the staleness clock for the occlusion
+    // GC. 0 = never.
+    mutable U32 mLastVisibleFrame = 0;
+
+    // Frame the texture's aggregate behindness last transitioned onto >0
+    // (0 = currently on screen); the dwell clock for the progressive
+    // off-screen unload.
+    mutable U32 mOffScreenEnterFrame = 0;
+
+    // Last frame the coverage sweep produced a real measurement for this
+    // texture (some face had usable extents). Distinguishes a transient
+    // unmeasured read (geometry rebuild in flight) from persistently
+    // unmeasured content in computeDesiredDiscard.
+    mutable U32 mLastMeasuredFrame = 0;
 
     // Membership flag for LLViewerTextureList::mFastFetchList (dedup).
     bool mInFastFetchList = false;
@@ -498,6 +510,12 @@ protected:
     // scaleDown can still trim the GL pyramid past this.
     static constexpr S8 sFallbackCodecMaxDiscardLevel = 5; // MIN_DECOMPOSITION_LEVELS
     S8  mCodecMaxDiscardLevel = sFallbackCodecMaxDiscardLevel;
+
+    // Finest discard this texture has ever had created this session. Reload
+    // targets at/coarser than this are disk-cache-backed: progressive fetch
+    // stepping is skipped for them (each step is a full lap through the fetch
+    // queue - pure latency when the bytes are local).
+    S8    mBestDiscardEver = S8_MAX;
 
     bool mNeedsAux;                 // We need to decode the auxiliary channels
     bool mHasAux;                    // We have aux channels

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -243,6 +243,12 @@ protected:
     // unmeasured content in computeDesiredDiscard.
     mutable U32 mLastMeasuredFrame = 0;
 
+    // Debug taps for the TextureStreamDebugText overlay: continuous ideal
+    // discard before (policy) and after (final) the unload lifecycle.
+    // -1 = not computed this visit (early return / unmeasured).
+    mutable F32 mDbgIdealPolicy = -1.f;
+    mutable F32 mDbgIdealFinal = -1.f;
+
     // Membership flag for LLViewerTextureList::mFastFetchList (dedup).
     bool mInFastFetchList = false;
 

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -979,13 +979,18 @@ static void update_face_stream_vsize(LLFace* face)
     const LLVector4a* ext = face->isState(LLFace::RIGGED) ? face->mRiggedExtents : face->mExtents;
     LLVector4a diag;
     diag.setSub(ext[1], ext[0]);
-    // World area of the face ~ product of the two largest AABB dims (max
-    // pairwise product; robust for flat faces).
+    // Effective world area = (longest AABB dim)^2, not true area: mip need is
+    // driven by the longest axis (anisotropic sampling reads fine mips along
+    // it), and a true-area basis pins small/elongated faces (trim, signs) at
+    // the deepest mip. Matches legacy's bounding-disc basis for elongated
+    // faces, tighter for square ones.
     F32 dx = diag[0], dy = diag[1], dz = diag[2];
-    F32 area_world = llmax(dx * dy, llmax(dx * dz, dy * dz));
-    // Pixels per meter at the nearest point. Distance floored: nearer than
-    // this the screen clamp below governs anyway.
-    F32 dist = llmax(face->mDistanceToCamera, 0.5f);
+    F32 longest = llmax(dx, llmax(dy, dz));
+    F32 area_world = longest * longest;
+    // Pixels per meter at the nearest point. Floor is tiny (matching legacy's
+    // 0.001): small faces inspected up close land UNDER the screen clamp, so
+    // a coarse floor costs them a mip+.
+    F32 dist = llmax(face->mDistanceToCamera, 0.01f);
     F32 ppm = LLDrawable::sCurPixelAngle / dist;
     F32 face_px = area_world * ppm * ppm;
     if (face_px <= 0.f)
@@ -1359,15 +1364,31 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
         {
             imagep->mLastVisibleFrame = LLFrameTimer::getFrameCount();
         }
-    }
 
-#if 0
-    imagep->setDebugText(llformat("%d/%d -- %d/%d",
-        imagep->getDiscardLevel(),
-        imagep->getDesiredDiscardLevel(),
-        imagep->getWidth(),
-        imagep->getFullWidth()));
-#endif
+        // In-world streaming diagnostics: current/desired discard, held/full
+        // dims, measured coverage, behindness, off-screen flag, frames since
+        // last confirmed visible.
+        static LLCachedControl<bool> stream_debug(gSavedSettings, "TextureStreamDebugText", false);
+        if (stream_debug)
+        {
+            imagep->setDebugText(llformat("d%d>%d %d/%d r %.3f cov %.0f [N %.0f/%.0f BC %.0f/%.0f S %.0f/%.0f E %.0f/%.0f] i %.1f>%.1f b %.2f%s v %d",
+                imagep->getDiscardLevel(),
+                imagep->getDesiredDiscardLevel(),
+                imagep->getWidth(),
+                imagep->getFullWidth(),
+                LLViewerTexture::sPixelToTexelRatio,
+                max_coverage,
+                imagep->mChannelCoverage[0], imagep->mChannelCoverageMin[0],
+                imagep->mChannelCoverage[1], imagep->mChannelCoverageMin[1],
+                imagep->mChannelCoverage[2], imagep->mChannelCoverageMin[2],
+                imagep->mChannelCoverage[3], imagep->mChannelCoverageMin[3],
+                imagep->mDbgIdealPolicy,
+                imagep->mDbgIdealFinal,
+                imagep->mBehindness,
+                imagep->mOnScreen ? "" : " OFF",
+                (S32)(LLFrameTimer::getFrameCount() - imagep->mLastVisibleFrame)));
+        }
+    }
 
     F32 max_inactive_time = 20.f; // inactive time before deleting saved raw image
     S32 min_refs = 3; // 1 for mImageList, 1 for mUUIDMap, and 1 for "entries" in updateImagesFetchTextures

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -1134,7 +1134,12 @@ static void update_face_stream_vsize(LLFace* face)
 
 void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imagep, bool flush_images)
 {
-    llassert(!gCubeSnapshot);
+    // Real guard, not llassert (compiled out in Release): streaming inputs
+    // are world-view-only; a probe capture's camera would poison them.
+    if (gCubeSnapshot)
+    {
+        return;
+    }
 
     // Refresh spotlight priorities first: light projector textures register as
     // LIGHT_TEX volumes (no faces), and both their fetch priority
@@ -1162,7 +1167,8 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
         F32 max_coverage = 0.f;
         bool on_screen = false;   // any face's projected disc overlaps the screen
         bool any_face = false;
-        F32 min_overflow = FLT_MAX; // least out-of-frustum use across faces
+        F32 min_behindness = FLT_MAX; // least-behind (most on-screen) use across faces
+        bool any_visible = false; // any measured face's object is visible or merely frustum-culled (only occlusion stalls the GC clock)
 
 
         U32 face_count = 0;
@@ -1194,6 +1200,9 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
                 }
             }
             max_coverage = (F32)MAX_IMAGE_AREA;
+            // Used in too many places to scan - treat as visible so the GC clock
+            // keeps advancing (same full-screen reasoning as the coverage above).
+            any_visible = true;
         }
         else
         {
@@ -1235,7 +1244,28 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
 
                     any_face = true;
                     on_screen = on_screen || face->mInFrustum;
-                    min_overflow = llmin(min_overflow, face->mFrustumOverflow);
+                    min_behindness = llmin(min_behindness, face->mBehindness);
+
+                    // GC clock: the world camera's occlusion verdict is the
+                    // only input. The drawable cull stamp is pass-agnostic
+                    // (shadow/probe culls write it too) and must not drive
+                    // residency; the occlusion slot is world-pure. Out of
+                    // frustum the flag is frozen, so those faces always count
+                    // visible - the angular ramp owns them.
+                    LLDrawable* drawablep = face->getDrawable();
+                    bool visible;
+                    if (face->mBehindness > 0.f)
+                    {
+                        visible = true;   // out of frustum - angular policy territory
+                    }
+                    else
+                    {
+                        LLSpatialGroup* group = drawablep ? drawablep->getSpatialGroup() : nullptr;
+                        bool occluded = LLPipeline::sUseOcclusion > 1 && group &&
+                                        group->isOcclusionState(LLSpatialGroup::OCCLUDED);
+                        visible = !occluded;
+                    }
+                    any_visible = any_visible || visible;
 
                     if (bucket >= 0 && bucket < 4)
                     {
@@ -1315,9 +1345,20 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
         // spotlights, the >1024-face boost path, not-yet-built geometry) stay
         // eligible - blocking them is what stalls load-in.
         imagep->mOnScreen = on_screen || !any_face;
-        // Least out-of-frustum use governs the allowance falloff; unknown = 0
+        // Least-behind use governs the off-screen unload falloff; unknown = 0
         // (no penalty), same reasoning as mOnScreen.
-        imagep->mFrustumOverflow = any_face ? min_overflow : 0.f;
+        imagep->mBehindness = any_face ? min_behindness : 0.f;
+
+        // Stamp the occlusion GC's staleness clock whenever a measured face
+        // passed the cull verdict this sweep. Textures with no scannable faces
+        // (bakes, spotlights, terrain, not-yet-built geometry) count as visible
+        // so the GC never ages out content it can't see - same never-starve rule
+        // as mOnScreen above. computeDesiredDiscard reads LLFrameTimer's frame
+        // count, so stamp from the same source (not gFrameCount).
+        if (any_visible || !any_face)
+        {
+            imagep->mLastVisibleFrame = LLFrameTimer::getFrameCount();
+        }
     }
 
 #if 0


### PR DESCRIPTION
Moves back to using occlusion culling states for texture garbage collection.  Also splits between frustum cull and occlusion cull to better differentiate between the two - this is useful for making off screen garbage collection actually functional without occlusion cull state accidentally stomping on it.