### PR TITLE
Fix scale startup issues on MacOS

### DIFF
--- a/indra/llwindow/llopenglview-objc.mm
+++ b/indra/llwindow/llopenglview-objc.mm
@@ -137,6 +137,18 @@ attributedStringInfo getSegments(NSAttributedString *str)
 
 - (void)viewDidMoveToWindow
 {
+    // viewDidMoveToWindow is called both when the view is attached to a window
+    // and when it is detached (window == nil).
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                                         selector:@selector(performDeferredResolutionUpdate)
+                                         object:nil];
+
+    if (![self window])
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:self];
+        return;
+    }
+
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(windowResized:) name:NSWindowDidResizeNotification
                                                object:[self window]];
@@ -157,11 +169,37 @@ attributedStringInfo getSegments(NSAttributedString *str)
                                                object:[self window]];
 
 
-    NSRect wnd_rect = [[self window] frame];
-    NSRect dev_rect = [self convertRectToBacking:wnd_rect];
-    if (!NSEqualSizes(wnd_rect.size,dev_rect.size))
+    if (windowCallbacksReady())
     {
-        callResize(dev_rect.size.width, dev_rect.size.height);
+        NSRect wnd_rect = [[self window] frame];
+        NSRect dev_rect = [self convertRectToBacking:wnd_rect];
+        if (!NSEqualSizes(wnd_rect.size,dev_rect.size))
+        {
+            // If window size actually changes, update size immediately
+            callResize(dev_rect.size.width, dev_rect.size.height);
+        }
+        else
+        {
+            // Defer size update to let the window settle on its final display
+            // before checkSettings() reads the live backing size.
+            callRequestResolutionUpdate();
+        }
+    }
+    else
+    {
+        // Defer so that mCallbacks is the real callbacks object,
+        // not the null_callbacks used during LLWindowMacOSX construction.
+        // afterDelay will fire on the next loop iteration.
+        NSLog(@"viewDidMoveToWindow triggered, but callbacks not ready, postponing resolution update", nil);
+        [self performSelector:@selector(performDeferredResolutionUpdate) withObject:nil afterDelay:0];
+    }
+}
+
+- (void)performDeferredResolutionUpdate
+{
+    if ([self window])
+    {
+        callRequestResolutionUpdate();
     }
 }
 

--- a/indra/llwindow/llwindowcallbacks.cpp
+++ b/indra/llwindow/llwindowcallbacks.cpp
@@ -156,6 +156,10 @@ void LLWindowCallbacks::handleResize(LLWindow *window, const S32 width, const S3
 {
 }
 
+void LLWindowCallbacks::handleRequestResolutionUpdate(LLWindow* window)
+{
+}
+
 void LLWindowCallbacks::handleFocus(LLWindow *window)
 {
      LL_WARNS("COCOA") << "Called handleFocus proto" << LL_ENDL;

--- a/indra/llwindow/llwindowcallbacks.h
+++ b/indra/llwindow/llwindowcallbacks.h
@@ -63,6 +63,7 @@ public:
     virtual void handleScrollWheel(LLWindow *window,  S32 clicks);
     virtual void handleScrollHWheel(LLWindow *window,  S32 clicks);
     virtual void handleResize(LLWindow *window,  S32 width,  S32 height);
+    virtual void handleRequestResolutionUpdate(LLWindow* window);
     virtual void handleFocus(LLWindow *window);
     virtual void handleFocusLost(LLWindow *window);
     virtual void handleMenuSelect(LLWindow *window,  S32 menu_item);

--- a/indra/llwindow/llwindowmacosx-objc.h
+++ b/indra/llwindow/llwindowmacosx-objc.h
@@ -140,6 +140,7 @@ void callLeftMouseDown(float *pos, unsigned int mask);
 void callLeftMouseUp(float *pos, unsigned int mask);
 void callDoubleClick(float *pos, unsigned int mask);
 void callResize(unsigned int width, unsigned int height);
+void callRequestResolutionUpdate();
 void callMouseMoved(float *pos, unsigned int mask);
 void callMouseDragged(float *pos, unsigned int mask);
 void callScrollMoved(float deltaX, float deltaY);
@@ -157,6 +158,7 @@ void callFocusLost();
 void callModifier(unsigned int mask);
 void callQuitHandler();
 void commitCurrentPreedit(GLViewRef glView);
+bool windowCallbacksReady();
 
 #include <string>
 void callHandleDragEntered(std::string url);

--- a/indra/llwindow/llwindowmacosx.cpp
+++ b/indra/llwindow/llwindowmacosx.cpp
@@ -165,6 +165,7 @@ LLWindowMacOSX::LLWindowMacOSX(LLWindowCallbacks* callbacks,
     // Route them to a dummy callback structure until the end of constructor.
     LLWindowCallbacks null_callbacks;
     mCallbacks = &null_callbacks;
+    mIsConstructing = true;
 
     // Voodoo for calling cocoa from carbon (see llwindowmacosx-objc.mm).
     setupCocoa();
@@ -236,9 +237,8 @@ LLWindowMacOSX::LLWindowMacOSX(LLWindowCallbacks* callbacks,
     }
 
     mCallbacks = callbacks;
+    mIsConstructing = false;
     stop_glerror();
-
-
 }
 
 // These functions are used as wrappers for our internal event handling callbacks.
@@ -409,6 +409,14 @@ void callResize(unsigned int width, unsigned int height)
     if (gWindowImplementation && gWindowImplementation->getCallbacks())
     {
         gWindowImplementation->getCallbacks()->handleResize(gWindowImplementation, width, height);
+    }
+}
+
+void callRequestResolutionUpdate()
+{
+    if (gWindowImplementation && gWindowImplementation->getCallbacks())
+    {
+        gWindowImplementation->getCallbacks()->handleRequestResolutionUpdate(gWindowImplementation);
     }
 }
 
@@ -703,6 +711,11 @@ void getPreeditLocation(float *location, unsigned int length)
         location[0] = c[0];
         location[1] = c[1];
     }
