### PR TITLE
#6216 fix the issue with title bar scaling

### DIFF
--- a/indra/newview/windows.manifest
+++ b/indra/newview/windows.manifest
@@ -3,6 +3,7 @@
   <asmv3:application>
     <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
       <dpiAware>True/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
     </asmv3:windowsSettings>
   </asmv3:application>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 


### PR DESCRIPTION
Fix title bar DPI scaling when moving between monitors with different scaling factors. Use Per-Monitor DPI Awareness v2 instead of v1, which causes Windows to automatically resize the non-client area.

I don't have a KVM to reproduce the exact scenario mentioned in the ticket, but I see a similar issue when dragging the Viewer from my main monitor (100% UI scale) to a smaller one (150% UI scale): the title bar is not resized and appears too small. This is likely the same DPI issue, even though the symptom is opposite.

This changeset fixes the issue in my test case.