### PR TITLE
#6061 Fix wrapper exe having spaces

### DIFF
--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -764,7 +764,7 @@ class Windows_x86_64_Manifest(ViewerManifest):
         pack_version = '.'.join(self.args['version'][:3])
         if len(self.args['version']) > 3 and self.args['version'][3]:
             pack_version += '-' + self.args['version'][3]
-        pack_title = self.app_name()  # Display name with spaces
+        pack_title = pack_id  #Wrapper exe, don't use spaces
         pack_dir = self.get_dst_prefix()
         main_exe = self.final_exe()
         installer_base = self.installer_base_name()


### PR DESCRIPTION
26.3 packs with the same arguments as 26.2, yet wrapper sudenly started having spaces, which breaks some exising links.
Looks like velopack was updated and meaning of `--packTitle` changed. We manage links and uninstall record on our own, so just change packTitle.

P.S. This is partially a test to see if it actually works, packTitle might affect something I'm not aware of.