### PR TITLE
#6071 Exra logging and guards for LLVisualParamHint

### DIFF
--- a/indra/newview/lldrawpoolavatar.cpp
+++ b/indra/newview/lldrawpoolavatar.cpp
@@ -611,6 +611,7 @@ void LLDrawPoolAvatar::beginSkinned()
 
     sVertexProgram->bind();
     sVertexProgram->setMinimumAlpha(LLDrawPoolAvatar::sMinimumAlpha);
+    sDiffuseChannel = sVertexProgram->enableTexture(LLViewerShaderMgr::DIFFUSE_MAP);
 }
 
 void LLDrawPoolAvatar::endSkinned()
@@ -624,6 +625,7 @@ void LLDrawPoolAvatar::endSkinned()
 
     // if we're in software-blending, remember to set the fence _after_ we draw so we wait till this rendering is done
     sRenderingSkinned = false;
+    sVertexProgram->disableTexture(LLViewerShaderMgr::DIFFUSE_MAP);
     sVertexProgram->disableTexture(LLViewerShaderMgr::BUMP_MAP);
     gGL.getTexUnit(0)->activate();
     sVertexProgram->unbind();

--- a/indra/newview/lltoolmorph.cpp
+++ b/indra/newview/lltoolmorph.cpp
@@ -165,6 +165,13 @@ bool LLVisualParamHint::needsRender()
 
 void LLVisualParamHint::preRender(bool clear_depth)
 {
+    LL_DEBUGS("ParamHint") << "preRender: param=" << mVisualParam->getName()
+        << " id=" << mVisualParam->getID()
+        << " weight=" << mVisualParamWeight
+        << " dirtyMesh=" << gAgentAvatarp->mDirtyMesh
+        << " pixelArea=" << gAgentAvatarp->mAdjustedPixelArea
+        << " appearanceAnimating=" << gAgentAvatarp->getIsAppearanceAnimating()
+        << LL_ENDL;
     LLViewerWearable* wearable = dynamic_cast<LLViewerWearable*>(mWearablePtr);
     if (wearable)
     {
@@ -184,6 +191,19 @@ void LLVisualParamHint::preRender(bool clear_depth)
     {
         gAgentAvatarp->updateGeometry(gAgentAvatarp->mDrawable);
         gAgentAvatarp->updateLOD();
+
+        if (gAgentAvatarp->mDrawable->isState(LLDrawable::REBUILD_GEOMETRY))
+        {
+            LL_WARNS_ONCE("ParamHint") << "preRender: clearing REBUILD_GEOMETRY after updateGeometry/updateLOD"
+                << " param=" << mVisualParam->getName()
+                << " dirtyMesh=" << gAgentAvatarp->mDirtyMesh
+                << LL_ENDL;
+            // Clear REBUILD_GEOMETRY so that renderSkinned inside generateImpostor
+            // does not re-run updateMeshData() with a partially consistent mesh state,
+            // which would reassign mFace pointers on some meshes while others are
+            // mid-draw with stale vertex offsets.
+            gAgentAvatarp->mDrawable->clearState(LLDrawable::REBUILD_GEOMETRY);
+        }
     }
     else
     {
@@ -263,8 +283,15 @@ bool LLVisualParamHint::render()
 
     LLViewerCamera::getInstance()->setPerspective(false, mOrigin.mX, mOrigin.mY, mFullWidth, mFullHeight, false);
 
-    if (gAgentAvatarp->mDrawable.notNull())
+    llassert(!LLPipeline::sImpostorRender); // We are rendering this from UI, shouldn't be set
+    if (gAgentAvatarp->mDrawable.notNull() && !LLPipeline::sImpostorRender)
     {
+        LL_DEBUGS("ParamHint") << "render: generating impostor"
+            << " param=" << mVisualParam->getName()
+            << " drawableState=0x" << std::hex << gAgentAvatarp->mDrawable->getState() << std::dec
+            << " dirtyMesh=" << gAgentAvatarp->mDirtyMesh
+            << " mMeshValid=" << gAgentAvatarp->mMeshValid
+            << LL_ENDL;
         LLGLDepthTest gls_depth(GL_TRUE, GL_TRUE);
         gGL.flush();
         gGL.setSceneBlendType(LLRender::BT_REPLACE);

--- a/indra/newview/llviewerjoint.cpp
+++ b/indra/newview/llviewerjoint.cpp
@@ -145,6 +145,7 @@ U32 LLViewerJoint::render( F32 pixelArea, bool first_pass, bool is_dummy )
     {
         // LLViewerJoint is derived from LLAvatarJoint,
         // all children of LLAvatarJoint are assumed to be LLAvatarJoint
+        // LLJoint is not used directly and is always LLAvatarJoint
         LLAvatarJoint* joint = static_cast<LLAvatarJoint*>(j);
         F32 jointLOD = joint->getLOD();
         if (pixelArea >= jointLOD || sDisableLOD)

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -95,6 +95,7 @@ class LLVOAvatar :
 public:
     friend class LLVOAvatarSelf;
     friend class LLAvatarCheckImpostorMode;
+    friend class LLVisualParamHint;
 
 /********************************************************************************
  **                                                                            **


### PR DESCRIPTION
1. LLViewerJointMesh::drawShape utilizes sDiffuseChannel and apparently was using 'leftover' value from previous calls
2. Making sure REBUILD_GEOMETRY is not set, so no dynamic changes happen mid-draw inside impostor generator (might be a better idea to disable). Not sure if it can actually happen, but for now covering all bases
3. Double checking LLPipeline::sImpostorRender. I don't think there is a way for it to be set priot to the render() calls, but copilot didn't like the lack of the check and I don't see the harm in this case. 
4. Logging

P.S. Wanted to add logging into LLViewerJointMesh::drawShape, but it's rather troublesome to cover. Will consider making a temporary build with such logging if this doesn't fix the issue.