### PR TITLE
Two issues.

### DIFF
--- a/indra/llinventory/llinventory.cpp
+++ b/indra/llinventory/llinventory.cpp
@@ -63,6 +63,7 @@ static const std::string INV_CREATION_DATE_LABEL("created_at");
 static const std::string INV_TOGGLED_LABEL("toggled");
 static const std::string INV_SCRIPT_LABEL("script");
 static const std::string INV_RUNTIME_LABEL("runtime");
+static const std::string INV_METADATA_LABEL("metadata");
 
 // key used by agent-inventory-service
 static const std::string INV_ASSET_TYPE_LABEL_WS("type_default");
@@ -1110,6 +1111,35 @@ bool LLInventoryItem::fromLLSD(const LLSD& sd, bool is_new)
                 // Clear any stale runtime when a script block is present
                 // but no explicit runtime value is provided.
                 mRuntime.clear();
+            }
+            continue;
+        }
+
+        if (i->first == INV_METADATA_LABEL)
+        {
+            // Server (non-AIS) exports thumbnail/favorite/script nested under
+            // a "metadata" wrapper; mirror the legacy-stream parser behavior.
+            const LLSD& metadata = i->second;
+            if (metadata.has(INV_THUMBNAIL_LABEL))
+            {
+                const LLSD& thumbnail = metadata[INV_THUMBNAIL_LABEL];
+                if (thumbnail.has(INV_ASSET_ID_LABEL))
+                {
+                    mThumbnailUUID = thumbnail[INV_ASSET_ID_LABEL].asUUID();
+                }
+            }
+            if (metadata.has(INV_FAVORITE_LABEL))
+            {
+                const LLSD& favorite = metadata[INV_FAVORITE_LABEL];
+                if (favorite.has(INV_TOGGLED_LABEL))
+                {
+                    mFavorite = favorite[INV_TOGGLED_LABEL].asBoolean();
+                }
+            }
+            if (metadata.has(INV_SCRIPT_LABEL)
+                && metadata[INV_SCRIPT_LABEL].has(INV_RUNTIME_LABEL))
+            {
+                mRuntime = metadata[INV_SCRIPT_LABEL][INV_RUNTIME_LABEL].asString();
             }
             continue;
         }

--- a/indra/newview/llscripteditorws.cpp
+++ b/indra/newview/llscripteditorws.cpp
@@ -156,11 +156,11 @@ namespace
         }
         return std::string(s);
     }
+
+    LLCachedControl<bool>* OPT_ENABLESCRIPTEDITORWS(nullptr);
+    LLCachedControl<bool>* OPT_TIGHTINTEGRATION(nullptr);
+
 }
-
-LLCachedControl<bool> LLScriptEditorWSServer::sEnableScriptEditorWS(gSavedSettings, "ExternalWebsocketSyncEnable", false);
-LLCachedControl<bool> LLScriptEditorWSServer::sTightIntegration(gSavedSettings, "ExternalEditorTightIntegration", false);
-
 
 class LLPublishedPrimListener : public LLVOInventoryListener
 {
@@ -203,8 +203,8 @@ private:
 };
 
 //========================================================================
-LLScriptEditorWSServer::LLScriptEditorWSServer(const std::string& name, U16 port, bool local_only)
-    : LLJSONRPCServer(name, port, local_only)
+LLScriptEditorWSServer::LLScriptEditorWSServer(const std::string& name, U16 port, bool local_only):
+    LLJSONRPCServer(name, port, local_only)
 {
     LL_INFOS("ScriptEditorWS") << "Created JSON-RPC script editor server: " << name
                                << " on port " << port << LL_ENDL;
@@ -219,6 +219,24 @@ LLScriptEditorWSServer::ptr_t LLScriptEditorWSServer::getServer()
     LLWebsocketMgr&               wsmgr  = LLWebsocketMgr::instance();
     return std::static_pointer_cast<LLScriptEditorWSServer>(
             wsmgr.findServerByName(LLScriptEditorWSServer::DEFAULT_SERVER_NAME));
+}
+
+bool LLScriptEditorWSServer::isEnabled()
+{
+    if (!OPT_ENABLESCRIPTEDITORWS)
+    {
+        OPT_ENABLESCRIPTEDITORWS = new LLCachedControl<bool>(gSavedSettings, "ExternalWebsocketSyncEnable", false);
+    }
+    return *OPT_ENABLESCRIPTEDITORWS;
+}
+
+bool LLScriptEditorWSServer::isTightIntegration()
+{
+    if (!OPT_TIGHTINTEGRATION)
+    {
+        OPT_TIGHTINTEGRATION = new LLCachedControl<bool>(gSavedSettings, "ExternalWebsocketSyncTightIntegration", false);
+    }
+    return *OPT_TIGHTINTEGRATION;
 }
 
 LLScriptEditorWSServer::ptr_t LLScriptEditorWSServer::ensureServerRunning()

