### PR TITLE
#1841 Fix viewer attempting to parse joystick key string into an llsd

### DIFF
--- a/indra/llxml/llcontrol.cpp
+++ b/indra/llxml/llcontrol.cpp
@@ -192,20 +192,6 @@ LLSD LLControlVariable::getComparableValue(const LLSD& value)
             storable_value = false;
         }
     }
-    else if (TYPE_LLSD == type() && value.isString())
-    {
-        LLPointer<LLSDNotationParser> parser = new LLSDNotationParser;
-        LLSD result;
-        std::stringstream value_stream(value.asString());
-        if (parser->parse(value_stream, result, LLSDSerialize::SIZE_UNLIMITED) != LLSDParser::PARSE_FAILURE)
-        {
-            storable_value = result;
-        }
-        else
-        {
-            storable_value = value;
-        }
-    }
     else
     {
         storable_value = value;
@@ -733,6 +719,30 @@ void LLControlGroup::setColor4(std::string_view name, const LLColor4 &val)
 void LLControlGroup::setLLSD(std::string_view name, const LLSD& val)
 {
     set(name, val);
+}
+
+bool LLControlVariable::setValueFromNotation(const std::string& notation, bool saved_value)
+{
+    if (mType == TYPE_LLSD)
+    {
+        LLPointer<LLSDNotationParser> parser = new LLSDNotationParser;
+        LLSD result;
+        std::stringstream value_stream(notation);
+        S32 parse_count = parser->parse(value_stream, result, LLSDSerialize::SIZE_UNLIMITED);
+        if (parse_count != LLSDParser::PARSE_FAILURE)
+        {
+            setValue(result, saved_value);
+            return true;
+        }
+        LL_WARNS("Controls") << "Failed to parse LLSD notation for control '"
+            << mName << "': " << notation << LL_ENDL;
+    }
+    else
+    {
+        LL_WARNS("Controls") << "setValueFromNotation() called on non-LLSD control '"
+            << mName << "' (type " << LLControlGroup::typeEnumToString(mType) << "); ignoring." << LL_ENDL;
+    }
+    return false;
 }
 
 void LLControlGroup::setUntypedValue(std::string_view name, const LLSD& val)

--- a/indra/llxml/llcontrol.h
+++ b/indra/llxml/llcontrol.h
@@ -127,6 +127,7 @@ public:
     void setPersist(ePersist);
     void setHiddenFromSettingsEditor(bool hide);
     void setComment(const std::string& comment);
+    bool setValueFromNotation(const std::string& notation, bool saved_value = true);
 
 private:
     void firePropertyChanged(const LLSD &pPreviousValue)

--- a/indra/newview/llcommandlineparser.cpp
+++ b/indra/newview/llcommandlineparser.cpp
@@ -611,6 +611,11 @@ void setControlValueCB(const LLCommandLineParser::token_vector_t& value,
 
                     ctrl->setValue(llsdArray, false);
                 }
+                else if (ctrl->isType(TYPE_LLSD))
+                {
+                    // Command-line LLSD should support a notation format string
+                    ctrl->setValueFromNotation(onevalue(option, value), false);
+                }
                 else
                 {
                     ctrl->setValue(onevalue(option, value), false);

--- a/indra/newview/llviewercontrollistener.cpp
+++ b/indra/newview/llviewercontrollistener.cpp
@@ -65,6 +65,11 @@ LLViewerControlListener::LLViewerControlListener()
         grouphelp + replyhelp,
         &LLViewerControlListener::set,
         LLSDMap("group", LLSD())("key", LLSD()));
+    add("set_notation",
+        std::string("Set [\"group\"] TYPE_LLSD control [\"key\"] by parsing [\"value\"] as LLSD notation.\n") +
+        grouphelp + replyhelp,
+        &LLViewerControlListener::set_notation,
+        LLSDMap("group", LLSD())("key", LLSD())("value", LLSD()));
     add("toggle",
         std::string("Toggle [\"group\"] control [\"key\"], if boolean\n") + grouphelp + replyhelp,
         &LLViewerControlListener::toggle,
@@ -146,6 +151,36 @@ void LLViewerControlListener::set(LLSD const & request)
     else
     {
         info.control->resetToDefault();
+    }
+}
+
+//static
+void LLViewerControlListener::set_notation(LLSD const& request)
+{
+    Info info(request);
+    if (!info.control)
+        return;
+
+    if (!info.control->isType(TYPE_LLSD))
+    {
+        info.response.error(STRINGIZE("set_notation requires a TYPE_LLSD control, but '"
+            << info.key << "' in group '" << info.groupname
+            << "' has type "
+            << LLControlGroup::typeEnumToString(info.control->type())));
+        return;
+    }
+
+    if (!request["value"].isString())
+    {
+        info.response.error(STRINGIZE("set_notation requires [\"value\"] to be a string "
+            "containing LLSD notation, but received type: "
+            << LLSD::typeString(request["value"].type())));
+        return;
+    }
+
+    if (!info.control->setValueFromNotation(request["value"].asString()))
+    {
+        info.response.error(STRINGIZE("set_notation failed to parse notation"));
     }
 }
 

--- a/indra/newview/llviewercontrollistener.h
+++ b/indra/newview/llviewercontrollistener.h
@@ -41,6 +41,7 @@ public:
 
 private:
     static void set(LLSD const & event_data);
+    static void set_notation(LLSD const & event_data);
     static void toggle(LLSD const & event_data);
     static void get(LLSD const & event_data);
     static void groups(LLSD const & event_data);


### PR DESCRIPTION
Key already is an LLSD::String and needs no further parsing. This parsing was added for command line handling and should be done explicitly in command line's parser. Also extended event listeners, there should be no ambiguity in what kind of data we are passing.