### PR TITLE
feat(snapshot): add avatars-only capture mode

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -16555,5 +16555,60 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
+    <key>SnapshotAnimesh</key>
+    <map>
+      <key>Comment</key>
+      <string>If enabled, avatars-only snapshots also render animesh (animated objects).</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
+    <key>SnapshotParticles</key>
+    <map>
+      <key>Comment</key>
+      <string>If enabled, avatars-only snapshots also render particles.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
+    <key>SnapshotSelectedObjects</key>
+    <map>
+      <key>Comment</key>
+      <string>If enabled, avatars-only snapshots also render currently selected objects.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
+    <key>SnapshotAvatarsOnly</key>
+    <map>
+      <key>Comment</key>
+      <string>If enabled, snapshots render only avatars and their attachments on a transparent background.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
+    <key>SnapshotSitObjects</key>
+    <map>
+      <key>Comment</key>
+      <string>If enabled, avatars-only snapshots also render the objects avatars are sitting on.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
 </map>
 </llsd>

--- a/indra/newview/lldrawpoolalpha.cpp
+++ b/indra/newview/lldrawpoolalpha.cpp
@@ -836,7 +836,17 @@ void LLDrawPoolAlpha::renderAlpha(U32 mask, bool depth_only, bool rigged)
 
                 // install glow-accumulating blend mode
                 // don't touch color, add to alpha (glow)
-                gGL.blendFunc(LLRender::BF_ZERO, LLRender::BF_ONE, LLRender::BF_ONE, LLRender::BF_ONE);
+                if (LLPipeline::sSnapshotAvatarsOnly && !LLPipeline::sRenderingHUDs && !LLPipeline::sImpostorRender)
+                {
+                    // avatars-only snapshot repurposes the alpha channel as
+                    // transmittance for the transparent background; adding glow
+                    // there would punch see-through haze around glowing faces
+                    gGL.blendFunc(LLRender::BF_ZERO, LLRender::BF_ONE, LLRender::BF_ZERO, LLRender::BF_ONE);
+                }
+                else
+                {
+                    gGL.blendFunc(LLRender::BF_ZERO, LLRender::BF_ONE, LLRender::BF_ONE, LLRender::BF_ONE);
+                }
 
                 bool rebind = false;
                 LLGLSLShader* lastShader = current_shader;

--- a/indra/newview/llfloatersnapshot.cpp
+++ b/indra/newview/llfloatersnapshot.cpp
@@ -496,6 +496,66 @@ void LLFloaterSnapshotBase::ImplBase::onClickNoPost(LLUICtrl *ctrl, void* data)
     view->impl->updateControls(view);
 }
 
