### PR TITLE
Report viewer's VRAM usage to statistics

### DIFF
--- a/indra/llcommon/llprocessor.cpp
+++ b/indra/llcommon/llprocessor.cpp
@@ -123,6 +123,9 @@ namespace
         eSSE4_1_Features = 38,
         eSSE4_2_Features = 39,
         eSSE4a_Features = 40,
+        eAVX_Features = 41,
+        eAVX2_Features = 42,
+        eAVX512F_Features = 43,
     };
 
     const char* cpu_feature_names[] =
@@ -170,6 +173,9 @@ namespace
         "SSE4.1 Instructions",
         "SSE4.2 Instructions",
         "SSE4a Instructions",
+        "AVX Instructions",   // 41
+        "AVX2 Instructions",  // 42
+        "AVX-512F Instructions", // 43
     };
 
     std::string intel_CPUFamilyName(int composed_family)
@@ -281,6 +287,21 @@ public:
     bool hasSSE4a() const
     {
         return hasExtension(cpu_feature_names[eSSE4a_Features]);
+    }
+
+    bool hasAVX() const
+    {
+        return hasExtension(cpu_feature_names[eAVX_Features]);
+    }
+
+    bool hasAVX2() const
+    {
+        return hasExtension(cpu_feature_names[eAVX2_Features]);
+    }
+
+    bool hasAVX512F() const
+    {
+        return hasExtension(cpu_feature_names[eAVX512F_Features]);
     }
 
     bool hasAltivec() const
@@ -572,12 +593,39 @@ private:
                     setExtension(cpu_feature_names[eSSE4_2_Features]);
                 }
 
+                // AVX: CPUID leaf 1, ECX bit 28, OSXSAVE + XCR0[1:2] enabled
+                if ((cpu_info[2] & 0x18000000) == 0x18000000 && ((_xgetbv(0) & 0x6) == 0x6))
+                {
+                    setExtension(cpu_feature_names[eAVX_Features]);
+                }
+
                 unsigned int feature_info = (unsigned int) cpu_info[3];
                 for(unsigned int index = 0, bit = 1; index < eSSE3_Features; ++index, bit <<= 1)
                 {
                     if(feature_info & bit)
                     {
                         setExtension(cpu_feature_names[index]);
+                    }
+                }
+            }
+            else if (i == 7)
+            {
+                // AVX2/AVX-512* require AVX to be usable (OSXSAVE + XCR0 state)
+                if (hasExtension(cpu_feature_names[eAVX_Features]))
+                {
+                    int cpu_info7[4] = { -1 };
+                    __cpuidex(cpu_info7, 7, 0);
+                    // AVX2: EBX bit 5
+                    if (cpu_info7[1] & 0x20)
+                    {
+                        setExtension(cpu_feature_names[eAVX2_Features]);
+                    }
+
+                    // AVX-512F: EBX bit 16; ZMM state in XCR0 (bits 5-7)
+                    const unsigned long long xcr0 = _xgetbv(0);
+                    if ((cpu_info7[1] & 0x10000) && ((xcr0 & 0xE6) == 0xE6))
+                    {
+                        setExtension(cpu_feature_names[eAVX512F_Features]);
                     }
                 }
             }
@@ -779,6 +827,29 @@ private:
             // Not supposed to happen?
             setExtension(cpu_feature_names[eSSE4a_Features]);
         }
