### PR TITLE
#6228 fix setting the default device after a region change

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -702,7 +702,7 @@ void LLWebRTCImpl::workerStartPlayout()
 {
     // Only run playout while voice is enabled and there's a connection to
     // render (running the output device otherwise is heard as a buzz).
-    if (!mDeviceModule || !mVoiceEnabled || mTuningMode || mDeviceModule->Playing() || mPeerConnections.empty())
+    if (!mDeviceModule || !mVoiceEnabled || mTuningMode || mPeerConnections.empty())
     {
         return;
     }
@@ -724,6 +724,16 @@ void LLWebRTCImpl::workerStartPlayout()
                 break;
             }
         }
+    }
+
+    if (mDeviceModule->Playing())
+    {
+        if (mDeviceModule->GetPlayoutDevice() == playoutDevice)
+        {
+            return;
+        }
+
+        mDeviceModule->StopPlayout();
     }
 
 #if WEBRTC_WIN


### PR DESCRIPTION
Patch contributed by TJ Hecklezz

In `LLWebRTCPeerConnectionImpl::OnConnectionChange`, `startPlayout()` is called when a new connection is established. If playout was already active from a previous connection (after a region change), `mDeviceModule->Playing()` returns true, causing `workerStartPlayout()` to return early without calling `SetPlayoutDevice()`, leaving the output on the Windows default communication device instead of the one selected in preferences.