### PR TITLE
Fix LLViewerParcelMgr::writeHighlightSegments crashing from writing out of bounds

### DIFF
--- a/indra/newview/llviewerparcelmgr.cpp
+++ b/indra/newview/llviewerparcelmgr.cpp
@@ -309,6 +309,14 @@ void LLViewerParcelMgr::resetSegments(U8* segments)
 void LLViewerParcelMgr::writeHighlightSegments(F32 west, F32 south, F32 east,
                                                F32 north)
 {
+    if (west < 0 || south < 0 || east < 0 || north < 0)
+    {
+        LL_WARNS() << "Invalid parcel edge coordinates provided to writeHighlightSegments- "
+            << "west: " << west << ", south: " << south << ", east: " << east << ", north: " << north
+            << LL_ENDL;
+        return;
+    }
+
     S32 x, y;
     S32 min_x = ll_round( west / PARCEL_GRID_STEP_METERS );
     S32 max_x = ll_round( east / PARCEL_GRID_STEP_METERS );


### PR DESCRIPTION
Issue Fixed: https://github.com/secondlife/viewer/issues/6125

This PR simply checks if any of the edge coordinates provided to LLViewerParcelMgr::writeHighlightSegments are negative, and if so logs a warning and early returns so it never writes to mHighlightSegments with an out of bounds index.

Note: If you would prefer this handled differently, please feel free to suggest an alternative way and I'll change the PR accordingly.
You can refer to the screenshot provided in the issue to see the negative values that have been passed to the function that ended up causing an exception.