+        if (cpu_features_str.find(" AVX1.0 ") != std::string::npos)
+        {
+            setExtension(cpu_feature_names[eAVX_Features]);
+        }
+
+        // AVX2 and AVX-512F are reported in machdep.cpu.leaf7_features on macOS
+        char cpu_leaf7_features[1024];
+        len = sizeof(cpu_leaf7_features);
+        memset(cpu_leaf7_features, 0, len);
+        sysctlbyname("machdep.cpu.leaf7_features", (void*)cpu_leaf7_features, &len, NULL, 0);
+
+        std::string cpu_leaf7_str(cpu_leaf7_features);
+        cpu_leaf7_str = " " + cpu_leaf7_str + " ";
+
+        if (cpu_leaf7_str.find(" AVX2 ") != std::string::npos)
+        {
+            setExtension(cpu_feature_names[eAVX2_Features]);
+        }
+
+        if (cpu_leaf7_str.find(" AVX512F ") != std::string::npos)
+        {
+            setExtension(cpu_feature_names[eAVX512F_Features]);
+        }
     }
 };
 
@@ -915,6 +986,21 @@ private:
             setExtension(cpu_feature_names[eSSE4a_Features]);
         }
 
+        if (flags.find(" avx ") != std::string::npos)
+        {
+            setExtension(cpu_feature_names[eAVX_Features]);
+        }
+
+        if (flags.find(" avx2 ") != std::string::npos)
+        {
+            setExtension(cpu_feature_names[eAVX2_Features]);
+        }
+
+        if (flags.find(" avx512f ") != std::string::npos)
+        {
+            setExtension(cpu_feature_names[eAVX512F_Features]);
+        }
+
 # endif // LL_X86
     }
 
@@ -979,6 +1065,9 @@ bool LLProcessorInfo::hasSSE3S() const { return mImpl->hasSSE3S(); }
 bool LLProcessorInfo::hasSSE41() const { return mImpl->hasSSE41(); }
 bool LLProcessorInfo::hasSSE42() const { return mImpl->hasSSE42(); }
 bool LLProcessorInfo::hasSSE4a() const { return mImpl->hasSSE4a(); }
+bool LLProcessorInfo::hasAVX() const { return mImpl->hasAVX(); }
+bool LLProcessorInfo::hasAVX2() const { return mImpl->hasAVX2(); }
+bool LLProcessorInfo::hasAVX512F() const { return mImpl->hasAVX512F(); }
 bool LLProcessorInfo::hasAltivec() const { return mImpl->hasAltivec(); }
 std::string LLProcessorInfo::getCPUFamilyName() const { return mImpl->getCPUFamilyName(); }
 std::string LLProcessorInfo::getCPUBrandName() const { return mImpl->getCPUBrandName(); }

--- a/indra/llcommon/llprocessor.h
+++ b/indra/llcommon/llprocessor.h
@@ -46,6 +46,9 @@ public:
     bool hasSSE41() const;
     bool hasSSE42() const;
     bool hasSSE4a() const;
+    bool hasAVX() const;
+    bool hasAVX2() const;
+    bool hasAVX512F() const;
     bool hasAltivec() const;
     std::string getCPUFamilyName() const;
     std::string getCPUBrandName() const;

--- a/indra/llcommon/llsys.cpp
+++ b/indra/llcommon/llsys.cpp
@@ -590,6 +590,9 @@ LLCPUInfo::LLCPUInfo()
     mHasSSE41 = proc.hasSSE41();
     mHasSSE42 = proc.hasSSE42();
     mHasSSE4a = proc.hasSSE4a();
+    mHasAVX = proc.hasAVX();
+    mHasAVX2 = proc.hasAVX2();
+    mHasAVX512F = proc.hasAVX512F();
     mHasAltivec = proc.hasAltivec();
     mCPUMHz = (F64)proc.getCPUFrequency();
     mFamily = proc.getCPUFamilyName();
@@ -630,6 +633,18 @@ LLCPUInfo::LLCPUInfo()
     if (mHasSSE4a)
     {
         mSSEVersions.append("4a");
+    }
+    if (mHasAVX)
+    {
+        mSIMDVersions.append("AVX");
+    }
+    if (mHasAVX2)
+    {
+        mSIMDVersions.append("AVX2");
+    }
+    if (mHasAVX512F)
+    {
+        mSIMDVersions.append("AVX-512F");
     }
 }
 