+// avatars-only snapshot
+// static
+void LLFloaterSnapshotBase::ImplBase::onClickAvatarsOnly(LLUICtrl *ctrl, void* data)
+{
+    bool avatars_only = ((LLCheckBoxCtrl*)ctrl)->get();
+    gSavedSettings.setBOOL("SnapshotAvatarsOnly", avatars_only);
+
+    LLFloaterSnapshotBase* view = (LLFloaterSnapshotBase*)data;
+    view->getPreviewView()->updateSnapshot(true, true);
+    view->impl->updateControls(view);
+}
+
+// avatars-only seat objects
+// static
+void LLFloaterSnapshotBase::ImplBase::onClickSitObjects(LLUICtrl *ctrl, void* data)
+{
+    bool sit_objects = ((LLCheckBoxCtrl*)ctrl)->get();
+    gSavedSettings.setBOOL("SnapshotSitObjects", sit_objects);
+
+    LLFloaterSnapshotBase* view = (LLFloaterSnapshotBase*)data;
+    view->getPreviewView()->updateSnapshot(true, true);
+    view->impl->updateControls(view);
+}
+
+// avatars-only animesh
+// static
+void LLFloaterSnapshotBase::ImplBase::onClickAnimesh(LLUICtrl *ctrl, void* data)
+{
+    bool animesh = ((LLCheckBoxCtrl*)ctrl)->get();
+    gSavedSettings.setBOOL("SnapshotAnimesh", animesh);
+
+    LLFloaterSnapshotBase* view = (LLFloaterSnapshotBase*)data;
+    view->getPreviewView()->updateSnapshot(true, true);
+    view->impl->updateControls(view);
+}
+
+// avatars-only particles
+// static
+void LLFloaterSnapshotBase::ImplBase::onClickParticles(LLUICtrl *ctrl, void* data)
+{
+    bool particles = ((LLCheckBoxCtrl*)ctrl)->get();
+    gSavedSettings.setBOOL("SnapshotParticles", particles);
+
+    LLFloaterSnapshotBase* view = (LLFloaterSnapshotBase*)data;
+    view->getPreviewView()->updateSnapshot(true, true);
+    view->impl->updateControls(view);
+}
+
+// avatars-only selected objects
+// static
+void LLFloaterSnapshotBase::ImplBase::onClickSelectedObjects(LLUICtrl *ctrl, void* data)
+{
+    bool selected = ((LLCheckBoxCtrl*)ctrl)->get();
+    gSavedSettings.setBOOL("SnapshotSelectedObjects", selected);
+
+    LLFloaterSnapshotBase* view = (LLFloaterSnapshotBase*)data;
+    view->getPreviewView()->updateSnapshot(true, true);
+    view->impl->updateControls(view);
+}
+
 // static
 void LLFloaterSnapshotBase::ImplBase::onClickFilter(LLUICtrl *ctrl, void* data)
 {
@@ -1001,6 +1061,18 @@ bool LLFloaterSnapshot::postBuild()
 
     getChild<LLUICtrl>("no_post_check")->setValue(gSavedSettings.getBOOL("RenderSnapshotNoPost"));
     childSetCommitCallback("no_post_check", ImplBase::onClickNoPost, this);
+
+    // avatars-only snapshot
+    getChild<LLUICtrl>("avatars_only_check")->setValue(gSavedSettings.getBOOL("SnapshotAvatarsOnly"));
+    childSetCommitCallback("avatars_only_check", ImplBase::onClickAvatarsOnly, this);
+    getChild<LLUICtrl>("sit_objects_check")->setValue(gSavedSettings.getBOOL("SnapshotSitObjects"));
+    childSetCommitCallback("sit_objects_check", ImplBase::onClickSitObjects, this);
+    getChild<LLUICtrl>("animesh_check")->setValue(gSavedSettings.getBOOL("SnapshotAnimesh"));
+    childSetCommitCallback("animesh_check", ImplBase::onClickAnimesh, this);
+    getChild<LLUICtrl>("particles_check")->setValue(gSavedSettings.getBOOL("SnapshotParticles"));
+    childSetCommitCallback("particles_check", ImplBase::onClickParticles, this);
+    getChild<LLUICtrl>("selected_objects_check")->setValue(gSavedSettings.getBOOL("SnapshotSelectedObjects"));
+    childSetCommitCallback("selected_objects_check", ImplBase::onClickSelectedObjects, this);
 
     getChild<LLButton>("retract_btn")->setCommitCallback(boost::bind(&LLFloaterSnapshot::onExtendFloater, this));
     getChild<LLButton>("extend_btn")->setCommitCallback(boost::bind(&LLFloaterSnapshot::onExtendFloater, this));

--- a/indra/newview/llfloatersnapshot.h
+++ b/indra/newview/llfloatersnapshot.h
@@ -102,6 +102,11 @@ public:
     static void onClickNewSnapshot(void* data);
     static void onClickAutoSnap(LLUICtrl *ctrl, void* data);
     static void onClickNoPost(LLUICtrl *ctrl, void* data);
+    static void onClickAvatarsOnly(LLUICtrl *ctrl, void* data); // avatars-only snapshot
+    static void onClickSitObjects(LLUICtrl *ctrl, void* data);  // avatars-only seat objects
+    static void onClickAnimesh(LLUICtrl *ctrl, void* data);     // avatars-only animesh
+    static void onClickParticles(LLUICtrl *ctrl, void* data);        // avatars-only particles
+    static void onClickSelectedObjects(LLUICtrl *ctrl, void* data);  // avatars-only selected objects
     static void onClickFilter(LLUICtrl *ctrl, void* data);
     static void onClickDisplaySetting(LLUICtrl *ctrl, void* data);
     static void onCommitFreezeFrame(LLUICtrl* ctrl, void* data);

--- a/indra/newview/llsnapshotlivepreview.cpp
+++ b/indra/newview/llsnapshotlivepreview.cpp
@@ -54,6 +54,7 @@
 #include "llviewertexturelist.h"
 #include "llwindow.h"
 #include "llworld.h"
+#include "pipeline.h" // avatars-only snapshot
 #include <boost/filesystem.hpp>
 
 constexpr F32 AUTO_SNAPSHOT_TIME_DELAY = 1.f;
@@ -576,6 +577,10 @@ void LLSnapshotLivePreview::generateThumbnailImage(bool force_update)
     }
     else
     {
+        // avatars-only snapshot — only render avatars and their attachments
+        static LLCachedControl<bool> avatars_only_thumb(gSavedSettings, "SnapshotAvatarsOnly", false);
+        LLPipeline::setSnapshotAvatarsOnly(avatars_only_thumb);
+
         // The thumbnail is a screen view with screen grab positioning preview
         if(!gViewerWindow->thumbnailSnapshot(raw,
                                          mThumbnailWidth, mThumbnailHeight,
@@ -587,6 +592,8 @@ void LLSnapshotLivePreview::generateThumbnailImage(bool force_update)
         {
             raw = NULL ;
         }
+
+        LLPipeline::setSnapshotAvatarsOnly(false); // avatars-only snapshot
     }
 
     if (raw)
@@ -740,6 +747,10 @@ bool LLSnapshotLivePreview::onIdle( void* snapshot_preview )
         previewp->getWindow()->incBusyCount();
         previewp->setImageScaled(false);
 
+        // avatars-only snapshot — only render avatars and their attachments
+        static LLCachedControl<bool> avatars_only(gSavedSettings, "SnapshotAvatarsOnly", false);
+        LLPipeline::setSnapshotAvatarsOnly(avatars_only);
+
         // grab the raw image
         if (gViewerWindow->rawSnapshot(
                 previewp->mPreviewImage,
@@ -775,6 +786,7 @@ bool LLSnapshotLivePreview::onIdle( void* snapshot_preview )
             previewp->setThumbnailImageSize();
             previewp->generateThumbnailImage(true) ;
         }
+        LLPipeline::setSnapshotAvatarsOnly(false); // avatars-only snapshot
         previewp->getWindow()->decBusyCount();
         previewp->setVisible(use_freeze_frame && previewp->mAllowFullScreenPreview); // only show fullscreen preview when in freeze frame mode
         previewp->mSnapshotActive = false;
@@ -985,7 +997,15 @@ LLPointer<LLImageFormatted> LLSnapshotLivePreview::getFormattedImage()
                 mFormattedImage = new LLImageBMP();
                 break;
         }
-        if (mFormattedImage->encode(mPreviewImage, 0))
+        // JPEG encoder rejects RGBA input — flatten avatars-only captures to RGB
+        LLPointer<LLImageRaw> encode_src = mPreviewImage;
+        if (format == LLSnapshotModel::SNAPSHOT_FORMAT_JPEG && mPreviewImage->getComponents() == 4)
+        {
+            encode_src = new LLImageRaw(mPreviewImage->getWidth(), mPreviewImage->getHeight(), 3);
+            encode_src->copy(mPreviewImage);
+        }
+
+        if (mFormattedImage->encode(encode_src, 0))
         {
             // We can update the data size precisely at that point
             mDataSize = mFormattedImage->getDataSize();

--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -973,6 +973,12 @@ void display(bool rebuild, F32 zoom_factor, int subfield, bool for_snapshot)
             constexpr F32 g = 0.5f;
             glClearColor(g, g, g, 1.f);
         }
+        else if (LLPipeline::sSnapshotAvatarsOnly)
+        {
+            // avatars-only snapshot — sky is disabled, so the debug magenta clear would
+            // show through and bleed into alpha-blended edges; clear to black instead
+            glClearColor(0, 0, 0, 1);
+        }
         else
         {
             glClearColor(1, 0, 1, 1);
@@ -1241,6 +1247,12 @@ void display_cube_face()
     if (gUseWireframe)
     {
         glClearColor(0.5f, 0.5f, 0.5f, 1.f);
+    }
+    else if (LLPipeline::sSnapshotAvatarsOnly)
+    {
+        // avatars-only snapshot — sky is disabled, so the debug magenta clear would
+        // show through and bleed into alpha-blended edges; clear to black instead
+        glClearColor(0.f, 0.f, 0.f, 1.f);
     }
     else
     {

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -5238,9 +5238,12 @@ bool LLViewerWindow::rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_hei
 
     LLImageDataLock lock(raw);
 
+    // avatars-only color snapshots carry an alpha channel so the background can be transparent
+    bool avatars_only_alpha = LLPipeline::sSnapshotAvatarsOnly && type == LLSnapshotModel::SNAPSHOT_TYPE_COLOR;
+
     if ((image_buffer_x > 0) && (image_buffer_y > 0))
     {
-        raw->resize(image_buffer_x, image_buffer_y, 3);
+        raw->resize(image_buffer_x, image_buffer_y, avatars_only_alpha ? 4 : 3);
     }
     else
     {
@@ -5269,6 +5272,31 @@ bool LLViewerWindow::rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_hei
 
     F32 depth_conversion_factor_1 = (LLViewerCamera::getInstance()->getFar() + LLViewerCamera::getInstance()->getNear()) / (2.f * LLViewerCamera::getInstance()->getFar() * LLViewerCamera::getInstance()->getNear());
     F32 depth_conversion_factor_2 = (LLViewerCamera::getInstance()->getFar() - LLViewerCamera::getInstance()->getNear()) / (2.f * LLViewerCamera::getInstance()->getFar() * LLViewerCamera::getInstance()->getNear());
+
+    // avatars-only snapshot — hide sky, clouds, water, terrain and other world-only render types;
+    // world objects are culled in LLPipeline::markNotCulled
+    if (LLPipeline::sSnapshotAvatarsOnly)
+    {
+        static LLCachedControl<bool> include_particles(gSavedSettings, "SnapshotParticles", false);
+        gPipeline.pushRenderTypeMask();
+        gPipeline.clearRenderTypeMask(
+            LLPipeline::RENDER_TYPE_SKY,
+            LLPipeline::RENDER_TYPE_WL_SKY,
+            LLPipeline::RENDER_TYPE_CLOUDS,
+            LLPipeline::RENDER_TYPE_TERRAIN,
+            LLPipeline::RENDER_TYPE_TREE,
+            LLPipeline::RENDER_TYPE_GRASS,
+            LLPipeline::RENDER_TYPE_PASS_GRASS,
+            LLPipeline::RENDER_TYPE_WATER,
+            LLPipeline::RENDER_TYPE_VOIDWATER,
+            LLPipeline::END_RENDER_TYPES);
+        if (!include_particles)
+        {
+            gPipeline.clearRenderTypeMask(
+                LLPipeline::RENDER_TYPE_PARTICLES,
+                LLPipeline::END_RENDER_TYPES);
+        }
+    }
 
     // Subimages are in fact partial rendering of the final view. This happens when the final view is bigger than the screen.
     // In most common cases, scale_factor is 1 and there's no more than 1 iteration on x and y
@@ -5324,12 +5352,26 @@ bool LLViewerWindow::rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_hei
                     {
                         if (type == LLSnapshotModel::SNAPSHOT_TYPE_COLOR)
                         {
+                            // avatars-only — matting pass 1 (black background); alpha is
+                            // computed after the white-background pass below
+                            if (avatars_only_alpha)
+                            {
+                                glReadPixels(
+                                         subimage_x_offset, out_y + subimage_y_offset,
+                                         read_width, 1,
+                                         GL_RGBA, GL_UNSIGNED_BYTE,
+                                         raw->getData() + output_buffer_offset
+                                         );
+                            }
+                            else
+                            {
                             glReadPixels(
                                      subimage_x_offset, out_y + subimage_y_offset,
                                      read_width, 1,
                                      GL_RGB, GL_UNSIGNED_BYTE,
                                      raw->getData() + output_buffer_offset
                                      );
+                            }
                         }
                         else // LLSnapshotModel::SNAPSHOT_TYPE_DEPTH
                         {
@@ -5356,11 +5398,73 @@ bool LLViewerWindow::rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_hei
                         }
                     }
                 }
+
+                // avatars-only soft alpha — single-render coverage readback.
+                // The screen render target's alpha channel holds accumulated transparency:
+                // initialized to 1, stamped to 0 where opaque geometry wrote depth, and
+                // multiplied by 1-alpha for every blended fragment (renderGeomPostDeferred).
+                if (avatars_only_alpha)
+                {
+                    // accumulated transparency from the scene render target
+                    std::vector<U8> trans_buf((size_t)read_height * read_width * 4);
+                    gPipeline.mRT->screen.bindTarget();
+                    for (U32 out_y = 0; out_y < read_height; out_y++)
+                    {
+                        if (out_y % 100 == 0)
+                        {
+                            LLAppViewer::instance()->pingMainloopTimeout("LLViewerWindow::rawSnapshot");
+                        }
+                        glReadPixels(
+                                 subimage_x_offset, out_y + subimage_y_offset,
+                                 read_width, 1,
+                                 GL_RGBA, GL_UNSIGNED_BYTE,
+                                 trans_buf.data() + (size_t)out_y * read_width * 4
+                                 );
+                    }
+                    gPipeline.mRT->screen.flush();
+
+                    for (U32 out_y = 0; out_y < read_height; out_y++)
+                    {
+                        S32 output_buffer_offset = (
+                                                    (out_y * (raw->getWidth()))
+                                                    + (window_width * subimage_x)
+                                                    + (raw->getWidth() * window_height * subimage_y)
+                                                    - output_buffer_offset_x
+                                                    - (output_buffer_offset_y * (raw->getWidth()))
+                                                    ) * raw->getComponents();
+
+                        for (S32 i = 0; i < (S32)read_width; i++)
+                        {
+                            U8* px = raw->getData() + output_buffer_offset + (i * 4);
+                            // transparency accumulated by blended geometry (255 = background)
+                            S32 a = 255 - (S32)trans_buf[((size_t)out_y * read_width + i) * 4 + 3];
+
+                            if (a <= 0)
+                            {
+                                px[0] = px[1] = px[2] = px[3] = 0;
+                            }
+                            else
+                            {
+                                // un-premultiply: blended-over-background color is color * alpha
+                                px[0] = (U8)llmin(255, (S32)px[0] * 255 / a);
+                                px[1] = (U8)llmin(255, (S32)px[1] * 255 / a);
+                                px[2] = (U8)llmin(255, (S32)px[2] * 255 / a);
+                                px[3] = (U8)a;
+                            }
+                        }
+                    }
+                }
             }
             output_buffer_offset_x += subimage_x_offset;
             stop_glerror();
         }
         output_buffer_offset_y += subimage_y_offset;
+    }
+
+    // restore render types hidden for avatars-only snapshot
+    if (LLPipeline::sSnapshotAvatarsOnly)
+    {
+        gPipeline.popRenderTypeMask();
     }
 
     gDisplaySwapBuffers = false;
@@ -5386,7 +5490,11 @@ bool LLViewerWindow::rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_hei
 
     // Pre-pad image to number of pixels such that the line length is a multiple of 4 bytes (for BMP encoding)
     // Note: this formula depends on the number of components being 3.  Not obvious, but it's correct.
-    image_width += (image_width * 3) % 4;
+    // 4-component (avatars-only) rows are always 4-byte aligned, no padding needed
+    if (!avatars_only_alpha)
+    {
+        image_width += (image_width * 3) % 4;
+    }
 
     bool ret = true ;
     // Resize image

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -86,6 +86,7 @@
 #include "llviewerregion.h" // for audio debugging.
 #include "llviewerwindow.h" // For getSpinAxis
 #include "llvoavatarself.h"
+#include "llcontrolavatar.h" // avatars-only snapshot
 #include "llvocache.h"
 #include "llvosky.h"
 #include "llvowlsky.h"
@@ -325,6 +326,66 @@ bool    LLPipeline::sReflectionRender = false;
 bool    LLPipeline::sDistortionRender = false;
 bool    LLPipeline::sImpostorRender = false;
 bool    LLPipeline::sImpostorRenderAlphaDepthPass = false;
+bool    LLPipeline::sSnapshotAvatarsOnly = false; // snapshot renders only avatars and their attachments
+std::set<const LLViewerObject*> LLPipeline::sSnapshotSeatRoots;     // seat linkset roots kept in avatars-only snapshots
+std::set<const LLViewerObject*> LLPipeline::sSnapshotSelectedRoots; // selected object roots kept in avatars-only snapshots
+
+// enable/disable avatars-only snapshot rendering. When enabling with the seat
+// option on, collect the root of every linkset an avatar is sitting on so the cull
+// filter can keep it, and force it active so it culls as its own spatial bridge
+// (static objects share octree groups with unrelated neighbors).
+// static
+void LLPipeline::setSnapshotAvatarsOnly(bool enable)
+{
+    sSnapshotAvatarsOnly = enable;
+    sSnapshotSeatRoots.clear();
+    sSnapshotSelectedRoots.clear();
+
+    static LLCachedControl<bool> include_seats(gSavedSettings, "SnapshotSitObjects", false);
+    if (enable && include_seats)
+    {
+        for (LLCharacter* character : LLCharacter::sInstances)
+        {
+            LLVOAvatar* av = (LLVOAvatar*)character;
+            if (!av->isDead() && !av->isControlAvatar() && av->isSitting())
+            {
+                LLViewerObject* parent = (LLViewerObject*)av->getParent();
+                LLViewerObject* root = parent ? parent->getRootEdit() : nullptr;
+                if (root && root->mDrawable)
+                {
+                    sSnapshotSeatRoots.insert(root);
+                    root->mDrawable->makeActive();
+                }
+            }
+        }
+    }
+
+    static LLCachedControl<bool> include_selected(gSavedSettings, "SnapshotSelectedObjects", true);
+    if (enable && include_selected)
+    {
+        // Collect every selected root linkset so it renders in the snapshot.
+        // makeActive() moves the drawable into a spatial bridge so the cull
+        // filter (which only keeps bridge and avatar partitions) passes it.
+        LLObjectSelectionHandle sel = LLSelectMgr::getInstance()->getSelection();
+        for (LLObjectSelection::root_object_iterator it = sel->root_object_begin();
+             it != sel->root_object_end(); ++it)
+        {
+            LLViewerObject* root = (*it)->getObject();
+            if (!root) continue;
+            sSnapshotSelectedRoots.insert(root);
+            // Animated objects (animesh) are rendered through their LLControlAvatar
+            // spatial bridge; makeActive() on the root prim would move it to a new
+            // bridge that lacks bone-transform data, displacing rigged child geometry.
+            // For animesh we keep the root prim in sSnapshotSelectedRoots so the
+            // LLControlAvatar bridge check (above) can match via cav->mRootVolp.
+            if (root->mDrawable && !root->isAnimatedObject())
+            {
+                root->mDrawable->makeActive();
+            }
+        }
+    }
+}
+bool    LLPipeline::sShowJellyDollAsImpostor = true;
 bool    LLPipeline::sUnderWaterRender = false;
 bool    LLPipeline::sTextureBindTest = false;
 bool    LLPipeline::sRenderAttachedLights = true;
@@ -2570,6 +2631,88 @@ void LLPipeline::markNotCulled(LLSpatialGroup* group, LLCamera& camera)
         return;
     }
 
