### PR TITLE
#6167 fix WebRTC logging level

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -1811,20 +1811,20 @@ void LLWebRTCPeerConnectionImpl::OnStateChange()
     switch (mDataChannel->state())
     {
         case webrtc::DataChannelInterface::kOpen:
-            RTC_LOG(LS_INFO) << __FUNCTION__ << " Data Channel State Open";
+            RTC_LOG(LS_VERBOSE) << __FUNCTION__ << " Data Channel State Open";
             for (auto &observer : mSignalingObserverList)
             {
                 observer->OnDataChannelReady(this);
             }
             break;
         case webrtc::DataChannelInterface::kConnecting:
-            RTC_LOG(LS_INFO) << __FUNCTION__ << " Data Channel State Connecting";
+            RTC_LOG(LS_VERBOSE) << __FUNCTION__ << " Data Channel State Connecting";
             break;
         case webrtc::DataChannelInterface::kClosing:
-            RTC_LOG(LS_INFO) << __FUNCTION__ << " Data Channel State closing";
+            RTC_LOG(LS_VERBOSE) << __FUNCTION__ << " Data Channel State closing";
             break;
         case webrtc::DataChannelInterface::kClosed:
-            RTC_LOG(LS_INFO) << __FUNCTION__ << " Data Channel State closed";
+            RTC_LOG(LS_VERBOSE) << __FUNCTION__ << " Data Channel State closed";
             break;
         default:
             break;

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -81,19 +81,28 @@ public:
     {
         if (mCallback)
         {
+            // RTC_LOG prefixes each message with its "(file:line): " origin. Use it to demote
+            // libwebrtc's own chatty INFO/WARNING logging to verbose, keeping ours as-is.
+            static const std::string file_prefix("(llwebrtc.cpp:");
             switch (severity)
             {
                 case webrtc::LS_VERBOSE:
                     mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, msg);
                     break;
                 case webrtc::LS_INFO:
-                    mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, msg);
+                    mCallback->LogMessage(msg.rfind(file_prefix, 0) == 0
+                                               ? LLWebRTCLogCallback::LOG_LEVEL_INFO
+                                               : LLWebRTCLogCallback::LOG_LEVEL_VERBOSE,
+                                           msg);
                     break;
                 case webrtc::LS_WARNING:
-                    mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, msg);
+                    mCallback->LogMessage(msg.rfind(file_prefix, 0) == 0
+                                               ? LLWebRTCLogCallback::LOG_LEVEL_WARNING
+                                               : LLWebRTCLogCallback::LOG_LEVEL_VERBOSE,
+                                           msg);
                     break;
                 case webrtc::LS_ERROR:
-                    mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, msg);
+                    mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_ERROR, msg);
                     break;
                 default:
                     break;


### PR DESCRIPTION
`LLWebRTCLogSink::OnLogMessage` mapped every libwebrtc log severity to `LOG_LEVEL_VERBOSE`, so warnings and errors from llwebrtc.cpp never showed up in the viewer log unless LL_DEBUGS was enabled.

Now the real severity is passed through, but since libwebrtc's own internal INFO/WARNING logging is very noisy, only our own llwebrtc.cpp messages keep their real severity: libwebrtc's internal ones are demoted to LL_DEBUGS. Errors are always surfaced regardless of source.