### PR TITLE
Fix LLGroupMgr::removeObserver possibly failing to find and remove observers causing a crash

### DIFF
--- a/indra/newview/llgroupmgr.cpp
+++ b/indra/newview/llgroupmgr.cpp
@@ -869,18 +869,14 @@ void LLGroupMgr::removeObserver(LLGroupMgrObserver* observer)
     {
         return;
     }
-    observer_multimap_t::iterator it;
-    it = mObservers.find(observer->getID());
-    while (it != mObservers.end())
+    observer_multimap_t::iterator it = mObservers.lower_bound(observer->getID());
+    observer_multimap_t::iterator end = mObservers.upper_bound(observer->getID());
+    for (; it != end; ++it)
     {
         if (it->second == observer)
         {
             mObservers.erase(it);
             break;
-        }
-        else
-        {
-            ++it;
         }
     }
 }


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/6050

This PR very simply just corrects the LLGroupMgr::removeObserver(LLGroupMgrObserver* observer) function to use lower_bound and upper_bound to loop over the desired observers. Previously, std::multimap::find was used, but this did not guarantee that the returned iterator was the first instance, resulting in the observer sometimes not being found when it looped, and then causing a crash later on in LLGroupMgr::notifyObservers.