+    // avatars-only snapshot — cull everything that is not an avatar or one of its attachments
+    if (sSnapshotAvatarsOnly)
+    {
+        static LLCachedControl<bool> include_animesh(gSavedSettings, "SnapshotAnimesh", false);
+        static LLCachedControl<bool> include_particles(gSavedSettings, "SnapshotParticles", false);
+        LLSpatialPartition* part = group->getSpatialPartition();
+        LLSpatialBridge* bridge = part->asBridge();
+        if (bridge)
+        {
+            const LLViewerObject* vobj = bridge->mDrawable ? bridge->mDrawable->getVObj().get() : nullptr;
+            bool keep = false;
+            if (vobj)
+            {
+                if (vobj->isAvatar())
+                {
+                    const LLVOAvatar* av = static_cast<const LLVOAvatar*>(vobj);
+                    if (!av->isControlAvatar())
+                    {
+                        keep = true; // real avatar
+                    }
+                    else
+                    {
+                        // animesh: keep when worn as an attachment, always if the
+                        // animesh option is on, or when the root animesh prim was
+                        // explicitly selected (sSnapshotSelectedRoots).
+                        const LLControlAvatar* cav = static_cast<const LLControlAvatar*>(av);
+                        keep = include_animesh
+                            || (cav->mRootVolp && cav->mRootVolp->isAttachment())
+                            || (!sSnapshotSelectedRoots.empty() && cav->mRootVolp
+                                && sSnapshotSelectedRoots.count(cav->mRootVolp) > 0);
+                    }
+                }
+                else
+                {
+                    keep = vobj->isAttachment()
+                        || (include_animesh && vobj->isAnimatedObject())
+                        || (!sSnapshotSeatRoots.empty()     && sSnapshotSeatRoots.count(vobj)     > 0)
+                        || (!sSnapshotSelectedRoots.empty() && sSnapshotSelectedRoots.count(vobj) > 0);
+                }
+            }
+            if (!keep)
+            {
+                return;
+            }
+        }
+        else if (part->mPartitionType != LLViewerRegion::PARTITION_BRIDGE
+              && part->mPartitionType != LLViewerRegion::PARTITION_AVATAR
+              && part->mPartitionType != LLViewerRegion::PARTITION_CONTROL_AV
+              && part->mPartitionType != LLViewerRegion::PARTITION_HUD)
+        {
+            // world geometry — allow particle partitions only when the option is on
+            // AND at least one drawable in the group comes from an avatar attachment source
+            if (include_particles
+                && (part->mPartitionType == LLViewerRegion::PARTITION_PARTICLE
+                    || part->mPartitionType == LLViewerRegion::PARTITION_HUD_PARTICLE))
+            {
+                bool has_attachment_source = false;
+                for (LLSpatialGroup::element_iter it = group->getDataBegin();
+                     it != group->getDataEnd() && !has_attachment_source; ++it)
+                {
+                    LLDrawable* drawable = (LLDrawable*)(*it)->getDrawable();
+                    if (!drawable || drawable->isDead()) { continue; }
+                    LLVOPartGroup* vopg = dynamic_cast<LLVOPartGroup*>(drawable->getVObj().get());
+                    if (!vopg) { continue; }
+                    LLViewerPartGroup* vpg = vopg->getViewerPartGroup();
+                    if (!vpg || vpg->mParticles.empty()) { continue; }
+                    const LLViewerPartSource* src = vpg->mParticles[0]->mPartSourcep.get();
+                    if (src && src->mSourceObjectp.notNull()
+                        && src->mSourceObjectp->isAttachment())
+                    {
+                        has_attachment_source = true;
+                    }
+                }
+                if (!has_attachment_source) { return; }
+            }
+            else
+            {
+                return;
+            }
+        }
+    }
+
     group->setVisible();
 
     if (LLViewerCamera::sCurCameraID == LLViewerCamera::CAMERA_WORLD && !gCubeSnapshot)
