### PR TITLE
#6203 fix displaying current page number in chat history floater

### DIFF
--- a/indra/newview/llfloaterconversationpreview.cpp
+++ b/indra/newview/llfloaterconversationpreview.cpp
@@ -112,7 +112,9 @@ void LLFloaterConversationPreview::setPages(std::list<LLSD>* messages, const std
 
         mPageSpinner->setEnabled(true);
         mPageSpinner->setMaxValue((F32)(mCurrentPage+1));
-        mPageSpinner->set((F32)(mCurrentPage+1));
+        // set() won't refresh the displayed text while the editor has focus, unlike forceSetValue()
+        mPageSpinner->forceSetValue((F32)(mCurrentPage+1));
+        mPageSpinner->resetDirty();
 
         std::string total_page_num = llformat("/ %d", mCurrentPage+1);
         getChild<LLTextBox>("page_num_label")->setValue(total_page_num);


### PR DESCRIPTION
 The spinner grabs focus when the floater opens, so forceSetValue() should be used because it refreshes the displayed text in this case.