+}
+
+bool windowCallbacksReady()
+{
+    return gWindowImplementation && !gWindowImplementation->isConstructing();
 }
 
 void LLWindowMacOSX::updateMouseDeltas(float* deltas)

--- a/indra/llwindow/llwindowmacosx.h
+++ b/indra/llwindow/llwindowmacosx.h
@@ -147,6 +147,10 @@ public:
     // enable or disable multithreaded GL
     static void setUseMultGL(bool use_mult_gl);
 
+    // During construction null_callbacks are used,
+    // this is a way to determine when callbacks are ready.
+    bool isConstructing() const { return mIsConstructing; }
+
 protected:
     LLWindowMacOSX(LLWindowCallbacks* callbacks,
         const std::string& title, const std::string& name, int x, int y, int width, int height, U32 flags,
@@ -223,6 +227,7 @@ protected:
     bool        mMinimized;
     U32         mFSAASamples;
     bool        mForceRebuild;
+    bool        mIsConstructing = true;
 
     S32 mDragOverrideCursor;
 

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -1581,6 +1581,12 @@ void LLViewerWindow::handleResize(LLWindow *window,  S32 width,  S32 height)
     LL_DEBUGS("Window") << "handleResize, new width: " << width << " height: " << height << LL_ENDL;
 }
 
+void LLViewerWindow::handleRequestResolutionUpdate(LLWindow* window)
+{
+    requestResolutionUpdate();
+    LL_DEBUGS("Window") << "handleRequestResolutionUpdate: mResDirty set" << LL_ENDL;
+}
+
 // The top-level window has gained focus (e.g. via ALT-TAB)
 void LLViewerWindow::handleFocus(LLWindow *window)
 {
@@ -2043,7 +2049,7 @@ LLViewerWindow::LLViewerWindow(const Params& p)
     }
     else
     {
-        LL_DEBUGS("Window") << "Display init diagnostics:"
+        LL_DEBUGS("Window") << "Display init:"
             << " screen_size=" << scr.mX << "x" << scr.mY
             << " system_ui_size=" << mWindow->getSystemUISize()
             << " pixel_aspect_ratio=" << mWindow->getPixelAspectRatio()
@@ -6091,7 +6097,18 @@ void LLViewerWindow::checkSettings()
     // We want to update the resolution AFTER the states getting refreshed not before.
     if (mResDirty)
     {
-        reshape(getWindowWidthRaw(), getWindowHeightRaw());
+        LLCoordScreen window_size;
+        if (mWindow->getSize(&window_size))
+        {
+            reshape(window_size.mX, window_size.mY);
+        }
+        else
+        {
+            S32 width = getWindowWidthRaw();
+            S32 height = getWindowHeightRaw();
+            LL_WARNS() << "Failed to get window size, using raw window size " << width << "x" << height << "  instead" << LL_ENDL;
+            reshape(width, height);
+        }
         mResDirty = false;
     }
 }

--- a/indra/newview/llviewerwindow.h
+++ b/indra/newview/llviewerwindow.h
@@ -221,6 +221,7 @@ public:
                 void handleMouseDragged(LLWindow *window,  LLCoordGL pos, MASK mask);
     /*virtual*/ void handleMouseLeave(LLWindow *window);
     /*virtual*/ void handleResize(LLWindow *window,  S32 x,  S32 y);
+    /*virtual*/ void handleRequestResolutionUpdate(LLWindow* window);
     /*virtual*/ void handleFocus(LLWindow *window);
     /*virtual*/ void handleFocusLost(LLWindow *window);
     /*virtual*/ bool handleActivate(LLWindow *window, bool activated);


### PR DESCRIPTION
UI scale sometimes starts as massive on macOS, which is not visible in logs. What is also missing from logs is handleResize, so I assume that is the cause of the bug. Making viewDidMoveToWindow mark size as dirty even if size didn't change.

Snippet:
```
2026-08-28T16:59:27Z DEBUG #Window# newview/llviewerwindow.cpp(2046) LLViewerWindow : Display init: screen_size=3026x1794 system_ui_size=2 pixel_aspect_ratio=1 saved_UIScaleFactor=1.125 ResetUIScaleOnFirstRun=0
2026-08-28T16:59:27Z DEBUG #Window# newview/llviewerwindow.cpp(2061) LLViewerWindow : Display scale computed: ui_scale_factor=2.25 mDisplayScale={ 2.25, 2.25 } (clamped_to=[0.75, 7])2026-08-28T16:59:27Z DEBUG 2026-08-28T16:59:27Z DEBUG #Window# newview/llviewerwindow.cpp(2095) LLViewerWindow : Loading feature tables.
2026-08-28T16:59:29Z INFO #InitInfo# newview/llappviewer.cpp(1009) init : Window is initialized.
2026-08-28T16:59:29Z DEBUG #Window# newview/llviewerdisplay.cpp(176) display_startup : First display_startup frame
2026-08-28T16:59:29Z DEBUG #Window# newview/llviewerdisplay.cpp(176) display_startup : First display_startup frame
2026-08-28T16:59:29Z INFO #AppInit# newview/llstartup.cpp(3263) setStartupState : STATE_BROWSER_INIT --> STATE_LOGIN_SHOW
2026-08-28T16:59:29Z INFO #AppInit# newview/llstartup.cpp(2652) login_show : Initializing Login Screen
```