@@ -4136,6 +4279,223 @@ void LLPipeline::renderGeomPostDeferred(LLCamera& camera)
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DRAWPOOL;
     LL_PROFILE_GPU_ZONE("renderGeomPostDeferred");
 
+    // avatars-only snapshot — initialize the alpha channel as a transparency
+    // accumulator (1 = fully transparent), then stamp 0 (fully opaque) wherever the
+    // depth buffer already holds opaque geometry. The alpha pools' glow-suppression
+    // blend (dst_a *= 1 - src_a) then accumulates per-pixel coverage of blended
+    // geometry on top, and snapshot readback uses the accumulator alone. Stamping
+    // opaque coverage here (instead of classifying by depth at readback) lets rigged
+    // alpha keep its stock depth writes, which are needed to occlude layered alpha
+    // like inverted-hull cel-shade shells.
+    if (sSnapshotAvatarsOnly && !sRenderingHUDs && !sImpostorRender)
+    {
+        // Alpha-channel transparency stamp.  Clear alpha to 1 (transparent
+        // everywhere), then overdraw alpha=0 (opaque) wherever the deferred
+        // G-buffer recorded geometry (depth < 1 at the far plane).
+        gGL.setColorMask(false, true);
+        glClearColor(0.f, 0.f, 0.f, 1.f);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        {
+            LLGLDisable blend(GL_BLEND);
+            // fragment depth forced to the far plane; GL_GREATER passes only where
+            // opaque geometry wrote depth < 1
+            LLGLDepthTest depth(GL_TRUE, GL_FALSE, GL_GREATER);
+            glDepthRangef(1.f, 1.f);
+
+            gDebugProgram.bind();
+            gGL.diffuseColor4f(0.f, 0.f, 0.f, 0.f);
+
+            gGL.matrixMode(LLRender::MM_PROJECTION);
+            gGL.pushMatrix();
+            gGL.loadIdentity();
+            gGL.matrixMode(LLRender::MM_MODELVIEW);
+            gGL.pushMatrix();
+            gGL.loadIdentity();
+            gGL.syncMatrices();
+
+            mScreenTriangleVB->setBuffer();
+            mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+
+            gGL.matrixMode(LLRender::MM_PROJECTION);
+            gGL.popMatrix();
+            gGL.matrixMode(LLRender::MM_MODELVIEW);
+            gGL.popMatrix();
+
+            gDebugProgram.unbind();
+            glDepthRangef(0.f, 1.f);
+        }
+
+        // Seat alpha stamp: write alpha=0 (opaque) for the alpha-pool faces of
+        // each seat object, but only where the face's texture actually has
+        // coverage.  Faces are drawn textured through the fullbright alpha-mask
+        // shader so fully-transparent texels are discarded and never touch the
+        // alpha channel -- background pixels covered by oversized mostly
+        // transparent planes (shadow prims etc.) stay transparent.  Surviving
+        // fragments composite their texel alpha into the transmittance channel
+        // so baked shadow gradients keep partial coverage.  Depth is TESTed
+        // (no write) so pixels the avatar occupies (closer depth) are left
+        // alone.
+        if (!sSnapshotSeatRoots.empty() || !sSnapshotSelectedRoots.empty())
+        {
+            LLVertexBuffer::unbind();
+
+            // Keep culling enabled: stamping back faces creates opaque dark bands in
+            // gaps between geometry pieces (e.g. between control panels).  Post-deferred
+            // POOL_FULLBRIGHT faces (front rails, etc.) are caught by the second depth
+            // stamp below, which runs after the pool render loop and uses the depth that
+            // POOL_FULLBRIGHT wrote during its normal (cull-enabled) render pass.
+            LLGLEnable    seat_cull(GL_CULL_FACE);
+            LLGLDepthTest seat_depth(GL_TRUE, GL_FALSE, GL_LEQUAL);
+            LLGLEnable    seat_blend(GL_BLEND);
+            // Default blend for near-opaque faces (material alpha 0.8–0.99):
+            // composite transmittance dst_a *= (1 - texel_alpha) so partial-opacity
+            // seat faces render at their correct transparency.
+            // Fully-opaque-material faces override this to BF_ZERO/BF_ZERO per face
+            // (see below) so the entire geometry coverage stamps alpha=0 regardless
+            // of texture alpha — otherwise lace/ornate textures leave a noisy fringe
+            // of partially-opaque pixels inside what should be solid geometry.
+            gGL.blendFunc(LLRender::BF_ZERO, LLRender::BF_ONE_MINUS_SOURCE_ALPHA);
+
+            LLGLSLShader& stamp_shader = gDeferredFullbrightAlphaMaskProgram;
+            stamp_shader.bind();
+            stamp_shader.setMinimumAlpha(0.05f);
+            gGL.diffuseColor4f(1.f, 1.f, 1.f, 1.f);
+
+            gGL.matrixMode(LLRender::MM_PROJECTION);
+            gGL.pushMatrix();
+            gGL.loadMatrix(gGLProjection);
+            gGL.matrixMode(LLRender::MM_MODELVIEW);
+            gGL.pushMatrix();
+            gGL.loadMatrix(gGLModelView);
+
+            auto stampSeatFaces = [&](LLDrawable* drawable)
+            {
+                if (!drawable || drawable->isDead()) return;
+
+                gGL.pushMatrix();
+                gGL.multMatrix((F32*)drawable->getRenderMatrix().mMatrix);
+                gGL.syncMatrices();
+
+                for (S32 fi = 0; fi < drawable->getNumFaces(); ++fi)
+                {
+                    LLFace* face = drawable->getFace(fi);
+                    if (!face || !face->getIndicesCount()) continue;
+
+                    // Stamp alpha-blended faces AND post-deferred fullbright faces.
+                    // Opaque/deferred faces write to the G-buffer and are handled by
+                    // the depth stamp above.  Fullbright faces bypass the G-buffer
+                    // (renderPostDeferred), so they must be caught here too.
+                    U32 pt = face->getPoolType();
+                    if (pt != LLDrawPool::POOL_ALPHA_PRE_WATER &&
+                        pt != LLDrawPool::POOL_ALPHA_POST_WATER &&
+                        pt != LLDrawPool::POOL_ALPHA &&
+                        pt != LLDrawPool::POOL_FULLBRIGHT &&
+                        pt != LLDrawPool::POOL_FULLBRIGHT_ALPHA_MASK)
+                        continue;
+
+                    // Skip faces where material alpha < 80%.  Below this threshold the
+                    // face is intended to be partially transparent (shadow prims,
+                    // decorative overlays, etc.).  Stamping them creates a semi-opaque
+                    // dark overlay in the transparency mask that looks wrong against any
+                    // compositing background.  Faces above this threshold are treated
+                    // as solid and stamped with alpha=0 via BF_ZERO/BF_ZERO below.
+                    const LLTextureEntry* te = face->getTextureEntry();
+                    if (!te || te->getAlpha() < 0.8f) continue;
+
+                    // POOL_FULLBRIGHT = Alpha Mode None: scene ignores texture alpha → stamp
+                    // everything solid, minimum_alpha=0 so no texels are discarded.
+                    // POOL_ALPHA* = Blend mode: the face's edge gradient should remain soft so
+                    // the POOL_ALPHA glow-suppression blend (dst_a *= 1-src_a) can create the
+                    // correct smooth fade.  Raise minimum_alpha to 0.5 so only the clearly-
+                    // opaque part of the texture is hard-stamped; texels 0-0.49 are left at
+                    // alpha=1 for the pool render to handle naturally.  This prevents blend-mode
+                    // faces from looking like hard alpha-mask cutouts in the snapshot.
+                    // POOL_FULLBRIGHT_ALPHA_MASK keeps 0.05 for proper cutout shapes.
+                    float face_min_alpha;
+                    if (pt == LLDrawPool::POOL_FULLBRIGHT)
+                        face_min_alpha = 0.f;
+                    else if (pt == LLDrawPool::POOL_ALPHA ||
+                             pt == LLDrawPool::POOL_ALPHA_PRE_WATER ||
+                             pt == LLDrawPool::POOL_ALPHA_POST_WATER)
+                        face_min_alpha = 0.5f;
+                    else
+                        face_min_alpha = 0.05f;
+                    stamp_shader.setMinimumAlpha(face_min_alpha);
+
+                    // Fully-opaque-material faces use a solid stamp (BF_ZERO/BF_ZERO):
+                    // every covered pixel writes alpha=0 regardless of texture alpha.
+                    // This prevents lace/ornate textures with partial-alpha interiors
+                    // from leaving a scattered noisy fringe in the transparency mask.
+                    // Faces with partial material alpha keep gradient blend so their
+                    // semi-transparency is preserved in the composited output.
+                    gGL.blendFunc(LLRender::BF_ZERO,
+                                  (te->getAlpha() >= 0.99f) ? LLRender::BF_ZERO
+                                                             : LLRender::BF_ONE_MINUS_SOURCE_ALPHA);
+
+                    LLViewerTexture* tex = face->getTexture();
+                    if (!tex) continue;
+                    // shader is texture-indexed (samples tex0..texN by per-vertex
+                    // index); bind the face texture to every channel so any baked
+                    // index resolves to it
+                    S32 stamp_channels = llmax(1, (S32)stamp_shader.mFeatures.mIndexedTextureChannels);
+                    for (S32 ch = 0; ch < stamp_channels; ++ch)
+                    {
+                        gGL.getTexUnit(ch)->bindFast(tex);
+                    }
+
+                    LLVertexBuffer* vb = face->getVertexBuffer();
+                    if (!vb) continue;
+                    vb->setBuffer();
+                    vb->drawRange(LLRender::TRIANGLES,
+                        face->getGeomIndex(),
+                        face->getGeomIndex() + face->getGeomCount() - 1,
+                        face->getIndicesCount(),
+                        face->getIndicesStart());
+                }
+
+                gGL.popMatrix();
+            };
+
+            auto stampLinkset = [&](const LLViewerObject* root)
+            {
+                if (root->mDrawable) stampSeatFaces(root->mDrawable);
+                for (LLViewerObject* child : root->getChildren())
+                {
+                    if (child && child->mDrawable) stampSeatFaces(child->mDrawable);
+                }
+            };
+
+            for (const LLViewerObject* seat : sSnapshotSeatRoots)
+                stampLinkset(seat);
+            for (const LLViewerObject* sel : sSnapshotSelectedRoots)
+            {
+                // Animesh (animated objects) use rigged meshes driven by
+                // LLControlAvatar bone transforms.  The stamp shader has no
+                // bone-matrix support, so stamping rigged children positions
+                // them at their bind-pose location rather than the animated
+                // position, producing floating geometry at the wrong spot.
+                // Skip the stamp for animesh; their deferred body geometry is
+                // already covered by the first depth stamp (POOL_AVATAR writes
+                // to the G-buffer), and POOL_ALPHA hair over the stamped body
+                // will composite correctly from the pool render.
+                if (!sel->isAnimatedObject())
+                    stampLinkset(sel);
+            }
+
+            gGL.matrixMode(LLRender::MM_PROJECTION);
+            gGL.popMatrix();
+            gGL.matrixMode(LLRender::MM_MODELVIEW);
+            gGL.popMatrix();
+
+            stamp_shader.unbind();
+            LLVertexBuffer::unbind();
+            gGL.blendFunc(LLRender::BF_SOURCE_ALPHA, LLRender::BF_ONE_MINUS_SOURCE_ALPHA);
+        }
+
+        gGL.setColorMask(true, true);
+    }
+
     if (gUseWireframe)
     {
         glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
@@ -4148,6 +4508,11 @@ void LLPipeline::renderGeomPostDeferred(LLCamera& camera)
     bool done_atmospherics = LLPipeline::sRenderingHUDs; //skip atmospherics on huds
     bool done_water_haze = done_atmospherics;
     bool done_water_exclusion = false;
+    // avatars-only snapshot: second depth stamp fires just before POOL_ALPHA renders so
+    // it catches post-deferred pools (POOL_FULLBRIGHT, POOL_GLOW) but NOT POOL_ALPHA.
+    // Firing after POOL_ALPHA would stamp semi-transparent fur/cloth edge pixels as opaque
+    // with whatever sky color the scene rendered there, producing a colored fringe halo.
+    bool done_second_stamp = (!sSnapshotAvatarsOnly || sRenderingHUDs || sImpostorRender);
 
     // do water exclusion just before water pass.
     U32 water_exclusion_pass = LLDrawPool::POOL_WATEREXCLUSION;
@@ -4207,6 +4572,40 @@ void LLPipeline::renderGeomPostDeferred(LLCamera& camera)
             done_water_haze = true;
         }
 
