### PR TITLE
#6068 Prioritize the user's own attachment textures

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -11887,6 +11887,17 @@
       <key>Value</key>
       <real>8.0</real>
     </map>
+    <key>TextureSelfAvatarBoost</key>
+    <map>
+      <key>Comment</key>
+      <string>Coverage multiplier for textures used by the agent's own attachments. 4.0 gives approximately one mip of extra priority without pinning the texture or bypassing the maximum texture resolution.</string>
+      <key>Persist</key>
+      <integer>0</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>4.0</real>
+    </map>
     <key>TextureDecodeDisabled</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -31,6 +31,7 @@
 #include "llviewertexturelist.h"
 
 #include "llagent.h"
+#include "llvoavatarself.h"
 #include "llgl.h" // fot gathering stats from GL
 #include "llimagegl.h"
 #include "llimagebmp.h"
@@ -909,6 +910,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
 
         F32 max_vsize = 0.f;
         bool on_screen = false;
+        LLVOAvatarSelf* self_avatar = gAgentAvatarp.get();
 
         U32 face_count = 0;
         U32 max_faces_to_check = 1024;
@@ -975,6 +977,16 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
                     {
                         static LLCachedControl<F32> texture_camera_boost(gSavedSettings, "TextureCameraBoost", 8.f);
                         vsize *= llmax(face->mImportanceToCamera*texture_camera_boost, 1.f);
+                    }
+
+                    // Keep textures used by the agent's own attachments ahead of crowded-scene content.
+                    // Do not use BOOST_AVATAR_SELF here: attachment textures remain normal LOD textures so
+                    // RenderMaxTextureResolution and memory pressure continue to apply, and shared texture
+                    // assets are not permanently pinned after an attachment is removed.
+                    if (self_avatar && (face->mAvatar == self_avatar || (objp->isAttachment() && objp->getAvatarAncestor() == self_avatar)))
+                    {
+                        static LLCachedControl<F32> self_avatar_boost(gSavedSettings, "TextureSelfAvatarBoost", 4.f);
+                        vsize *= llmax((F32)self_avatar_boost, 1.f);
                     }
 
                     max_vsize = llmax(max_vsize, vsize);


### PR DESCRIPTION
Prioritize textures used by the agent’s own attachments so they recover faster after zooming out in crowded scenes.
The bounded boost preserves normal resolution caps and memory-pressure behavior.