### PR TITLE
#6163 Crash on LLImageGL::scaleDown(int)

### DIFF
--- a/indra/llrender/llimagegl.cpp
+++ b/indra/llrender/llimagegl.cpp
@@ -2583,6 +2583,12 @@ bool LLImageGL::scaleDown(S32 desired_discard)
         {
             glDrawArrays(GL_TRIANGLES, 0, 3);
 
+#if LL_DARWIN
+            // On mac OS, flush before freeing, otherwise the texture may be
+            // freed before Metal's 'lazy' evaluation/restoration behavior triggers.
+            glFlush();
+#endif
+
             free_tex_image(mTexName);
             glTexImage2D(mTarget, 0, mFormatInternal, desired_width, desired_height, 0, mFormatPrimary, mFormatType, nullptr);
             glCopyTexSubImage2D(mTarget, 0, 0, 0, 0, 0, desired_width, desired_height);


### PR DESCRIPTION
Coopilot suggested fix. 

Flush pending GPU commands before freeing/reallocating texture storage to prevent Metal-backed OpenGL from accessing stale data during texture restore on glTexImage2D on macOS.