### PR TITLE
#6119 Mutex deadlock on LLGridManager singleton

### DIFF
--- a/indra/llcommon/llwatchdog.h
+++ b/indra/llcommon/llwatchdog.h
@@ -91,6 +91,11 @@ public:
     LLWatchdog();
     ~LLWatchdog();
 
+    LLWatchdog(const LLWatchdog&) = delete;
+    LLWatchdog(LLWatchdog&&) = delete;
+    LLWatchdog& operator=(const LLWatchdog&) = delete;
+    LLWatchdog& operator=(LLWatchdog&&) = delete;
+
     // Add an entry to the watchdog.
     void add(LLWatchdogEntry* e);
     void remove(LLWatchdogEntry* e);

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -2175,6 +2175,7 @@ bool LLAppViewer::cleanup()
     LLWorld::deleteSingleton();
     LLVoiceClient::deleteSingleton();
     LLUI::deleteSingleton();
+    LLGridManager::deleteSingleton();
     LLWatchdog::deleteSingleton();
 
     // It's not at first obvious where, in this long sequence, a generic cleanup
@@ -3009,6 +3010,8 @@ bool LLAppViewer::initConfiguration()
         }
     }
 
+    LLGridManager::createInstance();
+
     LLSLURL start_slurl;
     if (!starting_location.empty())
     {
@@ -3057,6 +3060,7 @@ bool LLAppViewer::initConfiguration()
             // Do not save settings.
             // Might be smarter to have an exit code for a more reliable
             // "early exit, needs cleanup" case.
+            LLGridManager::deleteSingleton();
             LLSingletonBase::deleteAll();
             cleanupConsole();
             delete mSettingsLocationList;
@@ -3117,6 +3121,7 @@ bool LLAppViewer::initConfiguration()
 
         // Since returning 'false' is basically an error without cleanup,
         // do cleanup here. No need to worry about marker files here.
+        LLGridManager::deleteSingleton();
         LLSingletonBase::deleteAll();
         cleanupConsole();
         return false;

--- a/indra/newview/llviewernetwork.h
+++ b/indra/newview/llviewernetwork.h
@@ -57,13 +57,18 @@ protected:
  * This class maintains the currently selected grid, and provides short
  * form accessors for each of the properties of the selected grid.
  **/
-class LLGridManager : public LLSingleton<LLGridManager>
+class LLGridManager : public LLSimpleton<LLGridManager>
 {
+public:
     /// Instantiate the grid manager, load default grids, selects the default grid
-    LLSINGLETON(LLGridManager);
+    LLGridManager();
     ~LLGridManager();
 
-  public:
+    LLGridManager(const LLGridManager&) = delete;
+    LLGridManager(LLGridManager&&) = delete;
+    LLGridManager& operator=(const LLGridManager&) = delete;
+    LLGridManager& operator=(LLGridManager&&) = delete;
+
     /* ================================================================
      * @name Initialization and Configuration
      * @{

--- a/indra/newview/tests/llslurl_test.cpp
+++ b/indra/newview/tests/llslurl_test.cpp
@@ -147,10 +147,12 @@ namespace tut
     {
         slurlTest()
         {
+            LLGridManager::createInstance();
             LLGridManager::getInstance()->initialize(std::string(""));
         }
         ~slurlTest()
         {
+            LLGridManager::deleteSingleton();
         }
     };
 

--- a/indra/newview/tests/llviewernetwork_test.cpp
+++ b/indra/newview/tests/llviewernetwork_test.cpp
@@ -175,6 +175,7 @@ namespace tut
     {
         viewerNetworkTest()
         {
+            LLGridManager::createInstance();
             LLFile::remove(TEST_FILENAME);
             gCmdLineLoginURI.clear();
             gCmdLineGridChoice.clear();
@@ -185,6 +186,7 @@ namespace tut
         ~viewerNetworkTest()
         {
             LLFile::remove(TEST_FILENAME);
+            LLGridManager::deleteSingleton();
         }
     };
 


### PR DESCRIPTION
LLGridManager is performance critical and low level enough that it should just be turned into LLSimpleton. Without capture_dependency there won't be a 'deadlock'.