### PR TITLE
#5907 Fix textures for "Save" button in edit daycycle floater for flat UI appearance

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_edit_ext_day_cycle.xml
+++ b/indra/newview/skins/default/xui/en/floater_edit_ext_day_cycle.xml
@@ -622,11 +622,13 @@
             <button
                     follows="top|left"
                     height="23"
+                    image_selected="SegmentedBtn_Left_Selected"
+                    image_unselected="SegmentedBtn_Left_Off"
                     label="Save"
                     left="200"
                     top_pad="0"
                     name="save_btn"
-                    width="156" />
+                    width="134" />
 
             <button
                     follows="top|left"
@@ -634,14 +636,11 @@
                     name="btn_flyout"
                     label=""
                     layout="topleft"
-                    left_pad="-20"
+                    left_pad="0"
                     top="0"
-                    image_selected="SegmentedBtn_Right_Selected_Press"
-                    image_unselected="SegmentedBtn_Right_Off"
-                    image_pressed="SegmentedBtn_Right_Press"
-                    image_pressed_selected="SegmentedBtn_Right_Selected_Press"
-                    image_overlay="Arrow_Small_Up"
-                    width="20"/>
+                    image_selected="ComboButton_Selected"
+                    image_unselected="ComboButton_Off"
+                    width="22"/>
 
             <button
                     follows="top|left"


### PR DESCRIPTION
Additional fix for the appearance of the "Save" button in `floater_edit_day_cycle.xml':

<img width="395" height="87" alt="grafik" src="https://github.com/user-attachments/assets/4cd6a051-8dd8-462f-9f15-f14480491e49" />

Button itself isn't an actual flyout button, but appears as one. As such:
- Don't overlap buttons to fix weird discolorations and in case of pressed state an odd texture mismatch
- Switch up arrow with down arrow to for consistant look & feel of a flyout button