### PR TITLE
#6040 Minor startup warnings fixes

### DIFF
--- a/indra/newview/llfloaterworldmap.cpp
+++ b/indra/newview/llfloaterworldmap.cpp
@@ -419,7 +419,7 @@ bool LLFloaterWorldMap::postBuild()
     mEventsMatureCheck = getChild<LLCheckBoxCtrl>("events_mature_chk");
     mEventsAdultCheck = getChild<LLCheckBoxCtrl>("events_adult_chk");
 
-    mAvatarIcon = getChild<LLUICtrl>("avatar_icon");
+    mFriendAvatarIcon = getChild<LLUICtrl>("friends_icon");
     mLandmarkIcon = getChild<LLUICtrl>("landmark_icon");
     mLocationIcon = getChild<LLUICtrl>("location_icon");
 
@@ -610,11 +610,11 @@ void LLFloaterWorldMap::draw()
     LLTracker::ETrackingStatus tracking_status = LLTracker::getTrackingStatus();
     if (LLTracker::TRACKING_AVATAR == tracking_status)
     {
-        mAvatarIcon->setColor( map_track_color);
+        mFriendAvatarIcon->setColor( map_track_color);
     }
     else
     {
-        mAvatarIcon->setColor( map_track_disabled_color);
+        mFriendAvatarIcon->setColor( map_track_disabled_color);
     }
 
     if (LLTracker::TRACKING_LANDMARK == tracking_status)

--- a/indra/newview/llfloaterworldmap.h
+++ b/indra/newview/llfloaterworldmap.h
@@ -234,7 +234,7 @@ private:
     LLCheckBoxCtrl*         mEventsMatureCheck = nullptr;
     LLCheckBoxCtrl*         mEventsAdultCheck = nullptr;
 
-    LLUICtrl*               mAvatarIcon = nullptr;
+    LLUICtrl*               mFriendAvatarIcon = nullptr;
     LLUICtrl*               mLandmarkIcon = nullptr;
     LLUICtrl*               mLocationIcon = nullptr;
 

--- a/indra/newview/llinventoryfilter.h
+++ b/indra/newview/llinventoryfilter.h
@@ -208,12 +208,14 @@ public:
         Optional<FilterOps::Params> filter_ops;
         Optional<std::string>       substring;
         Optional<bool>              since_logoff;
+        Optional<S32>               order;
 
         Params()
         :   name("name"),
             filter_ops(""),
             substring("substring"),
-            since_logoff("since_logoff")
+            since_logoff("since_logoff"),
+            order("order")
         {}
     };
 

