### PR TITLE
 Fix LLViewerTexture::getSystemMemoryBudgetFactor result trunction when low on memory

### DIFF
--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -688,7 +688,7 @@ F32 LLViewerTexture::getSystemMemoryBudgetFactor()
         // Leave some padding, otherwise we will crash out of memory before hitting factor 2.
         const S32Megabytes PAD_BUFFER(32);
         // Result should range from 1 at 0 free budget to 2 at -224 free budget, 2.14 at -256MB
-        return 1.f - free_budget / (MIN_FREE_MAIN_MEMORY - PAD_BUFFER);
+        return 1.f - (F32)free_budget / (MIN_FREE_MAIN_MEMORY - PAD_BUFFER);
     }
     return 1.f;
 }


### PR DESCRIPTION
**Edit: Nevermind, I just noticed that the 26.3 branch has some additional changes not currently in develop that makes this issue not a problem anymore. Closing**

Issue Fixed: https://github.com/secondlife/viewer/issues/6137

Simply casts free_budget to a float so integer division trunction doesn't occur on the result, preventing returning 1.f when a value 1.f < x < 2.f should be returned, or a value of 2.f being returned when a value of 2.f < x < 3.f should be returned, etc.

Before this PR, if the system is low on memory, LLViewerTexture::getSystemMemoryBudgetFactor may have been returning 1.f as if the free_budget is >= 0 even when it isn't.