### PR TITLE
Fix vehicle unseating on region crossings by ignoring outgoing sim kills

### DIFF
--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -3677,6 +3677,16 @@ void process_kill_object(LLMessageSystem *mesgsys, void **user_data)
         LLViewerObject *objectp = gObjectList.findObject(id);
         if (objectp)
         {
+            // Block vehicle / seat kills sent by the outgoing simulator during region crossings
+            if ( regionp && (regionp != gAgent.getRegion()) &&
+                 isAgentAvatarValid() && gAgentAvatarp->isSitting() &&
+                 (gAgentAvatarp->getRoot() == objectp->getRootEdit()) )
+            {
+                LL_INFOS("Avatar") << "Ignoring vehicle kill from outgoing region " << regionp->getName()
+                    << " for seated root object " << objectp->getRootEdit()->getID() << LL_ENDL;
+                continue;
+            }
+
             // Display green bubble on kill
             if ( gShowObjectUpdates )
             {

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -3679,12 +3679,18 @@ void process_kill_object(LLMessageSystem *mesgsys, void **user_data)
         {
             // Block vehicle / seat kills sent by the outgoing simulator during region crossings
             if ( regionp && (regionp != gAgent.getRegion()) &&
-                 isAgentAvatarValid() && gAgentAvatarp->isSitting() &&
-                 (gAgentAvatarp->getRoot() == objectp->getRootEdit()) )
+                 isAgentAvatarValid() && gAgentAvatarp->isSitting() )
             {
-                LL_INFOS("Avatar") << "Ignoring vehicle kill from outgoing region " << regionp->getName()
-                    << " for seated root object " << objectp->getRootEdit()->getID() << LL_ENDL;
-                continue;
+                LLViewerObject* rootp = objectp->getRootEdit();
+                if (rootp && (gAgentAvatarp->getRoot() == rootp))
+                {
+                    if (objectp == rootp)
+                    {
+                        LL_INFOS("Avatar") << "Ignoring vehicle kill from outgoing region " << regionp->getName()
+                            << " for seated root object " << rootp->getID() << LL_ENDL;
+                    }
+                    continue;
+                }
             }
 
             // Display green bubble on kill


### PR DESCRIPTION
## Description

This PR resolves the long-standing bug where avatars are forcibly unseated from vehicles during region crossings.

### Root Cause
During a region crossing:
1. The avatar and vehicle cross into the receiving simulator, and the viewer sets its active agent region to the new simulator.
2. The *outgoing* simulator (lagging by 0–1s) cleans up its local physics representation of the vehicle and sends a UDP `KillObject` packet to the client.
3. Because the client did not differentiate between an active-region object deletion and an outgoing-simulator crossing cleanup, `process_kill_object` called `markDead()` on the vehicle prim.
4. In `LLViewerObject::markDead()`, lines 480-489 detected the seated avatar and executed `((LLVOAvatar*)childp)->getOffObject()`, prematurely severing the sit link on the client side before the receiving simulator's `ObjectUpdate` took over.

### Solution
In `process_kill_object` (`indra/newview/llviewermessage.cpp`), we check if a kill packet for the avatar's seated root object originates from a non-active (outgoing) region (`regionp != gAgent.getRegion()`). If so, the cleanup packet is ignored, keeping the vehicle and seated avatar intact across the boundary handoff.

Actual vehicle deletions (e.g. parcel auto-return, hard banlines, `llDie()`) sent by the active simulator (`regionp == gAgent.getRegion()`) continue to execute normally.

### Verification
- Tested in-world across 16+ region crossings with multiple vehicles.
- Confirmed zero `markDead()` unseat ejections.
- Maintained continuous, uninterrupted seating through multiple consecutive border crossings.