### PR TITLE
Defer script editor settings initialization

### DIFF
--- a/indra/newview/llscripteditorws.cpp
+++ b/indra/newview/llscripteditorws.cpp
@@ -158,10 +158,6 @@ namespace
     }
 }
 
-LLCachedControl<bool> LLScriptEditorWSServer::sEnableScriptEditorWS(gSavedSettings, "ExternalWebsocketSyncEnable", false);
-LLCachedControl<bool> LLScriptEditorWSServer::sTightIntegration(gSavedSettings, "ExternalEditorTightIntegration", false);
-
-
 class LLPublishedPrimListener : public LLVOInventoryListener
 {
 public:
@@ -219,6 +215,18 @@ LLScriptEditorWSServer::ptr_t LLScriptEditorWSServer::getServer()
     LLWebsocketMgr&               wsmgr  = LLWebsocketMgr::instance();
     return std::static_pointer_cast<LLScriptEditorWSServer>(
             wsmgr.findServerByName(LLScriptEditorWSServer::DEFAULT_SERVER_NAME));
+}
+
+bool LLScriptEditorWSServer::isEnabled()
+{
+    static LLCachedControl<bool> enabled(gSavedSettings, "ExternalWebsocketSyncEnable", false);
+    return enabled;
+}
+
+bool LLScriptEditorWSServer::isTightIntegration()
+{
+    static LLCachedControl<bool> tight_integration(gSavedSettings, "ExternalEditorTightIntegration", false);
+    return tight_integration;
 }
 
 LLScriptEditorWSServer::ptr_t LLScriptEditorWSServer::ensureServerRunning()

--- a/indra/newview/llscripteditorws.h
+++ b/indra/newview/llscripteditorws.h
@@ -211,8 +211,8 @@ public:
     void onLinksetChildAdded(const LLUUID& root_id, LLViewerObject* child);
     void onLinksetChildRemoved(const LLUUID& root_id, const LLUUID& child_id);
 
-    static bool isEnabled() { return sEnableScriptEditorWS; }
-    static bool isTightIntegration() { return sTightIntegration; }
+    static bool isEnabled();
+    static bool isTightIntegration();
 
 protected:
     LLWebsocketMgr::WSConnection::ptr_t connectionFactory(LLWebsocketMgr::WSServer::ptr_t server,
@@ -354,6 +354,4 @@ private:
     static constexpr F32 CLEANUP_INTERVAL = 60.0f; // seconds
     static constexpr F32 CONNECTION_TIMEOUT = 300.0f; // 5 minutes
 
-    static LLCachedControl<bool> sEnableScriptEditorWS;
-    static LLCachedControl<bool> sTightIntegration;
 };


### PR DESCRIPTION
Defers script editor settings initialization until first use, preventing a pre-main crash that caused Velopack installation to partially fail and the viewer not to launch.