### PR TITLE
Fix error popup saying voice is incompatible with region voice

### DIFF
--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -120,7 +120,7 @@ std::string LLVoiceClientStatusObserver::status2string(LLVoiceClientStatusObserv
 LLVoiceModuleInterface *getVoiceModule(const std::string &voice_server_type)
 {
 #ifndef DISABLE_WEBRTC
-    if (voice_server_type == WEBRTC_VOICE_SERVER_TYPE)
+    if (voice_server_type == WEBRTC_VOICE_SERVER_TYPE || voice_server_type.empty())
     {
         return (LLVoiceModuleInterface *) LLWebRTCVoiceClient::getInstance();
     }
@@ -972,7 +972,7 @@ class LLViewerRequiredVoiceVersion : public LLHTTPNode
         LLVoiceModuleInterface *voiceModule = NULL;
 
 #ifndef DISABLE_WEBRTC
-        if (voice_server_type == "webrtc" || voice_server_type.empty())
+        if (voice_server_type == WEBRTC_VOICE_SERVER_TYPE || voice_server_type.empty())
         {
             voiceModule = (LLVoiceModuleInterface *) LLWebRTCVoiceClient::getInstance();
         }


### PR DESCRIPTION
There is a race condition where voice can start up before the voice server type is retrieved from the region.  Since the voice server type defaults to null, and that wasn't allowed, a popup message happened.

The default voice type is webrtc, so we connect to that in cases where the voice server type is empty.

Since this is a rare issue, we can't really repro it, so test guidance is simply to
log in or TP a bunch of times.