+        if (cur_type >= water_haze_pass && !done_second_stamp)
+        {
+            // Run second depth stamp just before POOL_ALPHA renders.
+            // By now POOL_FULLBRIGHT (type 5) and POOL_GLOW (type 17) have written
+            // their depth, so this GL_GREATER pass picks them up.  POOL_ALPHA has NOT
+            // rendered yet, so semi-transparent alpha faces (shadow prims, fur edges)
+            // don't contaminate the mask with colored atmospheric RGB.
+            gGL.setColorMask(false, true);
+            {
+                LLGLDisable no_blend(GL_BLEND);
+                LLGLDepthTest d2(GL_TRUE, GL_FALSE, GL_GREATER);
+                glDepthRangef(1.f, 1.f);
+                gDebugProgram.bind();
+                gGL.diffuseColor4f(0.f, 0.f, 0.f, 0.f);
+                gGL.matrixMode(LLRender::MM_PROJECTION);
+                gGL.pushMatrix();
+                gGL.loadIdentity();
+                gGL.matrixMode(LLRender::MM_MODELVIEW);
+                gGL.pushMatrix();
+                gGL.loadIdentity();
+                gGL.syncMatrices();
+                mScreenTriangleVB->setBuffer();
+                mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+                gGL.matrixMode(LLRender::MM_PROJECTION);
+                gGL.popMatrix();
+                gGL.matrixMode(LLRender::MM_MODELVIEW);
+                gGL.popMatrix();
+                gDebugProgram.unbind();
+                glDepthRangef(0.f, 1.f);
+            }
+            gGL.setColorMask(true, false);
+            done_second_stamp = true;
+        }
+
         pool_set_t::iterator iter2 = iter1;
         if (hasRenderType(poolp->getType()) && poolp->getNumPostDeferredPasses() > 0)
         {
@@ -4252,6 +4651,41 @@ void LLPipeline::renderGeomPostDeferred(LLCamera& camera)
         }
         iter1 = iter2;
         stop_glerror();
