### PR TITLE
Use communications devices/scheme to get system audio processing

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2607,11 +2607,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>c39d041c9b68d9ae477934df9c77c53111d79f65</string>
+              <string>9622dbeb12d1c9592de3ea3f83c2c1a95b3c0822</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.19/webrtc-m144.7559.06.19.29561257244-darwin64-29561257244.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.19.hot-mic/webrtc-m144.7559.06.19.hot-mic.29761579711-darwin64-29761579711.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -2621,11 +2621,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>404775fa5ecd1d6eedbc34916df07cb70b8bbfdb</string>
+              <string>9113fdfafca5ca750e415abafaf080540346e068</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.19/webrtc-m144.7559.06.19.29561257244-linux64-29561257244.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.19.hot-mic/webrtc-m144.7559.06.19.hot-mic.29761579711-linux64-29761579711.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -2635,11 +2635,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>28a8d62165fd9cdf0de921879b88b098c0cb7076</string>
+              <string>1d8a82b72887abfb1c5014fcca4337703dfdcd25</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.19/webrtc-m144.7559.06.19.29561257244-windows64-29561257244.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m144.7559.06.19.hot-mic/webrtc-m144.7559.06.19.hot-mic.29761579711-windows64-29761579711.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -2652,7 +2652,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>copyright</key>
         <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
         <key>version</key>
-        <string>m144.7559.06.19.29561257244</string>
+        <string>m144.7559.06.19.hot-mic.29761579711</string>
         <key>name</key>
         <string>webrtc</string>
         <key>vcs_branch</key>

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -42,8 +42,8 @@
 namespace llwebrtc
 {
 #if WEBRTC_WIN
-static int16_t PLAYOUT_DEVICE_DEFAULT = webrtc::AudioDeviceModule::kDefaultDevice;
-static int16_t RECORD_DEVICE_DEFAULT  = webrtc::AudioDeviceModule::kDefaultDevice;
+static int16_t PLAYOUT_DEVICE_DEFAULT = webrtc::AudioDeviceModule::kDefaultCommunicationDevice;
+static int16_t RECORD_DEVICE_DEFAULT  = webrtc::AudioDeviceModule::kDefaultCommunicationDevice;
 #else
 static int16_t PLAYOUT_DEVICE_DEFAULT = 0;
 static int16_t RECORD_DEVICE_DEFAULT  = 0;


### PR DESCRIPTION
## Description
Use the communication devices for microphone to use the system audio processing on windows for noise cancellation, etc.

webrtc-internal processing still works, but isn't as good as the system processing.

For musicians and those who don't want system processing, they can disable that processing in the windows sound settings for the given device.

Test Guidance:
Play with the audio enhancements value in the windows system sound properties.

<img width="807" height="850" alt="image" src="https://github.com/user-attachments/assets/8513f964-b989-4e3c-929f-329a3c730faf" />

Also play with the viewer sound processing (noise cancellation, echo cancellation, AGC) when system sound processing (Voice Clarity) is on, or is off.