--- a/indra/newview/llnotificationstorage.cpp
+++ b/indra/newview/llnotificationstorage.cpp
@@ -108,7 +108,10 @@ bool LLNotificationStorage::readNotifications(LLSD& pNotificationData, bool is_n
 {
     std::string filename = is_new_filename? mFileName : mOldFileName;
 
-    LL_INFOS("LLNotificationStorage") << "starting read '" << filename << "'" << LL_ENDL;
+    if (!filename.empty())
+    {
+        LL_INFOS("LLNotificationStorage") << "starting read '" << filename << "'" << LL_ENDL;
+    }
 
     bool didFileRead;
 
@@ -118,7 +121,17 @@ bool LLNotificationStorage::readNotifications(LLSD& pNotificationData, bool is_n
     didFileRead = notifyFile.is_open();
     if (!didFileRead)
     {
-        LL_WARNS("LLNotificationStorage") << "Failed to open file '" << filename << "'" << LL_ENDL;
+        if (!filename.empty())
+        {
+            if (LLFile::isfile(filename))
+            {
+                LL_WARNS("LLNotificationStorage") << "Failed to open file '" << filename << "'" << LL_ENDL;
+            }
+            else
+            {
+                LL_INFOS("LLNotificationStorage") << "File '" << filename << "' doesn't exist" << LL_ENDL;
+            }
+        }
     }
     else
     {
@@ -144,7 +157,10 @@ bool LLNotificationStorage::readNotifications(LLSD& pNotificationData, bool is_n
             if(didFileRead)
             {
                 writeNotifications(pNotificationData);
-                LLFile::remove(mOldFileName);
+                if (!mOldFileName.empty())
+                {
+                    LLFile::remove(mOldFileName, ENOENT);
+                }
             }
         }
     }

--- a/indra/newview/llpanelmaininventory.cpp
+++ b/indra/newview/llpanelmaininventory.cpp
@@ -253,11 +253,21 @@ bool LLPanelMainInventory::postBuild()
                 LLParamSDParser parser;
                 parser.readSD(recent_items, p);
                 mRecentPanel->getFilter().fromParams(p);
-                mRecentPanel->setSortOrder(gSavedSettings.getU32(LLInventoryPanel::RECENTITEMS_SORT_ORDER));
+
+                // Restore sort order if it was saved
+                if (p.order.isProvided())
+                {
+                    mRecentPanel->setSortOrder(p.order());
+                }
+                else
+                {
+                    mRecentPanel->setSortOrder(gSavedSettings.getU32(LLInventoryPanel::RECENTITEMS_SORT_ORDER));
+                }
             }
         }
         if(mActivePanel)
         {
+            // 'all items' tab
             if(savedFilterState.has(mActivePanel->getFilter().getName()))
             {
                 LLSD items = savedFilterState.get(mActivePanel->getFilter().getName());

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -3189,7 +3189,14 @@ void LLVoiceWebRTCConnection::OnDataReceivedImpl(const std::string &data, bool b
         if (!mPrimary && isSpatial() && gAgent.getRegion())
         {
             is_primary_region = (mRegionID == gAgent.getRegion()->getRegionID());
-            LL_WARNS() << "mPrimary is false, expected: " << is_primary_region << " connection state: " << getVoiceConnectionState() << LL_ENDL;
+            if (is_primary_region)
+            {
+                LL_WARNS("Voice") << "mPrimary is false, expected: true, connection state: " << getVoiceConnectionState() << LL_ENDL;
+            }
+            else
+            {
+                LL_INFOS("Voice") << "mPrimary is false, expected: false, connection state: " << getVoiceConnectionState() << LL_ENDL;
+            }
         }
         boost::json::object voice_data = voice_data_parsed.as_object();
         boost::json::object mute;

--- a/indra/newview/skins/default/xui/en/floater_tools.xml
+++ b/indra/newview/skins/default/xui/en/floater_tools.xml
@@ -1559,9 +1559,7 @@ even though the user gets a free copy.
              left_delta="0"
              name="object_horizontal"
              top_pad="10"
-             width="95"
-             font="DejaVu"
-             font.size="LSmall" />
+             width="95" />
             <menu_button
              menu_filename="menu_copy_paste_pos.xml"
              follows="top|left"
@@ -2651,9 +2649,7 @@ even though the user gets a free copy.
              left="8"
              name="object_horizontal"
              top_pad="10"
-             width="278"
-             font="DejaVu"
-             font.size="LSmall" />
+             width="278" />
             <check_box
              height="16"
              label="Light"

--- a/indra/newview/skins/default/xui/en/floater_world_map.xml
+++ b/indra/newview/skins/default/xui/en/floater_world_map.xml
@@ -637,7 +637,6 @@
       Location:
       </text>
       <spinner
-        control_name="Teleport_Coordinate_X"
         decimal_digits="0"
         follows="right|bottom"
         height="23"
@@ -653,7 +652,6 @@
           function="WMap.Coordinates" />
       </spinner>
       <spinner
-        control_name="Teleport_Coordinate_Y"
         decimal_digits="0"
         follows="right|bottom"
         height="23"
@@ -669,7 +667,6 @@
           function="WMap.Coordinates" />
       </spinner>
       <spinner
-        control_name="Teleport_Coordinate_Z"
         decimal_digits="0"
         follows="right|bottom"
         height="23"

--- a/indra/newview/skins/default/xui/en/panel_tools_texture.xml
+++ b/indra/newview/skins/default/xui/en/panel_tools_texture.xml
@@ -153,9 +153,7 @@
              left="8"
              name="object_horizontal"
              top_pad="4"
-             width="278"
-             font="DejaVu"
-             font.size="LSmall" />
+             width="278" />
             <text
              type="string"
              length="1"


### PR DESCRIPTION
- view_border doesn't need font declarations
- Controls like Teleport_Coordinate_X never existed and never worked
- mAvatarIcon was hooked to a non existing UI element
- Notification storage shouldn't warn about missing files, it's expected 
- Inventory filter was storing, but not using "order" (looks like it doesn't need to cover mActivePanel)
- Voice should info, not warn. Regions can legaly be nonprimary.