### PR TITLE
#6040 Fix object cache logging

### DIFF
--- a/indra/newview/llvocache.cpp
+++ b/indra/newview/llvocache.cpp
@@ -1754,7 +1754,7 @@ void LLVOCache::writeToCache(U64 handle, const LLUUID& id, const LLVOCacheEntry:
 
     if(mReadOnly)
     {
-        LL_WARNS() << "Not writing cache for " << filename << " (handle:" << handle << "): Cache is currently in read-only mode." << LL_ENDL;
+        LL_INFOS() << "Not writing cache for " << filename << " (handle:" << handle << "): Cache is currently in read-only mode." << LL_ENDL;
         return ;
     }
 
@@ -1795,7 +1795,10 @@ void LLVOCache::writeToCache(U64 handle, const LLUUID& id, const LLVOCacheEntry:
 
     if(!dirty_cache)
     {
-        LL_WARNS() << "Skipping write to cache for " << filename << " (handle:" << handle << "): cache not dirty" << LL_ENDL;
+        if (!LLAppViewer::instance()->isQuitting())
+        {
+            LL_WARNS() << "Skipping write to cache for " << filename << " (handle:" << handle << "): cache not dirty" << LL_ENDL;
+        }
         return ; //nothing changed, no need to update.
     }
 


### PR DESCRIPTION
Just a small adjustment for shutdown logging.

mReadOnly is an expected state for second instance. There is nothing to fix, nothing unexpected, so it doesn't deserve a warning. Similar for dirty_cache, it's notmal to not have changes there on global shutdown. Might even want it as infos (like a region loads and immediately unloads, would trip the warning despite it being expected not to have dirty cache)