### PR TITLE
Fix blank disabled HiDPI value in About floater

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -3746,6 +3746,13 @@ std::string LLAppViewer::getViewerInfoString(bool default_string) const
             {
                 args[ii->first] = LLTrans::getString("none_text", default_string);
             }
+            else if (ii->second.isBoolean())
+            {
+                // LLSD intentionally renders false as an empty string to
+                // preserve string-to-boolean round trips. Viewer info is
+                // human-readable, so show both boolean states explicitly.
+                args[ii->first] = ii->second.asBoolean() ? "true" : "false";
+            }
             else
             {
                 // don't forget to render value asString()


### PR DESCRIPTION
## Description

Fix the macOS About floater so a disabled HiDPI setting is displayed as
`false` instead of an empty value.

`LLSD::ImplBoolean::asString()` intentionally converts `false` to an empty
string to preserve LLSD string-to-boolean round trips. The viewer-info text
formatter used that conversion for every scalar value, which made
`HIDPI=false` appear blank.

This change handles boolean values explicitly in the human-readable formatter.
It leaves `getViewerInfo()` unchanged, so structured consumers still receive a
boolean rather than a string.

## Related Issues

- [x] **Please link to a relevant GitHub issue for additional context.**

Issue Link: Closes https://github.com/secondlife/viewer/issues/3703

---

## Checklist

- [x] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/main/CONTRIBUTING.md).

---

## Validation

- `python -m pre_commit run --files indra/newview/llappviewer.cpp`
- `git diff --check`
- `autobuild configure -c ReleaseOS`
- `autobuild build --no-configure -c ReleaseOS`
- Verified the regression path: `LLSD(false).asString()` is empty, while the
  new boolean formatting branch renders `false` explicitly.

The complete open-source Windows build succeeded with Visual Studio Build
Tools 2022, MSVC 14.44, Windows 11 SDK 10.0.26100, CMake 4.4.0, and Autobuild
3.10.2. The build produced `newview/Release/secondlife-bin.exe`.

## Additional Notes

The change is intentionally limited to human-readable viewer information and
does not modify LLSD's established boolean conversion behavior.