@@ -673,6 +688,21 @@ bool LLCPUInfo::hasSSE4a() const
     return mHasSSE4a;
 }
 
+bool LLCPUInfo::hasAVX() const
+{
+    return mHasAVX;
+}
+
+bool LLCPUInfo::hasAVX2() const
+{
+    return mHasAVX2;
+}
+
+bool LLCPUInfo::hasAVX512F() const
+{
+    return mHasAVX512F;
+}
+
 F64 LLCPUInfo::getMHz() const
 {
     return mCPUMHz;
@@ -686,6 +716,11 @@ std::string LLCPUInfo::getCPUString() const
 const LLSD& LLCPUInfo::getSSEVersions() const
 {
     return mSSEVersions;
+}
+
+const LLSD& LLCPUInfo::getSIMDVersions() const
+{
+    return mSIMDVersions;
 }
 
 void LLCPUInfo::stream(std::ostream& s) const

--- a/indra/llcommon/llsys.h
+++ b/indra/llcommon/llsys.h
@@ -81,6 +81,7 @@ public:
 
     std::string getCPUString() const;
     const LLSD& getSSEVersions() const;
+    const LLSD& getSIMDVersions() const;
 
     bool hasAltivec() const;
     bool hasSSE() const;
@@ -90,6 +91,9 @@ public:
     bool hasSSE41() const;
     bool hasSSE42() const;
     bool hasSSE4a() const;
+    bool hasAVX() const;
+    bool hasAVX2() const;
+    bool hasAVX512F() const;
     F64 getMHz() const;
 
     // Family is "AMD Duron" or "Intel Pentium Pro"
@@ -103,11 +107,15 @@ private:
     bool mHasSSE41;
     bool mHasSSE42;
     bool mHasSSE4a;
+    bool mHasAVX;
+    bool mHasAVX2;
+    bool mHasAVX512F;
     bool mHasAltivec;
     F64 mCPUMHz;
     std::string mFamily;
     std::string mCPUString;
     LLSD mSSEVersions;
+    LLSD mSIMDVersions;
 };
 
 //=============================================================================

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -3890,8 +3890,12 @@ void LLAppViewer::writeSystemInfo()
     gDebugInfo["CPUInfo"]["CPUFamily"] = gSysCPU.getFamily();
     gDebugInfo["CPUInfo"]["CPUMhz"] = (S32)gSysCPU.getMHz();
     gDebugInfo["CPUInfo"]["CPUAltivec"] = gSysCPU.hasAltivec();
-    gDebugInfo["CPUInfo"]["CPUSSE"] = gSysCPU.hasSSE();
-    gDebugInfo["CPUInfo"]["CPUSSE2"] = gSysCPU.hasSSE2();
+    gDebugInfo["CPUInfo"]["CPUSSE42"] = gSysCPU.hasSSE42();
+    gDebugInfo["CPUInfo"]["CPUSSE4a"] = gSysCPU.hasSSE4a();
+    gDebugInfo["CPUInfo"]["CPUAVX"] = gSysCPU.hasAVX();
+    gDebugInfo["CPUInfo"]["CPUAVX2"] = gSysCPU.hasAVX2();
+    gDebugInfo["CPUInfo"]["CPUAVX512F"] = gSysCPU.hasAVX512F();
+
 
     gDebugInfo["RAMInfo"]["Physical"] = LLSD::Integer(gSysMemory.getPhysicalMemoryKB().value());
     gDebugInfo["RAMInfo"]["Allocated"] = LLSD::Integer(gMemoryAllocated.valueInUnits<LLUnits::Kilobytes>());

