### PR TITLE
#6153 Make hardware test more robust

### DIFF
--- a/indra/llcommon/llprocess.cpp
+++ b/indra/llcommon/llprocess.cpp
@@ -143,6 +143,11 @@ namespace {
         }
     }
 }
+
+LL_COMMON_API void LLProcess_assignToJobObject(HANDLE hProcess, const std::string& desc)
+{
+    AssignProcessToJob(hProcess, desc);
+}
 #endif
 
 namespace bp = boost::process::v2;

--- a/indra/llcommon/llprocess.cpp
+++ b/indra/llcommon/llprocess.cpp
@@ -143,11 +143,6 @@ namespace {
         }
     }
 }
-
-LL_COMMON_API void LLProcess_assignToJobObject(HANDLE hProcess, const std::string& desc)
-{
-    AssignProcessToJob(hProcess, desc);
-}
 #endif
 
 namespace bp = boost::process::v2;

--- a/indra/llcommon/llprocess.cpp
+++ b/indra/llcommon/llprocess.cpp
@@ -1114,6 +1114,11 @@ bool LLProcess::kill(const LLProcessPtr& ptr, const std::string& who)
     return !ptr || ptr->kill(who);
 }
 
+void LLProcess::pump()
+{
+    tick();
+}
+
 LLProcess::id LLProcess::getProcessID() const
 {
     if (!mChild)

--- a/indra/llcommon/llprocess.h
+++ b/indra/llcommon/llprocess.h
@@ -234,6 +234,10 @@ public:
     bool kill(const std::string& who = "");
     static bool kill(const LLProcessPtr& p, const std::string& who = "");
 
+    /// Manually drive pending I/O and check process state.
+    /// If mainloop is not yet running or was terminated.
+    void pump();
+
 #if LL_WINDOWS
     typedef int id;
     typedef HANDLE handle;

--- a/indra/llcommon/llprocess.h
+++ b/indra/llcommon/llprocess.h
@@ -235,7 +235,7 @@ public:
     static bool kill(const LLProcessPtr& p, const std::string& who = "");
 
     /// Manually drive pending I/O and check process state.
-    /// If mainloop is not yet running or was terminated.
+    /// Use this when the mainloop is not yet running or was terminated.
     void pump();
 
 #if LL_WINDOWS

--- a/indra/newview/app_settings/cmd_line.xml
+++ b/indra/newview/app_settings/cmd_line.xml
@@ -90,6 +90,12 @@
       <string>ConnectAsGod</string>
     </map>
 
+    <key>gpubenchmark</key>
+    <map>
+      <key>desc</key>
+      <string>Run GPU memory bandwidth benchmark, print result to stdout, and exit. Used internally by the viewer to isolate benchmark from the main process.</string>
+    </map>
+
     <key>graphicslevel</key>
     <map>
       <key>desc</key>

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -300,6 +300,11 @@ extern bool gDebugGL;
 extern bool gHiDPISupport;
 #endif
 
+#if LL_WINDOWS
+extern bool gGPUBenchmarkMode;
+#endif // LL_WINDOWS
+
+
 ////////////////////////////////////////////////////////////
 // All from the last globals push...
 
@@ -2373,11 +2378,17 @@ void LLAppViewer::initLoggingAndGetLastDuration()
 
     if (mSecondInstance)
     {
-        LLFile::mkdir(gDirUtilp->getDumpLogsDirPath());
+        if (!gGPUBenchmarkMode)
+        {
+            LLFile::mkdir(gDirUtilp->getDumpLogsDirPath());
 
-        LLUUID uid;
-        uid.generate();
-        LLError::logToFile(gDirUtilp->getDumpLogsDirPath(uid.asString() + ".log"));
+            LLUUID uid;
+            uid.generate();
+            // Is this even usefull?
+            // Originally this wa used to store states but I don't think it spractical with bugsplat attributes.
+            // So it just spams files now.
+            LLError::logToFile(gDirUtilp->getDumpLogsDirPath(uid.asString() + ".log"));
+        }
     }
     else
     {
@@ -3081,12 +3092,15 @@ bool LLAppViewer::initConfiguration()
 
     // Display splash screen.  Must be after above check for previous
     // crash as this dialog is always frontmost.
-    std::string splash_msg;
-    LLStringUtil::format_map_t args;
-    args["[APP_NAME]"] = LLTrans::getString("SECOND_LIFE");
-    splash_msg = LLTrans::getString("StartupLoading", args);
-    LLSplashScreen::show();
-    LLSplashScreen::update(splash_msg);
+    if (!gGPUBenchmarkMode)
+    {
+        std::string splash_msg;
+        LLStringUtil::format_map_t args;
+        args["[APP_NAME]"] = LLTrans::getString("SECOND_LIFE");
+        splash_msg = LLTrans::getString("StartupLoading", args);
+        LLSplashScreen::show();
+        LLSplashScreen::update(splash_msg);
+    }
 
     //LLVolumeMgr::initClass();
     LLVolumeMgr* volume_manager = new LLVolumeMgr();
@@ -4139,6 +4153,13 @@ bool LLAppViewer::getMarkerData(const std::string& marker_name, std::string& dat
 
 void LLAppViewer::processMarkerFiles()
 {
+    if (gGPUBenchmarkMode)
+    {
+        // Skipping marker file processing in GPU benchmark mode
+        mSecondInstance = true;
+        initLoggingAndGetLastDuration();
+        return;
+    }
     //We've got 4 things to test for here
     // - Other Process Running (SecondLife.exec_marker present, locked)
     // - Freeze (SecondLife.exec_marker present, not locked)

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -2386,8 +2386,8 @@ void LLAppViewer::initLoggingAndGetLastDuration()
 
             LLUUID uid;
             uid.generate();
-            // Is this even usefull?
-            // Originally this wa used to store states but I don't think it spractical with bugsplat attributes.
+            // Is this even useful?
+            // Originally this wa used to store states, but I don't think it's practical with bugsplat attributes.
             // So it just spams files now.
             LLError::logToFile(gDirUtilp->getDumpLogsDirPath(uid.asString() + ".log"));
         }

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -302,6 +302,8 @@ extern bool gHiDPISupport;
 
 #if LL_WINDOWS
 extern bool gGPUBenchmarkMode;
+#else
+static constexpr bool gGPUBenchmarkMode = false;
 #endif // LL_WINDOWS
 
 

--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -234,6 +234,8 @@ namespace
 }
 #endif // LL_BUGSPLAT
 
+extern bool gGPUBenchmarkMode;
+
 namespace
 {
     void (*gOldTerminateHandler)() = NULL;
@@ -515,12 +517,21 @@ int APIENTRY WINMAIN(HINSTANCE hInstance,
     gIconResource = MAKEINTRESOURCE(IDI_LL_ICON);
     gIconSmallResource = MAKEINTRESOURCE(IDI_LL_ICON_SMALL);
 
+    // Benchmark subprocess mode before full init for LLFeatureManager::loadGPUClass().
+    {
+        std::wstring cmdLineStr(pCmdLine ? pCmdLine : L"");
+        if (cmdLineStr.find(L"--gpubenchmark") != std::wstring::npos)
+        {
+            gGPUBenchmarkMode = true;
+        }
+    }
+
     LLAppViewerWin32* viewer_app_ptr = new LLAppViewerWin32(ll_convert_wide_to_string(pCmdLine).c_str());
 
     gOldTerminateHandler = std::set_terminate(exceptionTerminateHandler);
 
     // Set a debug info flag to indicate if multiple instances are running.
-    bool found_other_instance = !create_app_mutex();
+    bool found_other_instance = gGPUBenchmarkMode || !create_app_mutex();
     gDebugInfo["FoundOtherInstanceAtStartup"] = LLSD::Boolean(found_other_instance);
 
     bool ok = viewer_app_ptr->init();
@@ -940,7 +951,10 @@ void LLAppViewerWin32::initLoggingAndGetLastDuration()
 void LLAppViewerWin32::initConsole()
 {
     // pop up debug console
-    mIsConsoleAllocated = create_console();
+    if (!gGPUBenchmarkMode)
+    {
+        mIsConsoleAllocated = create_console();
+    }
     return LLAppViewer::initConsole();
 }
 

--- a/indra/newview/llcommandlineparser.cpp
+++ b/indra/newview/llcommandlineparser.cpp
@@ -60,7 +60,7 @@ namespace
     // List of command-line switches that can't map-to settings variables.
     // Going forward, we want every new command-line switch to map-to some
     // settings variable. This list is used to validate that.
-    const std::set<std::string> unmapped_options = { "help", "set", "setdefault", "settings", "sessionsettings", "usersessionsettings" };
+    const std::set<std::string> unmapped_options = { "help", "set", "setdefault", "settings", "sessionsettings", "usersessionsettings", "gpubenchmark" };
 
     po::options_description gOptionsDesc;
     po::positional_options_description gPositionalOptions;

--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -388,128 +388,76 @@ bool gGPUBenchmarkMode = false;
 // Runs gpu_benchmark() in a subprocess (exe with --gpubenchmark).
 static F32 subprocess_gpu_benchmark()
 {
-    std::string exe = gDirUtilp->getExecutablePathAndName();
-    std::wstring cmd = L"\"" + ll_convert_string_to_wide(exe) + L"\" --gpubenchmark";
+    LLProcess::Params params;
+    params.executable = gDirUtilp->getExecutablePathAndName();
+    params.args.add("--gpubenchmark");
+    params.desc       = "GPU benchmark";
+    params.autokill   = true;   // killed via job object if parent crashes
+    params.attached   = true;   // killed on LLProcessPtr destruction (timeout)
+    params.files.add(LLProcess::FileParam());                    // stdin:  default
+    params.files.add(LLProcess::FileParam().type("pipe"));       // stdout: pipe
+    params.files.add(LLProcess::FileParam());                    // stderr: default
 
-    SECURITY_ATTRIBUTES sa = {};
-    sa.nLength = sizeof(sa);
-    sa.bInheritHandle = TRUE;
-
-    HANDLE hReadPipe = NULL, hWritePipe = NULL;
-    if (!CreatePipe(&hReadPipe, &hWritePipe, &sa, 0))
+    LLProcessPtr child;
+    try
     {
-        LL_WARNS("RenderInit") << "subprocess_gpu_benchmark: CreatePipe failed, error "
-            << GetLastError() << LL_ENDL;
+        child = LLProcess::create(params);
+    }
+    catch (const std::exception& e)
+    {
+        LL_WARNS("RenderInit") << "subprocess_gpu_benchmark: failed to launch: "
+                               << e.what() << LL_ENDL;
         return -1.f;
     }
-    SetHandleInformation(hReadPipe, HANDLE_FLAG_INHERIT, 0);
 
-    STARTUPINFOW si = {};
-    si.cb = sizeof(si);
-    si.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
-    si.wShowWindow = SW_HIDE;
-    si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
-    si.hStdOutput = hWritePipe;
-    si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
-
-    PROCESS_INFORMATION pi = {};
-    BOOL launched = CreateProcessW(
-        NULL, cmd.data(),
-        NULL, NULL,
-        TRUE, 0, NULL, NULL,
-        &si, &pi);
-
-    CloseHandle(hWritePipe); // close parent's write end so we see EOF when child exits
-
-    if (!launched)
+    if (!child)
     {
-        LL_WARNS("RenderInit") << "subprocess_gpu_benchmark: CreateProcessW failed, error "
-            << GetLastError() << LL_ENDL;
-        CloseHandle(hReadPipe);
+        LL_WARNS("RenderInit") << "subprocess_gpu_benchmark: LLProcess::create returned null." << LL_ENDL;
         return -1.f;
     }
-    CloseHandle(pi.hThread);
-    LLProcess_assignToJobObject(pi.hProcess, "GPU benchmark subprocess");
 
-    // Wait for data on the pipe with a generous timeout.
-    // The subprocess must go through full viewer init before running the benchmark,
-    // so we poll for pipe data rather than waiting for process exit, which lets us
-    // read the result the moment it's written without waiting for full teardown.
-    const DWORD POLL_INTERVAL_MS  = 250;
-    const DWORD TOTAL_TIMEOUT_MS  = 90000; // 1.5 minutes; we have to wait for the init and for benchmark
-    DWORD elapsed = 0;
+    LLProcess::ReadPipe& out = child->getReadPipe(LLProcess::STDOUT);
 
-    char buf[128] = {};
-    DWORD bytesRead = 0;
-    bool gotData = false;
+    const F32 POLL_INTERVAL_S  = 0.25f;
+    const F32 TOTAL_TIMEOUT_S  = 120.f; // covers full viewer init + benchmark
+    LLTimer timer;
+    timer.start();
 
-    while (elapsed < TOTAL_TIMEOUT_MS)
+    while (timer.getElapsedTimeF32() < TOTAL_TIMEOUT_S)
     {
-        DWORD bytesAvail = 0;
-        if (PeekNamedPipe(hReadPipe, NULL, 0, NULL, &bytesAvail, NULL) && bytesAvail > 0)
+        child->pump();
+
+        // Result is a single float followed by '\n'
+        if (out.contains('\n'))
         {
-            if (ReadFile(hReadPipe, buf, sizeof(buf) - 1, &bytesRead, NULL) && bytesRead > 0)
+            std::string line = out.getline();
+            float parsed = 0.f;
+            if (sscanf_s(line.c_str(), "%f", &parsed) == 1 && parsed > 0.f)
             {
-                gotData = true;
+                LL_INFOS("RenderInit") << "subprocess_gpu_benchmark: result = "
+                                       << parsed << " GB/sec" << LL_ENDL;
+                // Let LLProcessPtr destructor handle cleanup
+                return parsed;
             }
-            break;
-        }
-
-        // Check if the child died without writing anything
-        if (WaitForSingleObject(pi.hProcess, 0) == WAIT_OBJECT_0)
-        {
-            // Process exited; try one final read in case data was buffered
-            DWORD finalBytes = 0;
-            if (PeekNamedPipe(hReadPipe, NULL, 0, NULL, &finalBytes, NULL) && finalBytes > 0)
-            {
-                if (ReadFile(hReadPipe, buf, sizeof(buf) - 1, &bytesRead, NULL) && bytesRead > 0)
-                {
-                    gotData = true;
-                }
-            }
-            break;
-        }
-
-        Sleep(POLL_INTERVAL_MS);
-        elapsed += POLL_INTERVAL_MS;
-    }
-
-    F32 result = -1.f;
-
-    if (elapsed >= TOTAL_TIMEOUT_MS)
-    {
-        LL_WARNS("RenderInit") << "GPU benchmark subprocess timed out after "
-            << (TOTAL_TIMEOUT_MS / 1000) << " seconds; killing." << LL_ENDL;
-        TerminateProcess(pi.hProcess, 1);
-        WaitForSingleObject(pi.hProcess, 3000);
-    }
-    else if (gotData)
-    {
-        buf[bytesRead] = '\0';
-        float parsed = 0.f;
-        if (sscanf_s(buf, "%f", &parsed) == 1 && parsed > 0.f)
-        {
-            result = parsed;
-        }
-        else
-        {
             LL_WARNS("RenderInit") << "subprocess_gpu_benchmark: unparseable output: '"
-                << buf << "'" << LL_ENDL;
+                                   << line << "'" << LL_ENDL;
+            return -1.f;
         }
+
+        // If child already exited without writing anything, bail
+        if (!child->isRunning())
+        {
+            LL_WARNS("RenderInit") << "subprocess_gpu_benchmark: process exited without result." << LL_ENDL;
+            return -1.f;
+        }
+
+        ms_sleep((U32)(POLL_INTERVAL_S * 1000));
     }
-    else
-    {
-        LL_WARNS("RenderInit") << "subprocess_gpu_benchmark: process exited without writing result." << LL_ENDL;
-    }
 
-    // Now wait for clean process exit (it should call ExitProcess right after writing)
-    WaitForSingleObject(pi.hProcess, 5000);
-
-    CloseHandle(hReadPipe);
-    CloseHandle(pi.hProcess);
-
-    LL_INFOS("RenderInit") << "subprocess_gpu_benchmark: result = " << result << " GB/sec" << LL_ENDL;
-    return result;
+    // Timeout: attached=true means LLProcessPtr destructor kills it
+    LL_WARNS("RenderInit") << "GPU benchmark subprocess timed out after "
+                           << (int)TOTAL_TIMEOUT_S << " seconds; killing." << LL_ENDL;
+    return -1.f;
 }
 
 F32 logExceptionBenchmark()
@@ -604,7 +552,6 @@ bool LLFeatureManager::loadGPUClass()
                 // Normal path: run benchmark in an isolated subprocess so a
                 // driver hang can be killed without freezing the main viewer.
                 gbps = subprocess_gpu_benchmark();
-                LL_INFOS("Benchmark") << "Memory bandwidth, process run is " << llformat("%.3f", gbps) << LL_ENDL;
                 if (gbps == -1.f
                     && gGLManager.getRawGLString().find("Radeon") != std::string::npos
                     && checkRDNA35())

--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -597,7 +597,6 @@ bool LLFeatureManager::loadGPUClass()
                 // We ARE the benchmark subprocess; run directly in-process.
                 // logExceptionBenchmark wraps with SEH so structured exceptions
                 // (e.g. access violations inside the driver) are still caught.
-                //ms_sleep(10000);
                 gbps = logExceptionBenchmark();
             }
             else

--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -67,6 +67,12 @@ const char FEATURE_TABLE_FILENAME[] = "featuretable_linux.txt";
 const char FEATURE_TABLE_FILENAME[] = "featuretable.txt";
 #endif
 
+#if LL_WINDOWS
+// Defined in llprocess.cpp -- assigns hProcess to the viewer's job object
+// so it is killed automatically if the parent process exits.
+LL_COMMON_API void LLProcess_assignToJobObject(HANDLE hProcess, const std::string& desc);
+#endif
+
 #if 0                               // consuming code in #if 0 below
 #endif
 LLFeatureInfo::LLFeatureInfo(const std::string& name, const bool available, const F32 level)
@@ -377,6 +383,135 @@ F32 gpu_benchmark();
 
 #if LL_WINDOWS
 
+bool gGPUBenchmarkMode = false;
+
+// Runs gpu_benchmark() in a subprocess (exe with --gpubenchmark).
+static F32 subprocess_gpu_benchmark()
+{
+    std::string exe = gDirUtilp->getExecutablePathAndName();
+    std::wstring cmd = L"\"" + ll_convert_string_to_wide(exe) + L"\" --gpubenchmark";
+
+    SECURITY_ATTRIBUTES sa = {};
+    sa.nLength = sizeof(sa);
+    sa.bInheritHandle = TRUE;
+
+    HANDLE hReadPipe = NULL, hWritePipe = NULL;
+    if (!CreatePipe(&hReadPipe, &hWritePipe, &sa, 0))
+    {
+        LL_WARNS("RenderInit") << "subprocess_gpu_benchmark: CreatePipe failed, error "
+            << GetLastError() << LL_ENDL;
+        return -1.f;
+    }
+    SetHandleInformation(hReadPipe, HANDLE_FLAG_INHERIT, 0);
+
+    STARTUPINFOW si = {};
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
+    si.wShowWindow = SW_HIDE;
+    si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+    si.hStdOutput = hWritePipe;
+    si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
+
+    PROCESS_INFORMATION pi = {};
+    BOOL launched = CreateProcessW(
+        NULL, cmd.data(),
+        NULL, NULL,
+        TRUE, 0, NULL, NULL,
+        &si, &pi);
+
+    CloseHandle(hWritePipe); // close parent's write end so we see EOF when child exits
+
+    if (!launched)
+    {
+        LL_WARNS("RenderInit") << "subprocess_gpu_benchmark: CreateProcessW failed, error "
+            << GetLastError() << LL_ENDL;
+        CloseHandle(hReadPipe);
+        return -1.f;
+    }
+    CloseHandle(pi.hThread);
+    LLProcess_assignToJobObject(pi.hProcess, "GPU benchmark subprocess");
+
+    // Wait for data on the pipe with a generous timeout.
+    // The subprocess must go through full viewer init before running the benchmark,
+    // so we poll for pipe data rather than waiting for process exit, which lets us
+    // read the result the moment it's written without waiting for full teardown.
+    const DWORD POLL_INTERVAL_MS  = 250;
+    const DWORD TOTAL_TIMEOUT_MS  = 90000; // 1.5 minutes; we have to wait for the init and for benchmark
+    DWORD elapsed = 0;
+
+    char buf[128] = {};
+    DWORD bytesRead = 0;
+    bool gotData = false;
+
+    while (elapsed < TOTAL_TIMEOUT_MS)
+    {
+        DWORD bytesAvail = 0;
+        if (PeekNamedPipe(hReadPipe, NULL, 0, NULL, &bytesAvail, NULL) && bytesAvail > 0)
+        {
+            if (ReadFile(hReadPipe, buf, sizeof(buf) - 1, &bytesRead, NULL) && bytesRead > 0)
+            {
+                gotData = true;
+            }
+            break;
+        }
+
+        // Check if the child died without writing anything
+        if (WaitForSingleObject(pi.hProcess, 0) == WAIT_OBJECT_0)
+        {
+            // Process exited; try one final read in case data was buffered
+            DWORD finalBytes = 0;
+            if (PeekNamedPipe(hReadPipe, NULL, 0, NULL, &finalBytes, NULL) && finalBytes > 0)
+            {
+                if (ReadFile(hReadPipe, buf, sizeof(buf) - 1, &bytesRead, NULL) && bytesRead > 0)
+                {
+                    gotData = true;
+                }
+            }
+            break;
+        }
+
+        Sleep(POLL_INTERVAL_MS);
+        elapsed += POLL_INTERVAL_MS;
+    }
+
+    F32 result = -1.f;
+
+    if (elapsed >= TOTAL_TIMEOUT_MS)
+    {
+        LL_WARNS("RenderInit") << "GPU benchmark subprocess timed out after "
+            << (TOTAL_TIMEOUT_MS / 1000) << " seconds; killing." << LL_ENDL;
+        TerminateProcess(pi.hProcess, 1);
+        WaitForSingleObject(pi.hProcess, 3000);
+    }
+    else if (gotData)
+    {
+        buf[bytesRead] = '\0';
+        float parsed = 0.f;
+        if (sscanf_s(buf, "%f", &parsed) == 1 && parsed > 0.f)
+        {
+            result = parsed;
+        }
+        else
+        {
+            LL_WARNS("RenderInit") << "subprocess_gpu_benchmark: unparseable output: '"
+                << buf << "'" << LL_ENDL;
+        }
+    }
+    else
+    {
+        LL_WARNS("RenderInit") << "subprocess_gpu_benchmark: process exited without writing result." << LL_ENDL;
+    }
+
+    // Now wait for clean process exit (it should call ExitProcess right after writing)
+    WaitForSingleObject(pi.hProcess, 5000);
+
+    CloseHandle(hReadPipe);
+    CloseHandle(pi.hProcess);
+
+    LL_INFOS("RenderInit") << "subprocess_gpu_benchmark: result = " << result << " GB/sec" << LL_ENDL;
+    return result;
+}
+
 F32 logExceptionBenchmark()
 {
     // FIXME: gpu_benchmark uses many C++ classes on the stack to control state.
@@ -457,7 +592,29 @@ bool LLFeatureManager::loadGPUClass()
         try
         {
 #if LL_WINDOWS
-            gbps = logExceptionBenchmark();
+            if (gGPUBenchmarkMode)
+            {
+                // We ARE the benchmark subprocess; run directly in-process.
+                // logExceptionBenchmark wraps with SEH so structured exceptions
+                // (e.g. access violations inside the driver) are still caught.
+                //ms_sleep(10000);
+                gbps = logExceptionBenchmark();
+            }
+            else
+            {
+                // Normal path: run benchmark in an isolated subprocess so a
+                // driver hang can be killed without freezing the main viewer.
+                gbps = subprocess_gpu_benchmark();
+                LL_INFOS("Benchmark") << "Memory bandwidth, process run is " << llformat("%.3f", gbps) << LL_ENDL;
+                if (gbps == -1.f
+                    && gGLManager.getRawGLString().find("Radeon") != std::string::npos
+                    && checkRDNA35())
+                {
+                    // Certain AMD GPUs have known issues with shader profiling and occlusion queries that can lead to hangs.
+                    // If test returned -1, we are likely on a bad driver.
+                    gSavedSettings.setBOOL("UseOcclusion", false);
+                }
+            }
 #else
             gbps = gpu_benchmark();
 #endif
@@ -467,6 +624,21 @@ bool LLFeatureManager::loadGPUClass()
             gbps = -1.f;
             LL_WARNS("RenderInit") << "GPU benchmark failed: " << e.what() << LL_ENDL;
         }
+
+#if LL_WINDOWS
+        // If we are the benchmark subprocess, write the raw result to stdout
+        // so the parent process can read it, then exit immediately.
+        if (gGPUBenchmarkMode)
+        {
+            LL_WARNS("RenderInit") << "Passing " << gbps << " to parent" << LL_ENDL;
+            char buf[64];
+            int len = snprintf(buf, sizeof(buf), "%.6f\n", gbps);
+            DWORD written = 0;
+            WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), buf, (DWORD)len, &written, NULL);
+            FlushFileBuffers(GetStdHandle(STD_OUTPUT_HANDLE));
+            ExitProcess(0);
+        }
+#endif
 
         mGPUMemoryBandwidth = gbps;
 

--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -67,12 +67,6 @@ const char FEATURE_TABLE_FILENAME[] = "featuretable_linux.txt";
 const char FEATURE_TABLE_FILENAME[] = "featuretable.txt";
 #endif
 
-#if LL_WINDOWS
-// Defined in llprocess.cpp -- assigns hProcess to the viewer's job object
-// so it is killed automatically if the parent process exits.
-LL_COMMON_API void LLProcess_assignToJobObject(HANDLE hProcess, const std::string& desc);
-#endif
-
 #if 0                               // consuming code in #if 0 below
 #endif
 LLFeatureInfo::LLFeatureInfo(const std::string& name, const bool available, const F32 level)


### PR DESCRIPTION
Harware test can freeze and crash, taking whole viewer with it. Move test to a process to make sure viewer doesn't get affected.