+    }
+
+    // Fallback: second depth stamp if the pool loop never reached water_haze_pass
+    // (e.g. no POOL_ALPHA pools exist in this frame — unusual but possible).
+    if (!done_second_stamp)
+    {
+        gGL.setColorMask(false, true);
+
+        LLGLDisable blend2(GL_BLEND);
+        LLGLDepthTest depth2(GL_TRUE, GL_FALSE, GL_GREATER);
+        glDepthRangef(1.f, 1.f);
+
+        gDebugProgram.bind();
+        gGL.diffuseColor4f(0.f, 0.f, 0.f, 0.f);
+
+        gGL.matrixMode(LLRender::MM_PROJECTION);
+        gGL.pushMatrix();
+        gGL.loadIdentity();
+        gGL.matrixMode(LLRender::MM_MODELVIEW);
+        gGL.pushMatrix();
+        gGL.loadIdentity();
+        gGL.syncMatrices();
+
+        mScreenTriangleVB->setBuffer();
+        mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+
+        gGL.matrixMode(LLRender::MM_PROJECTION);
+        gGL.popMatrix();
+        gGL.matrixMode(LLRender::MM_MODELVIEW);
+        gGL.popMatrix();
+
+        gDebugProgram.unbind();
+        glDepthRangef(0.f, 1.f);
+
+        gGL.setColorMask(true, true);
     }
 
     gGLLastMatrix = NULL;
