### PR TITLE
Fix rendering on Parallels VMs with graphics set to "low"

### DIFF
--- a/indra/llrender/llrender.cpp
+++ b/indra/llrender/llrender.cpp
@@ -1043,7 +1043,7 @@ void LLRender::syncMatrices()
                 shader->uniformMatrix3fv(LLShaderMgr::NORMAL_MATRIX, 1, GL_FALSE, norm_mat);
             }
 
-            if (shader->getUniformLocation(LLShaderMgr::INVERSE_MODELVIEW_MATRIX))
+            if (shader->getUniformLocation(LLShaderMgr::INVERSE_MODELVIEW_MATRIX) >= 0)
             {
                 shader->uniformMatrix4fv(LLShaderMgr::INVERSE_MODELVIEW_MATRIX, 1, GL_FALSE, glm::value_ptr(cached_inv_mdv));
             }
@@ -1075,14 +1075,14 @@ void LLRender::syncMatrices()
             // GZ: This was previously disabled seemingly due to a bug involving the deferred renderer's regular pushing and popping of mats.
             // We're reenabling this and cleaning up the code around that - that would've been the appropriate course initially.
             // Anything beyond the standard proj and inv proj mats are special cases.  Please setup special uniforms accordingly in the future.
-            if (shader->getUniformLocation(LLShaderMgr::INVERSE_PROJECTION_MATRIX))
+            if (shader->getUniformLocation(LLShaderMgr::INVERSE_PROJECTION_MATRIX) >= 0)
             {
                 glm::mat4 inv_proj = glm::inverse(mat);
                 shader->uniformMatrix4fv(LLShaderMgr::INVERSE_PROJECTION_MATRIX, 1, false, glm::value_ptr(inv_proj));
             }
 
             // Used by some full screen effects - such as full screen lights, glow, etc.
-            if (shader->getUniformLocation(LLShaderMgr::IDENTITY_MATRIX))
+            if (shader->getUniformLocation(LLShaderMgr::IDENTITY_MATRIX) >= 0)
             {
                 shader->uniformMatrix4fv(LLShaderMgr::IDENTITY_MATRIX, 1, GL_FALSE, glm::value_ptr(glm::identity<glm::mat4>()));
             }

--- a/indra/newview/app_settings/shaders/class3/deferred/materialF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/materialF.glsl
@@ -262,7 +262,7 @@ void alphaMask(float alpha)
 #endif
 }
 
-void waterClip()
+void applyWaterClip()
 {
 #if (DIFFUSE_ALPHA_MODE == DIFFUSE_ALPHA_MODE_BLEND)
     waterClip(vary_position.xyz);
@@ -284,17 +284,17 @@ float getShadow(vec3 pos, vec3 norm)
     #if (DIFFUSE_ALPHA_MODE == DIFFUSE_ALPHA_MODE_BLEND)
         return sampleDirectionalShadow(pos, norm, vary_texcoord0.xy);
     #else
-        return 1;
+        return 1.0;
     #endif
 #else
-    return 1;
+    return 1.0;
 #endif
 }
 
 void main()
 {
     mirrorClip(vary_position);
-    waterClip();
+    applyWaterClip();
 
     // diffcol == diffuse map combined with vertex color
     vec4 diffcol = texture(diffuseMap, vary_texcoord0.xy);
@@ -441,5 +441,3 @@ void main()
 
 #endif
 }
-
-

--- a/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflUtil.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/screenSpaceReflUtil.glsl
@@ -323,7 +323,7 @@ float tapScreenSpaceReflection(int totalSamples, vec2 tc, vec3 viewPos, vec3 n, 
 {
 #ifdef TRANSPARENT_SURFACE
 collectedColor = vec4(1, 0, 1, 1);
-    return 0;
+    return 0.0;
 #endif
     collectedColor = vec4(0);
     int hits = 0;


### PR DESCRIPTION
## Description

This allows Second Life to render properly when running in a Parallels virtual machine - Windows on Apple Silicon


Issue 1: Matrices were used uninitialized. 

In LLRender::syncMatrices():

- Treat uniform location 0 as valid when uploading the inverse model-view, inverse projection, and identity matrices. Only location -1 indicates that a uniform is absent. (This is a zero-based index.)


Issue 2: Parallels GLSL compilation:

- return float literals (not ints) from functions declared to return float
  - Parallels' shader compiler rejects these in their current form. These will be a NOP with compilers that automatically cast the ints to floats.

- rename the local waterClip() wrapper to avoid an overload conflict
  - I think Parallels is in the wrong by not allowing the local overload, but the workaround creates no overhead on other platforms.


## Related Issues

- [ x ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** [Second Life renders mostly-white screens under Parallels](https://github.com/secondlife/viewer/issues/6052)

---

## Checklist

Please ensure the following before requesting review:

- [ x ] I have provided a clear title and detailed description for this pull request.
- [ x ] If useful, I have included media such as screenshots and video to show off my changes.
- [ x ] The PR is linked to a relevant issue with sufficient context.
- [ x ] I have tested the changes locally and verified they work as intended.
- [ x ] All new and existing tests pass.
- [ x ] Code follows the project's style guidelines.
- [ n/a ] Documentation has been updated if needed.
- [ n/a ] Any dependent changes have been merged and published in downstream modules
- [ x ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
<img width="3972" height="1474" alt="Matrix Oopsies" src="https://github.com/user-attachments/assets/1284c8b5-528e-4084-9485-4e54fdb4a805" />
