### PR TITLE
Fix fullscreen focus with native file dialogs

### DIFF
--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -177,6 +177,19 @@ void show_window_creation_error(const std::string& title)
     LL_WARNS("Window") << title << LL_ENDL;
 }
 
+static bool is_thread_from_current_process(DWORD thread_id)
+{
+    HANDLE thread_handle = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, thread_id);
+    if (!thread_handle)
+    {
+        return false;
+    }
+
+    const DWORD process_id = GetProcessIdOfThread(thread_handle);
+    CloseHandle(thread_handle);
+    return process_id == GetCurrentProcessId();
+}
+
 HGLRC SafeCreateContext(HDC &hdc)
 {
     __try
@@ -2484,6 +2497,15 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                 {
                     // This message should be sent whenever the app gains or loses focus.
                     BOOL activating = (BOOL)w_param;
+
+                    // Native dialogs run on a worker thread. Moving focus between
+                    // the viewer and one of those dialogs must not be treated as
+                    // switching to another application: in fullscreen that would
+                    // minimize the viewer and hide its owned dialog.
+                    if (!activating && is_thread_from_current_process(static_cast<DWORD>(l_param)))
+                    {
+                        activating = TRUE;
+                    }
 
                     if (window_imp->mFullscreen)
                     {

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -2493,6 +2493,10 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
         case WM_ACTIVATEAPP:
         {
             LL_PROFILE_ZONE_NAMED_CATEGORY_WIN32("mwp - WM_ACTIVATEAPP");
+            // Resolve ownership before deferring the work because thread IDs can
+            // be reused after a thread exits.
+            const bool activating_same_process_thread =
+                !w_param && is_thread_from_current_process(static_cast<DWORD>(l_param));
             window_imp->post([=]()
                 {
                     // This message should be sent whenever the app gains or loses focus.
@@ -2502,7 +2506,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                     // the viewer and one of those dialogs must not be treated as
                     // switching to another application: in fullscreen that would
                     // minimize the viewer and hide its owned dialog.
-                    if (!activating && is_thread_from_current_process(static_cast<DWORD>(l_param)))
+                    if (!activating && activating_same_process_thread)
                     {
                         activating = TRUE;
                     }


### PR DESCRIPTION
## Summary

Prevent the Windows viewer from minimizing in exclusive fullscreen when focus moves to a native file dialog owned by the same process.

Fixes #4569.

## Root cause

Native file dialogs can run on a worker thread. When focus moves between the viewer window and that dialog, `WM_ACTIVATEAPP` reports deactivation and the fullscreen handling minimizes the viewer, even though the newly active thread belongs to the viewer process.

## Changes

- Determine whether the thread receiving activation belongs to the current process.
- Keep the application active for same-process focus transitions.
- Preserve the existing minimize behavior when focus moves to another application.

## Validation

- `git diff --check`
- `cmake --build build-vc170-64 --config Release --target llwindow -- /m`
- `cmake --build build-vc170-64 --config Release --target secondlife-bin -- /m`

Both `llwindow.lib` and `secondlife-bin.exe` were built successfully with Visual Studio 2022. Manual reproduction in exclusive fullscreen is still pending.