@@ -7350,6 +7784,18 @@ void LLPipeline::copyScreenSpaceReflections(LLRenderTarget* src, LLRenderTarget*
 void LLPipeline::generateGlow(LLRenderTarget* src)
 {
     LL_PROFILE_GPU_ZONE("glow generate");
+
+    // avatars-only snapshot hijacks the screen alpha channel as a transparency
+    // accumulator; the glow extractor reads that channel as glow strength and would
+    // bloom the entire image. Output black glow instead.
+    if (sSnapshotAvatarsOnly)
+    {
+        mGlow[1].bindTarget();
+        mGlow[1].clear();
+        mGlow[1].flush();
+        return;
+    }
+
     if (sRenderGlow)
     {
         mGlow[2].bindTarget();
@@ -8043,7 +8489,12 @@ void LLPipeline::renderFinalize()
 
         generateLuminance(&mRT->screen, &mLuminanceMap);
 
-        generateExposure(&mLuminanceMap, &mExposureMap);
+        // avatars-only snapshot — keep the pre-snapshot exposure; adapting to the
+        // synthetic black background makes the live view flash dark/bright afterwards
+        if (!sSnapshotAvatarsOnly)
+        {
+            generateExposure(&mLuminanceMap, &mExposureMap);
+        }
 
         static LLCachedControl<F32> cas_sharpness(gSavedSettings, "RenderCASSharpness", 0.4f);
         bool apply_cas = cas_sharpness != 0.0f && gCASProgram.isComplete() && gCASLegacyGammaProgram.isComplete();
@@ -8992,7 +9443,10 @@ void LLPipeline::doAtmospherics()
 
         LLGLEnable blend(GL_BLEND);
         gGL.blendFunc(LLRender::BF_ONE, LLRender::BF_SOURCE_ALPHA, LLRender::BF_ZERO, LLRender::BF_SOURCE_ALPHA);
-        gGL.setColorMask(true, true);
+        // avatars-only snapshot hijacks the screen alpha as a transparency mask;
+        // the haze full-screen blit modifies alpha via dst*src_alpha, which corrupts
+        // transparent (alpha=1) gap pixels.  Don't write alpha during haze in that mode.
+        gGL.setColorMask(true, !sSnapshotAvatarsOnly);
 
         // apply haze
         LLGLSLShader& haze_shader = gHazeProgram;
@@ -9056,8 +9510,8 @@ void LLPipeline::doWaterHaze()
 
         LLGLEnable blend(GL_BLEND);
         gGL.blendFunc(LLRender::BF_ONE, LLRender::BF_SOURCE_ALPHA, LLRender::BF_ZERO, LLRender::BF_SOURCE_ALPHA);
-
-        gGL.setColorMask(true, true);
+        // same transparency-mask protection as doAtmospherics
+        gGL.setColorMask(true, !sSnapshotAvatarsOnly);
 
         // apply haze
         LLGLSLShader& haze_shader = gHazeWaterProgram;

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -42,6 +42,7 @@
 #include "llheroprobemanager.h"
 
 #include <stack>
+#include <set>
 
 class LLViewerTexture;
 class LLFace;
@@ -674,6 +675,11 @@ public:
     static bool             sDistortionRender;
     static bool             sImpostorRender;
     static bool             sImpostorRenderAlphaDepthPass;
+    static bool             sSnapshotAvatarsOnly; // snapshot renders only avatars and their attachments
+    static std::set<const LLViewerObject*> sSnapshotSeatRoots;     // seat linkset roots kept in avatars-only snapshots
+    static std::set<const LLViewerObject*> sSnapshotSelectedRoots; // selected object roots kept in avatars-only snapshots
+    static void             setSnapshotAvatarsOnly(bool enable); // sets the flag and collects seated-on / selected objects
+    static bool             sShowJellyDollAsImpostor;
     static bool             sUnderWaterRender;
     static bool             sRenderGlow;
     static bool             sTextureBindTest;

--- a/indra/newview/skins/default/xui/en/floater_snapshot.xml
+++ b/indra/newview/skins/default/xui/en/floater_snapshot.xml
@@ -5,7 +5,7 @@
  can_minimize="true"
  can_resize="false"
  can_close="true"
- height="475"
+ height="561"
  layout="topleft"
  name="Snapshot"
  single_instance="true"
@@ -115,7 +115,7 @@
 	   top_delta="0"
        width="31" />
 	<panel
-     height="179"
+     height="268"
      layout="topleft"
 	 follows="top|left"
      left="0"
@@ -213,6 +213,55 @@
          top_pad="1"
          width="180"
          name="no_post_check" />
+        <check_box
+         label="Avatars only"
+         tool_tip="Render only avatars and their attachments. World, sky and water are hidden and the background is transparent (save as PNG to keep transparency)."
+         layout="topleft"
+         height="16"
+         left="10"
+         top_pad="1"
+         width="180"
+         name="avatars_only_check" />
+        <check_box
+         enabled_control="SnapshotAvatarsOnly"
+         label="Include seat objects"
+         tool_tip="Also render the objects avatars are sitting on (chairs, vehicles, poseballs)."
+         layout="topleft"
+         height="16"
+         left="30"
+         top_pad="1"
+         width="160"
+         name="sit_objects_check" />
+        <check_box
+         enabled_control="SnapshotAvatarsOnly"
+         label="Include animesh"
+         tool_tip="Also render animesh (animated objects) that are not worn as attachments."
+         layout="topleft"
+         height="16"
+         left="30"
+         top_pad="1"
+         width="160"
+         name="animesh_check" />
+        <check_box
+         enabled_control="SnapshotAvatarsOnly"
+         label="Include particles"
+         tool_tip="Also render particles in avatars-only snapshots."
+         layout="topleft"
+         height="16"
+         left="30"
+         top_pad="1"
+         width="160"
+         name="particles_check" />
+        <check_box
+         enabled_control="SnapshotAvatarsOnly"
+         label="Include selected objects"
+         tool_tip="Also render currently selected objects in avatars-only snapshots."
+         layout="topleft"
+         height="16"
+         left="30"
+         top_pad="1"
+         width="160"
+         name="selected_objects_check" />
         <text
          type="string"
          length="1"


### PR DESCRIPTION
Renders avatars and their attachments on a transparent background (save as PNG to keep transparency). Four opt-in sub-options:

- Include seat objects     (SnapshotSitObjects)
- Include animesh          (SnapshotAnimesh)
- Include particles        (SnapshotParticles, attachment-sourced only)
- Include selected objects (SnapshotSelectedObjects)

World geometry, sky, water, and terrain are culled. Particle groups are filtered to those whose emitter source is an avatar attachment, preventing world emitters from corrupting the transparent background. Seat and selected objects use makeActive() to move into spatial bridges so the avatars-only cull filter passes them; a depth-stamp pass writes their silhouette into the alpha channel.

## Description
This add the ability to take screen shots with a transparent background only showing avatars, animesh, particles from the avatar, objects sat on, and selected objects.

This will make it easier for users to take screen shots of just avatars and specific objects without having to deal with the drawbacks of a green screen.

<!--
Describe what this PR changes or adds. Include any relevant context or motivation.
-->

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes
<img width="1200" height="2048" alt="Snapshot_2026-07-30_145935_001" src="https://github.com/user-attachments/assets/28913e11-fcf9-4a42-8826-b7a9ab8efe55" />

<img width="701" height="433" alt="SecondLifeViewer_b9ryQAlNON" src="https://github.com/user-attachments/assets/ff1880ba-b9af-4752-ac9a-04b20a1133d2" />
