### PR TITLE
#6092 'Save As' button in personal lighting floater

### DIFF
--- a/indra/newview/llfloatereditenvironmentbase.cpp
+++ b/indra/newview/llfloatereditenvironmentbase.cpp
@@ -281,6 +281,9 @@ void LLFloaterEditEnvironmentBase::onSaveAsCommit(const LLSD& notification, cons
         else
         {
             LL_WARNS() << "Failed to copy fixed env setting" << LL_ENDL;
+            LLSD args;
+            args["SETTINGS_NAME"] = settings_name;
+            LLNotificationsUtil::add("SettingsSaveAsFailure", args);
         }
     }
 }

--- a/indra/newview/llfloaterenvironmentadjust.cpp
+++ b/indra/newview/llfloaterenvironmentadjust.cpp
@@ -28,15 +28,19 @@
 
 #include "llfloaterenvironmentadjust.h"
 
+#include "llcolorswatch.h"
+#include "llenvironment.h"
+#include "llinventorymodel.h"
+#include "llinventorypanel.h" // For opening after saving
 #include "llnotificationsutil.h"
+#include "llsettingsvo.h"
 #include "llslider.h"
 #include "llsliderctrl.h"
-#include "llcolorswatch.h"
 #include "lltexturectrl.h"
 #include "llvirtualtrackball.h"
-#include "llenvironment.h"
 #include "llviewercontrol.h"
 #include "pipeline.h"
+
 
 //=========================================================================
 namespace
@@ -65,6 +69,7 @@ namespace
     const std::string FIELD_SKY_MOON_ELEVATION("moon_elevation");
     const std::string FIELD_REFLECTION_PROBE_AMBIANCE("probe_ambiance");
     const std::string BTN_RESET("btn_reset");
+    const std::string BTN_SAVE_AS("btn_save_as");
 
     const F32 SLIDER_SCALE_SUN_AMBIENT(3.0f);
     const F32 SLIDER_SCALE_BLUE_HORIZON_DENSITY(2.0f);
@@ -110,6 +115,7 @@ bool LLFloaterEnvironmentAdjust::postBuild()
     getChild<LLUICtrl>(FIELD_SKY_MOON_AZIMUTH)->setCommitCallback([this](LLUICtrl *, const LLSD &) { onMoonAzimElevChanged(); });
     getChild<LLUICtrl>(FIELD_SKY_MOON_ELEVATION)->setCommitCallback([this](LLUICtrl *, const LLSD &) { onMoonAzimElevChanged(); });
     getChild<LLUICtrl>(BTN_RESET)->setCommitCallback([this](LLUICtrl *, const LLSD &) { onButtonReset(); });
+    getChild<LLUICtrl>(BTN_SAVE_AS)->setCommitCallback([this](LLUICtrl*, const LLSD&) { onButtonSaveAs(); });
 
     getChild<LLTextureCtrl>(FIELD_SKY_CLOUD_MAP)->setCommitCallback([this](LLUICtrl *, const LLSD &) { onCloudMapChanged(); });
     getChild<LLTextureCtrl>(FIELD_SKY_CLOUD_MAP)->setDefaultImageAssetID(LLSettingsSky::GetDefaultCloudNoiseTextureId());
@@ -258,8 +264,114 @@ void LLFloaterEnvironmentAdjust::onButtonReset()
             LLEnvironment::instance().setSelectedEnvironment(LLEnvironment::ENV_LOCAL);
         }
     });
-
 }
