### PR TITLE
#5574 Add Lua and LSL-on-Luau options to Build - Scripts - Recompile Scripts.

### DIFF
--- a/indra/newview/llcompilequeue.cpp
+++ b/indra/newview/llcompilequeue.cpp
@@ -52,7 +52,6 @@
 #include "lldir.h"
 #include "llnotificationsutil.h"
 #include "llviewerstats.h"
-#include "llfilesystem.h"
 #include "lluictrlfactory.h"
 #include "lltrans.h"
 
@@ -61,7 +60,6 @@
 
 #include "llviewerassetupload.h"
 #include "llcorehttputil.h"
-#include "llpreviewscript.h"
 
 namespace
 {
@@ -463,31 +461,22 @@ bool LLFloaterCompileQueue::processScript(LLHandle<LLFloaterCompileQueue> hfloat
 
     LLUUID assetId = result["asset_id"];
 
-    // Check if this is a SLua script that shouldn't be recompiled to Mono/LSL
-    if (compile_target == "mono" || compile_target == "lsl2")
-    {
-        // Read the script from cache to check its type
-        LLFileSystem file(assetId, LLAssetType::AT_LSL_TEXT, LLFileSystem::READ);
-        if (file.getSize() > 0)
-        {
-            S32 file_length = file.getSize();
-            std::vector<char> buffer(file_length + 1);
-            file.read((U8*)&buffer[0], file_length);
-            buffer[file_length] = 0;
-            std::string script_text(&buffer[0]);
+    const bool script_is_lua = item->getInventorySubType() == SST_LUA;
+    const bool target_is_lua = compile_target == "luau";
+    const bool incompatible_language = target_is_lua != script_is_lua;
 
-            if (is_lua_script(script_text))
-            {
-                // This is a SLua script - skip it with a warning
-                LLStringUtil::format_map_t args;
-                args["[SCRIPT_NAME]"] = inventory->getName();
-                args["[TARGET]"] = (compile_target == "mono") ? "Mono" : "LSL";
-                std::string buffer = floater->getString("SkippingSluaScript", args);
-                floater->addStringMessage(buffer);
-                LL_INFOS("SCRIPTQ") << "Skipping SLua script: " << inventory->getName() << LL_ENDL;
-                return true;
-            }
-        }
+    // Lua and LSL use different source languages, so do not send an incompatible
+    // script to the compiler. The inventory subtype identifies the source language.
+    if (incompatible_language)
+    {
+        LLStringUtil::format_map_t args;
+        args["[SCRIPT_NAME]"] = inventory->getName();
+        args["[TARGET]"] = compile_target;
+        std::string buffer = floater->getString("SkippingIncompatibleScript", args);
+        floater->addStringMessage(buffer);
+        LL_INFOS("SCRIPTQ") << "Skipping incompatible script: " << inventory->getName()
+            << " (target " << compile_target << ")" << LL_ENDL;
+        return true;
     }
 
     std::string url = object->getRegion()->getCapability("UpdateScriptTask");

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -124,6 +124,7 @@
 #include "llviewernetwork.h"
 #include "llviewerobjectlist.h"
 #include "llviewerparcelmgr.h"
+#include "llviewerregion.h"
 #include "llviewerstats.h"
 #include "llviewerstatsrecorder.h"
 #include "llvlcomposition.h"
@@ -8037,6 +8038,20 @@ class LLToolsSelectedScriptAction : public view_listener_t
             msg = "Recompile";
             title = LLTrans::getString("CompileQueueTitle");
         }
+        else if (action == "compile lua")
+        {
+            name = "compile_queue";
+            target = "luau";
+            msg = "Recompile";
+            title = LLTrans::getString("CompileQueueTitle");
+        }
+        else if (action == "compile lsl-luau")
+        {
+            name = "compile_queue";
+            target = "lsl-luau";
+            msg = "Recompile";
+            title = LLTrans::getString("CompileQueueTitle");
+        }
         else if (action == "reset")
         {
             name = "reset_queue";
@@ -8456,6 +8471,27 @@ class LLEditableSelectedMono : public view_listener_t
             new_value = is_editable_selected() && have_cap;
         }
         return new_value;
+    }
+};
+
+static bool is_lua_scripts_enabled()
+{
+    LLViewerRegion* region = gAgent.getRegion();
+    if (!region || region->getCapability("UpdateScriptTask").empty() || !region->simulatorFeaturesReceived())
+    {
+        return false;
+    }
+
+    LLSD simulator_features;
+    region->getSimulatorFeatures(simulator_features);
+    return simulator_features["LuaScriptsEnabled"].asBoolean();
+}
+
+class LLEditableSelectedLua : public view_listener_t
+{
+    bool handleEvent(const LLSD& userdata)
+    {
+        return is_editable_selected() && is_lua_scripts_enabled();
     }
 };
 
@@ -10383,5 +10419,6 @@ void initialize_menus()
     view_listener_t::addMenu(new LLSomethingSelectedNoHUD(), "SomethingSelectedNoHUD");
     view_listener_t::addMenu(new LLEditableSelected(), "EditableSelected");
     view_listener_t::addMenu(new LLEditableSelectedMono(), "EditableSelectedMono");
+    view_listener_t::addMenu(new LLEditableSelectedLua(), "EditableSelectedLua");
     view_listener_t::addMenu(new LLToggleUIHints(), "ToggleUIHints");
 }

--- a/indra/newview/skins/default/xui/en/floater_script_queue.xml
+++ b/indra/newview/skins/default/xui/en/floater_script_queue.xml
@@ -38,8 +38,8 @@
         Loading inventory for: [OBJECT_NAME]
     </floater.string>
     <floater.string
-     name="SkippingSluaScript">
-        Skipping SLua script "[SCRIPT_NAME]" (cannot recompile to [TARGET])
+     name="SkippingIncompatibleScript">
+        Skipping script "[SCRIPT_NAME]" (cannot recompile to [TARGET])
     </floater.string>
     <button
      follows="right|bottom"

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -1366,6 +1366,24 @@ function="World.EnvPreset"
                function="EditableSelected" />
           </menu_item_call>
           <menu_item_call
+             label="Recompile Scripts (Lua)"
+             name="Lua">
+            <menu_item_call.on_click
+               function="Tools.SelectedScriptAction"
+               parameter="compile lua" />
+            <menu_item_call.on_enable
+               function="EditableSelectedLua" />
+          </menu_item_call>
+          <menu_item_call
+             label="Recompile Scripts (LSL on Luau)"
+             name="LSL on Luau">
+            <menu_item_call.on_click
+               function="Tools.SelectedScriptAction"
+               parameter="compile lsl-luau" />
+            <menu_item_call.on_enable
+               function="EditableSelectedLua" />
+          </menu_item_call>
+          <menu_item_call
              label="Reset Scripts"
              name="Reset Scripts">
             <menu_item_call.on_click


### PR DESCRIPTION
**Testing plan**

1. Create a box.
2. Add one Lua script and one LSL script.
3. Run "Recompile Scripts (Lua)".
4. Run "Recompile Scripts (LSL on Luau)".
5. Verify that compatible scripts compile successfully and incompatible scripts are skipped with a clear message.
6. Verify that the existing Mono and LSL recompilation options still work.