### PR TITLE
Budget incremental reflection probe updates

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9361,6 +9361,17 @@
     <string>F32</string>
     <key>Value</key>
     <real>2.0</real>
+    </map>
+  <key>RenderReflectionProbeUpdateBudget</key>
+  <map>
+    <key>Comment</key>
+    <string>CPU time in milliseconds accrued per frame for incremental reflection probe updates. Set to 0 to disable throttling.</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>F32</string>
+    <key>Value</key>
+    <real>1.0</real>
   </map>
   <key>RenderReflectionProbeLevel</key>
   <map>

--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -40,6 +40,7 @@
 #include "llstartup.h"
 #include "llviewermenufile.h"
 #include "llnotificationsutil.h"
+#include "lltimer.h"
 
 #if LL_WINDOWS
 #pragma warning (push)
@@ -218,6 +219,8 @@ void LLReflectionMapManager::update()
         return;
     }
 
+    replenishProbeUpdateBudget();
+
     if (mPaused && gFrameTimeSeconds > mResumeTime)
     {
         resume();
@@ -335,7 +338,10 @@ void LLReflectionMapManager::update()
     if (mUpdatingProbe != nullptr)
     {
         did_update = true;
-        doProbeUpdate();
+        if (hasProbeUpdateBudget())
+        {
+            doBudgetedProbeUpdate();
+        }
     }
 
     // update distance to camera for all probes
@@ -497,7 +503,7 @@ void LLReflectionMapManager::update()
     }
 
     // switch to updating the next oldest probe
-    if (!did_update && oldestProbe != nullptr)
+    if (!did_update && oldestProbe != nullptr && hasProbeUpdateBudget())
     {
         LLReflectionMap* probe = oldestProbe;
         llassert(probe->mCubeIndex != -1);
@@ -506,7 +512,7 @@ void LLReflectionMapManager::update()
 
         sUpdateCount++;
         mUpdatingProbe = probe;
-        doProbeUpdate();
+        doBudgetedProbeUpdate();
     }
 
     if (oldestOccluded)
@@ -735,6 +741,44 @@ void LLReflectionMapManager::deleteProbe(U32 i)
 
     // Probes are distance sorted, order matters.
     mProbes.erase(mProbes.begin() + i);
+}
+
+void LLReflectionMapManager::replenishProbeUpdateBudget()
+{
+    static LLCachedControl<F32> update_budget(gSavedSettings, "RenderReflectionProbeUpdateBudget", 1.f);
+
+    mProbeUpdateBudget = llmax((F32)update_budget, 0.f);
+    ++mFramesSinceProbeUpdate;
+
+    if (mProbeUpdateBudget > 0.f)
+    {
+        // Permit a small burst so an expensive face does not permanently put
+        // the scheduler behind, while preventing unlimited idle-time credit.
+        const F32 credit_limit = llmax(mProbeUpdateBudget * 4.f, mProbeUpdateCost * 2.f);
+        mProbeUpdateCredit = llmin(mProbeUpdateCredit + mProbeUpdateBudget, credit_limit);
+    }
+}
+
+bool LLReflectionMapManager::hasProbeUpdateBudget() const
+{
+    constexpr U32 MAX_DEFERRED_FRAMES = 30;
+    return mProbeUpdateBudget <= 0.f ||
+           mProbeUpdateCredit >= mProbeUpdateCost ||
+           mFramesSinceProbeUpdate >= MAX_DEFERRED_FRAMES;
+}
+
+void LLReflectionMapManager::doBudgetedProbeUpdate()
+{
+    LLTimer timer;
+    doProbeUpdate();
+
+    const F32 elapsed_ms = timer.getElapsedTimeF32() * 1000.f;
+    mProbeUpdateCost = lerp(mProbeUpdateCost, llmax(elapsed_ms, 0.01f), 0.2f);
+    if (mProbeUpdateBudget > 0.f)
+    {
+        mProbeUpdateCredit -= elapsed_ms;
+    }
+    mFramesSinceProbeUpdate = 0;
 }
 
 

--- a/indra/newview/llreflectionmapmanager.h
+++ b/indra/newview/llreflectionmapmanager.h
@@ -218,6 +218,11 @@ private:
     // perform an update on the currently updating Probe
     void doProbeUpdate();
 
+    // Accumulate and consume the per-frame CPU budget for non-realtime probe updates.
+    void replenishProbeUpdateBudget();
+    bool hasProbeUpdateBudget() const;
+    void doBudgetedProbeUpdate();
+
     // update the specified face of the specified probe
     void updateProbeFace(LLReflectionMap* probe, U32 face);
 
@@ -263,6 +268,12 @@ private:
     U32 mRenderReflectionProbeCount = 256U;
     S32 mRenderReflectionProbeDynamicAllocation = -1;
 
+    // CPU milliseconds available for incremental reflection probe work.
+    F32 mProbeUpdateBudget = 0.f;
+    F32 mProbeUpdateCredit = 0.f;
+    F32 mProbeUpdateCost = 1.f;
+    U32 mFramesSinceProbeUpdate = 0;
+
     // resolution of reflection probes
     U32 mProbeResolution = 128;
 
@@ -284,4 +295,3 @@ private:
 
     ReflectionProbeData mProbeData;
 };
-


### PR DESCRIPTION
## Description

Adds a token-bucket CPU budget for incremental, non-realtime reflection probe face updates.

The scheduler measures actual update time, smooths the observed cost, accrues a configurable allowance each frame, and caps idle credit. It forces progress after 30 deferred frames so probe generation cannot stall indefinitely.

`RenderReflectionProbeUpdateBudget` defaults to 1 ms per frame. Setting it to `0` restores the previous unthrottled behavior. Explicit realtime probes retain their existing six-face-per-frame behavior.

A native Apple Silicon profile of the closely related Firestorm viewer placed `LLReflectionMapManager::update()` / `doProbeUpdate()` on roughly 8% of main-thread samples even with static-only reflections. The official `develop` branch contains the same one-face-per-frame incremental scheduler.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**

Issue Link: None; opened as a draft for upstream performance evaluation.

---

## Checklist

- [x] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have reviewed the contributing guidelines.

---

## Additional Notes

Validation performed:

- clean `git diff --check`
- `xmllint --noout indra/newview/app_settings/settings.xml`
- exact stable patch-ID match with the Firestorm implementation
- reviewed credit accrual, measured-cost debit, disabled-budget behavior, and starvation escape

A full official viewer build was not available because this host lacks the autobuild dependency bundle and full Xcode toolchain. This remains a draft pending native build and benchmark coverage.