--- a/indra/newview/llscripteditorws.cpp
+++ b/indra/newview/llscripteditorws.cpp
@@ -157,9 +157,6 @@ namespace
         return std::string(s);
     }
 
-    LLCachedControl<bool>* OPT_ENABLESCRIPTEDITORWS(nullptr);
-    LLCachedControl<bool>* OPT_TIGHTINTEGRATION(nullptr);
-
 }
 
 class LLPublishedPrimListener : public LLVOInventoryListener
@@ -223,20 +220,14 @@ LLScriptEditorWSServer::ptr_t LLScriptEditorWSServer::getServer()
 
 bool LLScriptEditorWSServer::isEnabled()
 {
-    if (!OPT_ENABLESCRIPTEDITORWS)
-    {
-        OPT_ENABLESCRIPTEDITORWS = new LLCachedControl<bool>(gSavedSettings, "ExternalWebsocketSyncEnable", false);
-    }
-    return *OPT_ENABLESCRIPTEDITORWS;
+    static LLCachedControl<bool> OPT_ENABLESCRIPTEDITORWS(gSavedSettings, "ExternalWebsocketSyncEnable", false);
+    return OPT_ENABLESCRIPTEDITORWS;
 }
 
 bool LLScriptEditorWSServer::isTightIntegration()
 {
-    if (!OPT_TIGHTINTEGRATION)
-    {
-        OPT_TIGHTINTEGRATION = new LLCachedControl<bool>(gSavedSettings, "ExternalWebsocketSyncTightIntegration", false);
-    }
-    return *OPT_TIGHTINTEGRATION;
+    static LLCachedControl<bool> OPT_TIGHTINTEGRATION(gSavedSettings, "ExternalWebsocketSyncTightIntegration", false);
+    return OPT_TIGHTINTEGRATION;
 }
 
 LLScriptEditorWSServer::ptr_t LLScriptEditorWSServer::ensureServerRunning()

--- a/indra/newview/llscripteditorws.h
+++ b/indra/newview/llscripteditorws.h
@@ -354,6 +354,4 @@ private:
     static constexpr F32 CLEANUP_INTERVAL = 60.0f; // seconds
     static constexpr F32 CONNECTION_TIMEOUT = 300.0f; // 5 minutes
 
-    LLCachedControl<bool> *mEnableScriptEditorWS;
-    LLCachedControl<bool> *mTightIntegration;
 };

--- a/indra/newview/llscripteditorws.h
+++ b/indra/newview/llscripteditorws.h
@@ -211,8 +211,8 @@ public:
     void onLinksetChildAdded(const LLUUID& root_id, LLViewerObject* child);
     void onLinksetChildRemoved(const LLUUID& root_id, const LLUUID& child_id);
 
-    static bool isEnabled() { return sEnableScriptEditorWS; }
-    static bool isTightIntegration() { return sTightIntegration; }
+    static bool isEnabled();
+    static bool isTightIntegration();
 
 protected:
     LLWebsocketMgr::WSConnection::ptr_t connectionFactory(LLWebsocketMgr::WSServer::ptr_t server,
@@ -354,6 +354,6 @@ private:
     static constexpr F32 CLEANUP_INTERVAL = 60.0f; // seconds
     static constexpr F32 CONNECTION_TIMEOUT = 300.0f; // 5 minutes
 
-    static LLCachedControl<bool> sEnableScriptEditorWS;
-    static LLCachedControl<bool> sTightIntegration;
+    LLCachedControl<bool> *mEnableScriptEditorWS;
+    LLCachedControl<bool> *mTightIntegration;
 };


### PR DESCRIPTION
1. Was static constructing the LLCacheControl before gSystemOptions
2. Not correctly parsing metadata back from the task inventory api.

## Description

### Testing
1. It doesn't crash at startup.
2. Correct VM target is shown in edit box after close and reopen. 