+
+void LLFloaterEnvironmentAdjust::onButtonSaveAs()
+{
+    // Note that this saves only the sky, not water.
+    // Water is represented as a single texture here, for now
+    // might be not worth saving. Consider saving water as well
+    // or alternatively generating a day cycle (fixed ones are
+    // easier to export/import).
+    if (!mLiveSky)
+        return;
+
+    // Verify every texture embedded in the sky settings is either
+    // a sky default, a predefined/library texture, or a copy-permitted
+    // inventory item owned by the agent.  Collect all failing textures
+    // into one list and show a single notification.
+    struct TexEntry { LLUUID id; std::string name; };
+    const std::vector<TexEntry> textures_to_check =
+    {
+        { mLiveSky->getCloudNoiseTextureId(),  "cloud_map" },
+        { mLiveSky->getSunTextureId(),         "sun_texture" },
+        { mLiveSky->getMoonTextureId(),        "moon_texture" },
+        { mLiveSky->getBloomTextureId(),       "bloom_texture"},
+        { mLiveSky->getRainbowTextureId(),     "rainbow_texture"},
+        { mLiveSky->getHaloTextureId(),        "halo_texture" },
+    };
+
+    // Helper: a null UUID is "no texture" and is always allowed.
+    // A texture is safe when it is one of the sky defaults,
+    // a general predefined texture, or is present in inventory.
+    auto is_safe_texture = [](const LLUUID& tex_id) -> bool
+    {
+        if (tex_id.isNull())
+            return true;
+        // TODO: find a graceful way to move these ids (and water ones) into get_can_copy_texture
+        // as pickers should permit these textures by default to be able to work well with settings.
+        if (tex_id == LLSettingsSky::GetDefaultSunTextureId()
+            || tex_id == LLSettingsSky::GetBlankSunTextureId()
+            || tex_id == LLSettingsSky::GetDefaultMoonTextureId()
+            || tex_id == LLSettingsSky::GetDefaultCloudNoiseTextureId()
+            || tex_id == LLSettingsSky::GetDefaultBloomTextureId()
+            || tex_id == LLSettingsSky::GetDefaultRainbowTextureId()
+            || tex_id == LLSettingsSky::GetDefaultHaloTextureId())
+        {
+            return true;
+        }
+        return get_can_copy_texture(tex_id);
+    };
+
+    std::string bad_textures;
+    for (const TexEntry& entry : textures_to_check)
+    {
+        if (!is_safe_texture(entry.id))
+        {
+            if (!bad_textures.empty())
+                bad_textures += "\n";
+            std::string label = getString(entry.name);
+            bad_textures += "  - " + label;
+        }
+    }
+
+    if (!bad_textures.empty())
+    {
+        LLSD args;
+        args["TEXTURES"] = bad_textures;
+        LLNotificationsUtil::add("PersonalSettingsTexPermFail", args);
+        return;
+    }
+
+    LLSettingsSky::ptr_t sky_clone = mLiveSky->buildClone();
+    LLSD args;
+    args["DESC"] = getString("new_sky"); // note that notification adds (new) at the end
+
+    LLNotificationsUtil::add("SaveSettingAs", args, LLSD(),
+        [sky_clone](const LLSD& notification, const LLSD& response)
+    {
+        S32 option = LLNotificationsUtil::getSelectedOption(notification, response);
+        if (option != 0)
+            return;
+
+        std::string settings_name = response["message"].asString();
+        LLInventoryObject::correctInventoryName(settings_name);
+        if (settings_name.empty())
+        {
+            settings_name = "Unnamed";
+        }
+
+        sky_clone->setName(settings_name);
+
+        LLUUID parent_id = gInventory.findCategoryUUIDForType(LLFolderType::FT_SETTINGS);
+        LLSettingsVOBase::createInventoryItem(sky_clone, parent_id, settings_name,
+            [settings_name](LLUUID /*asset_id*/, LLUUID inventory_id, LLUUID, LLSD results)
+        {
+            if (inventory_id.notNull())
+            {
+                LLInventoryPanel::openInventoryPanelAndSetSelection(true, inventory_id, true);
+            }
+            else
+            {
+                LL_WARNS("ENVIRONMENT") << "Failed to create sky settings inventory item. Results: " << results << LL_ENDL;
+                LLSD args;
+                args["SETTINGS_NAME"] = settings_name;
+                LLNotificationsUtil::add("SettingsSaveAsFailure", args);
+            }
+        });
+    });
+}
+
 //-------------------------------------------------------------------------
 void LLFloaterEnvironmentAdjust::onAmbientLightChanged()
 {

--- a/indra/newview/llfloaterenvironmentadjust.h
+++ b/indra/newview/llfloaterenvironmentadjust.h
@@ -85,6 +85,7 @@ private:
     void                        onReflectionProbeAmbianceChanged();
     void                        updateGammaLabel();
     void                        onButtonReset();
+    void                        onButtonSaveAs();
 
     void                        onEnvironmentUpdated(LLEnvironment::EnvSelection_t env, S32 version);
 

--- a/indra/newview/llsurface.cpp
+++ b/indra/newview/llsurface.cpp
@@ -127,6 +127,36 @@ LLSurface::~LLSurface()
     }
     else
     {
+        // Pools are unique and can't be shared (unless two regions somehow have same coordinates)
+
+        // Which patch VOs were not cleaned up?
+        // Does mRegionp matches this surface's region?
+        LL_WARNS() << "Terrain pool not empty on destruction! "
+            << poolp->mReferences.size() << " face(s) still registered. "
+            << "Surface region: " << (mRegionp ? mRegionp->getName() : "NULL")
+            << " (" << (void*)mRegionp << ")"
+            << LL_ENDL;
+
+        // If there are dangling pointers, this is going to crash.
+        // Set an error message and state early.
+
+        for (LLFace* facep : poolp->mReferences)
+        {
+            LLDrawable* drawable = facep ? facep->getDrawable() : nullptr;
+            LLViewerObject* vobj = drawable ? drawable->getVObj().get() : nullptr;
+            LLViewerRegion* face_region = vobj ? vobj->getRegion() : nullptr;
+
+            LL_WARNS() << "  Remaining face " << (void*)facep
+                << " drawable=" << (void*)drawable
+                << " vobj=" << (void*)vobj
+                << " vobj.type=" << (vobj ? (S32)vobj->getPCode() : -1)
+                << " vobj.dead=" << (vobj ? vobj->isDead() : -1)
+                << " face_region=" << (face_region ? face_region->getName() : "NULL")
+                << " (" << (void*)face_region << ")"
+                << " region_matches=" << (face_region == mRegionp)
+                << LL_ENDL;
+        }
+
         LL_ERRS() << "Terrain pool not empty!" << LL_ENDL;
     }
 }