--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -2527,18 +2527,26 @@ S32 LLTextureFetch::createRequest(FTType f_type, const std::string& url, const L
     {
         LL_DEBUGS("Avatar") << " requesting " << id << " " << w << "x" << h << " discard " << desired_discard << " type " << f_type << LL_ENDL;
     }
-    LLTextureFetchWorker* worker = getWorker(id);
+
+    // Potentially we might remove a request, lock queue here instead
+    // of getWorker to make sure request will persist till removeRequest
+    lockQueue();
+    LLTextureFetchWorker* worker = getWorkerAfterLock(id);
     if (worker)
     {
         if (worker->mHost != host)
         {
             LL_WARNS(LOG_TXT) << "LLTextureFetch::createRequest " << id << " called with multiple hosts: "
                 << host << " != " << worker->mHost << LL_ENDL;
-            removeRequest(worker, true);
+            size_t erased_1 = mRequestMap.erase(worker->mID);
+            llassert_always(erased_1 > 0);
+            unlockQueue();
+            worker->scheduleDelete();
             worker = NULL;
             return CREATE_REQUEST_ERROR_MHOSTS;
         }
     }
+    unlockQueue();
 
     S32 desired_size;
     std::string exten = gDirUtilp->getExtension(url);
@@ -2717,9 +2725,11 @@ void LLTextureFetch::deleteAllRequests()
         }
 
         LLTextureFetchWorker* worker = mRequestMap.begin()->second;
-        unlockQueue() ;
+        size_t erased_1 = mRequestMap.erase(worker->mID);
+        llassert_always(erased_1 > 0);
+        unlockQueue();
 
-        removeRequest(worker, true);
+        worker->scheduleDelete();
     }
 }
 

--- a/indra/newview/llviewerstats.cpp
+++ b/indra/newview/llviewerstats.cpp
@@ -714,6 +714,8 @@ void send_viewer_stats(bool include_preferences)
     system["os"] = LLOSInfo::instance().getOSStringSimple();
     system["cpu"] = gSysCPU.getCPUString();
     system["cpu_sse"] = gSysCPU.getSSEVersions();
+    system["cpu_simd"] = gSysCPU.getSIMDVersions();
+    system["cpu_mhz"] = gSysCPU.getMHz();
     system["address_size"] = ADDRESS_SIZE;
     system["os_bitness"] = LLOSInfo::instance().getOSBitness();
     system["hardware_concurrency"] = (LLSD::Integer) std::thread::hardware_concurrency();
@@ -736,6 +738,19 @@ void send_viewer_stats(bool include_preferences)
     system["gpu_vendor"] = gGLManager.mGLVendorShort;
     system["gpu_version"] = gGLManager.mDriverVersionVendorString;
     system["opengl_version"] = gGLManager.mGLVersionString;
+    system["gpu_vram_mb"] = (S32)gGLManager.mVRAM;
+    system["glsl_version"] = llformat("%d.%d", gGLManager.mGLSLVersionMajor, gGLManager.mGLSLVersionMinor);
+
+    // Resource usage
+    // getAvailableMemKB might be a bit stale, but that's fine, this is statistics,
+    // not a debug tool.
+    // TODO: 26.3 branch introduced getAvailableCommitMemMB, use that on windows
+    system["ram_avail_mb"] = (S32Megabytes)(LLMemory::getAvailableMemKB()).value();
+    system["ram_allocated_mb"] = (S32Megabytes)(LLMemory::getAllocatedMemKB()).value();
+    static constexpr F64 BYTES_TO_MB = 1024.0 * 1024.0;
+    F64 texture_bytes_alloc = LLImageGL::getTextureBytesAllocated() / BYTES_TO_MB;
+    F64 vertex_bytes_alloc = LLVertexBuffer::getBytesAllocated() / BYTES_TO_MB;
+    system["gpu_vram_tracked_mb"] = (F32)(texture_bytes_alloc + vertex_bytes_alloc);
 
     gGLManager.asLLSD(system["gl"]);
 


### PR DESCRIPTION
- Added ram and vram tracking to our statistics reports
- Updated 'sse' reporting with simd.
- Small crash fix for workers (something is racing to remove workers?)