@@ -137,6 +167,16 @@ void LLSurface::initClasses()
 
 void LLSurface::setRegion(LLViewerRegion *regionp)
 {
+    if (mPatchList && mRegionp && mRegionp != regionp)
+    {
+        // surface patches can't cross regions
+        LL_WARNS() << "LLSurface::setRegion called with region already set and patches existing!"
+            << " old_region=" << mRegionp->getName() << " (" << (void*)mRegionp << ")"
+            << " new_region=" << (regionp ? regionp->getName() : "NULL") << " (" << (void*)regionp << ")"
+            << LL_ENDL;
+        llassert(false);
+    }
+
     mRegionp = regionp;
     mWaterObjp = nullptr; // depends on regionp, needs recreating
 }

--- a/indra/newview/skins/default/xui/en/floater_adjust_environment.xml
+++ b/indra/newview/skins/default/xui/en/floater_adjust_environment.xml
@@ -13,6 +13,13 @@
   <string name="hdr_string">HDR Scale:</string>
   <string name="brightness_string">Brightness:</string>
   <string name="hdr_tooltip">Intensity of lighting effects such as realistically bright skies and dynamic exposure. 1.0 is the default, 0 is off, values between 0 and 1 are mixing Ambient with HDR.</string>
+  <string name="cloud_map">Cloud map</string>
+  <string name="sun_texture">Sun texture</string>
+  <string name="moon_texture">Moon texture</string>
+  <string name="bloom_texture">Bloom texture</string>
+  <string name="rainbow_texture">Rainbow texture</string>
+  <string name="halo_texture">Halo texture</string>
+  <string name="new_sky">Sky</string>
     <layout_stack name="outer_stack"
                   width="845"
                   height="275"
@@ -100,6 +107,16 @@
                       name="btn_reset"
                       left_delta="-2"
                       top_pad="10"
+                      width="100"/>
+                    <button
+                      follows="left|top"
+                      height="23"
+                      label="Save As"
+                      tool_tip="Save these settings as a fixed sky environment"
+                      layout="topleft"
+                      name="btn_save_as"
+                      left_delta="0"
+                      top_pad="4"
                       width="100"/>
                     <text follows="right|top"
                           name="sun_color_lbl"

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -12451,6 +12451,17 @@ Are you sure you want to continue?
   </notification>
 
   <notification
+   icon="alertmodal.tga"
+   name="SettingsSaveAsFailure"
+   type="alertmodal">
+Failed to create settings inventory item [SETTINGS_NAME].
+    <tag>fail</tag>
+    <usetemplate
+     name="okbutton"
+     yestext="OK"/>
+  </notification>
+
+  <notification
  icon="alertmodal.tga"
  name="PersonalSettingsConfirmReset"
  type="alertmodal">
@@ -12461,6 +12472,18 @@ Are you sure you want to continue?
      name="okcancelbuttons"
      notext="No"
      yestext="Yes"/>
+  </notification>
+
+  <notification
+ icon="alertmodal.tga"
+ name="PersonalSettingsTexPermFail"
+ type="alertmodal">
+Cannot save as sky settings because the following textures are not owned by you or are not copyable:
+[TEXTURES]
+      <tag>fail</tag>
+      <usetemplate
+       name="okbutton"
+       yestext="OK"/>
   </notification>
 
   <notification


### PR DESCRIPTION
An option to save personal lightning as a fixed sky setting inventory item.

Only permits saving if textures are default or inventory.