### PR TITLE
FIX - Keep moving linkset children aligned with focused root

### DIFF
--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -1651,6 +1651,73 @@ LLVector3d LLAgentCamera::calcFocusPositionTargetGlobal()
                             gPipeline.updateMoveDampedAsync(drawablep);
                         }
                     }
+
+                    // Updating only a moving linkset root leaves its children on the normal
+                    // update pass, which makes them appear dislocated from the root every few
+                    // frames when the root was updated first.
+                    // This is particularly noticeable on moving children or avatars (and avatar attachments).
+                    if (mFocusObject->isRoot())
+                    {
+                        for (LLViewerObject* childp : mFocusObject->getChildren())
+                        {
+                            LLDrawable* child_drawablep = childp ? childp->mDrawable.get() : nullptr;
+                            if (!child_drawablep || child_drawablep->isDead() || !child_drawablep->isActive())
+                            {
+                                continue;
+                            }
+
+                            child_drawablep->clearState(LLDrawable::EARLY_MOVE);
+
+                            if (childp->isSelected() ||
+                                child_drawablep->isState(LLDrawable::MOVE_UNDAMPED) ||
+                                !childp->getAngularVelocity().isExactlyZero())
+                            {
+                                gPipeline.updateMoveNormalAsync(child_drawablep);
+                            }
+                            else
+                            {
+                                gPipeline.updateMoveDampedAsync(child_drawablep);
+                            }
+
+                            // Also apply transform to any seated avatars
+                            if (LLVOAvatar* avatarp = childp->asAvatar())
+                            {
+                                if (LLJoint* root_jointp = avatarp->getRootJoint())
+                                {
+                                    root_jointp->touch();
+                                    root_jointp->updateWorldMatrixChildren();
+                                    const LLVector3 hud_name_pos =
+                                        avatarp->idleCalcNameTagPosition(root_jointp->getWorldPosition());
+                                    avatarp->idleUpdateNameTag(hud_name_pos);
+                                    avatarp->idleUpdateVoiceVisualizerPosition(hud_name_pos);
+                                }
+
+                                // ... and also the avatar's unrigged attachments (those are not
+                                // children of the vehicle, they are children of the avatar)
+                                for (const auto& attachment_entry : avatarp->mAttachmentPoints)
+                                {
+                                    LLViewerJointAttachment* attachment = attachment_entry.second;
+                                    if (!attachment)
+                                    {
+                                        continue;
+                                    }
+
+                                    for (const auto& attached_objectp : attachment->mAttachedObjects)
+                                    {
+                                        LLViewerObject* attached_object = attached_objectp.get();
+                                        if (!attached_object || attached_object->isDead() || attached_object->mDrawable.isNull())
+                                        {
+                                            continue;
+                                        }
+
+                                        attached_object->mDrawable->clearState(LLDrawable::EARLY_MOVE);
+                                        gPipeline.updateMoveNormalAsync(attached_object->mDrawable);
+                                        attached_object->updateText();
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
             // if not tracking object, update offset based on new object position
@@ -2948,4 +3015,3 @@ S32 LLAgentCamera::directionToKey(S32 direction)
 
 
 // EOF
-

--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -1694,25 +1694,27 @@ LLVector3d LLAgentCamera::calcFocusPositionTargetGlobal()
 
                                 // ... and also the avatar's unrigged attachments (those are not
                                 // children of the vehicle, they are children of the avatar)
-                                for (const auto& attachment_entry : avatarp->mAttachmentPoints)
+                                for (LLVOAvatar::attachment_map_t::iterator iter = avatarp->mAttachmentPoints.begin();
+                                     iter != avatarp->mAttachmentPoints.end(); )
                                 {
-                                    LLViewerJointAttachment* attachment = attachment_entry.second;
+                                    LLVOAvatar::attachment_map_t::iterator curiter = iter++;
+                                    LLViewerJointAttachment* attachment = curiter->second;
                                     if (!attachment)
                                     {
                                         continue;
                                     }
 
-                                    for (const auto& attached_objectp : attachment->mAttachedObjects)
+                                    for (LLViewerJointAttachment::attachedobjs_vec_t::iterator attachment_iter = attachment->mAttachedObjects.begin();
+                                         attachment_iter != attachment->mAttachedObjects.end();
+                                         ++attachment_iter)
                                     {
-                                        LLViewerObject* attached_object = attached_objectp.get();
-                                        if (!attached_object || attached_object->isDead() || attached_object->mDrawable.isNull())
+                                        LLViewerObject* attached_object = attachment_iter->get();
+                                        if (attached_object && !attached_object->isDead() && attached_object->mDrawable.notNull())
                                         {
-                                            continue;
+                                            attached_object->mDrawable->clearState(LLDrawable::EARLY_MOVE);
+                                            gPipeline.updateMoveNormalAsync(attached_object->mDrawable);
+                                            attached_object->updateText();
                                         }
-
-                                        attached_object->mDrawable->clearState(LLDrawable::EARLY_MOVE);
-                                        gPipeline.updateMoveNormalAsync(attached_object->mDrawable);
-                                        attached_object->updateText();
                                     }
                                 }
                             }

--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -150,6 +150,9 @@ static void updateFocusedLinksetObject(LLViewerObject* objectp)
             }
 
             // Attachments have mixed movement sources. Preserve the same policy used by the normal avatar update path.
+            const bool attachment_selected =
+                LLSelectMgr::getInstance()->getSelection()->getObjectCount() > 0 &&
+                LLSelectMgr::getInstance()->getSelection()->isAttachment();
             for (LLVOAvatar::attachment_map_t::iterator iter = avatarp->mAttachmentPoints.begin();
                  iter != avatarp->mAttachmentPoints.end(); )
             {
@@ -179,7 +182,7 @@ static void updateFocusedLinksetObject(LLViewerObject* objectp)
 
                     if (!attached_drawablep->isState(LLDrawable::EARLY_MOVE))
                     {
-                        if (attached_object->isSelected())
+                        if (attachment_selected)
                         {
                             gPipeline.updateMoveNormalAsync(attached_drawablep);
                         }

--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -158,7 +158,7 @@ static void updateFocusedLinksetObject(LLViewerObject* objectp)
             {
                 LLVOAvatar::attachment_map_t::iterator curiter = iter++;
                 LLViewerJointAttachment* attachment = curiter->second;
-                if (!attachment)
+                if (!attachment || !attachment->getValid())
                 {
                     continue;
                 }

--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -196,6 +196,8 @@ static void updateFocusedLinksetObject(LLViewerObject* objectp)
                             gPipeline.updateMoveNormalAsync(bridgep);
                         }
                     }
+
+                    attached_object->updateText();
                 }
             }
         }

--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -187,6 +187,11 @@ static void updateFocusedLinksetObject(LLViewerObject* objectp)
                         {
                             gPipeline.updateMoveDampedAsync(attached_drawablep);
                         }
+
+                        if (LLSpatialBridge* bridgep = attached_drawablep->getSpatialBridge())
+                        {
+                            gPipeline.updateMoveNormalAsync(bridgep);
+                        }
                     }
                 }
             }

--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -106,6 +106,100 @@ static bool isDisableCameraConstraints()
     return sDisableCameraConstraints;
 }
 
+// Keep the focused linkset's render state in step with the focused root without
+// replaying movement that the normal pipeline has already processed this frame.
+static void updateFocusedLinksetObject(LLViewerObject* objectp)
+{
+    if (!objectp || objectp->isDead())
+    {
+        return;
+    }
+
+    LLDrawable* drawablep = objectp->mDrawable.get();
+    bool movement_updated = false;
+    if (drawablep && drawablep->isActive())
+    {
+        if (!drawablep->isState(LLDrawable::EARLY_MOVE))
+        {
+            if (objectp->isSelected() ||
+                drawablep->isState(LLDrawable::MOVE_UNDAMPED) ||
+                !objectp->getAngularVelocity().isExactlyZero())
+            {
+                gPipeline.updateMoveNormalAsync(drawablep);
+            }
+            else
+            {
+                gPipeline.updateMoveDampedAsync(drawablep);
+            }
+            movement_updated = true;
+        }
+    }
+
+    if (LLVOAvatar* avatarp = objectp->asAvatar())
+    {
+        if (movement_updated)
+        {
+            if (LLJoint* root_jointp = avatarp->getRootJoint())
+            {
+                root_jointp->touch();
+                root_jointp->updateWorldMatrixChildren();
+                const LLVector3 hud_name_pos =
+                    avatarp->idleCalcNameTagPosition(root_jointp->getWorldPosition());
+                avatarp->idleUpdateNameTag(hud_name_pos);
+                avatarp->idleUpdateVoiceVisualizerPosition(hud_name_pos);
+            }
+
+            // Attachments have mixed movement sources. Preserve the same policy used by the normal avatar update path.
+            for (LLVOAvatar::attachment_map_t::iterator iter = avatarp->mAttachmentPoints.begin();
+                 iter != avatarp->mAttachmentPoints.end(); )
+            {
+                LLVOAvatar::attachment_map_t::iterator curiter = iter++;
+                LLViewerJointAttachment* attachment = curiter->second;
+                if (!attachment)
+                {
+                    continue;
+                }
+
+                for (LLViewerJointAttachment::attachedobjs_vec_t::iterator attachment_iter = attachment->mAttachedObjects.begin();
+                     attachment_iter != attachment->mAttachedObjects.end();
+                     ++attachment_iter)
+                {
+                    LLViewerObject* attached_object = attachment_iter->get();
+                    if (!attached_object || attached_object->isDead() ||
+                        attached_object->mDrawable.isNull())
+                    {
+                        continue;
+                    }
+
+                    LLDrawable* attached_drawablep = attached_object->mDrawable.get();
+                    if (!attached_drawablep->isActive())
+                    {
+                        continue;
+                    }
+
+                    if (!attached_drawablep->isState(LLDrawable::EARLY_MOVE))
+                    {
+                        if (attached_object->isSelected())
+                        {
+                            gPipeline.updateMoveNormalAsync(attached_drawablep);
+                        }
+                        else
+                        {
+                            gPipeline.updateMoveDampedAsync(attached_drawablep);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Seated avatars and sit-target children can be deeper than one level in the hierarchy.
+    for (LLViewerObject* childp : objectp->getChildren())
+    {
+        updateFocusedLinksetObject(childp);
+    }
+}
+
 // The agent instance.
 LLAgentCamera gAgentCamera;
 
@@ -1628,102 +1722,14 @@ LLVector3d LLAgentCamera::calcFocusPositionTargetGlobal()
     {
         if (mFocusObject.notNull() && !mFocusObject->isDead() && mFocusObject->mDrawable.notNull())
         {
-            LLDrawable* drawablep = mFocusObject->mDrawable;
-
             if (mTrackFocusObject &&
-                drawablep &&
-                drawablep->isActive())
+                mFocusObject->mDrawable->isActive() &&
+                !mFocusObject->isAvatar())
             {
-                if (!mFocusObject->isAvatar())
-                {
-                    if (mFocusObject->isSelected())
-                    {
-                        gPipeline.updateMoveNormalAsync(drawablep);
-                    }
-                    else
-                    {
-                        if (drawablep->isState(LLDrawable::MOVE_UNDAMPED))
-                        {
-                            gPipeline.updateMoveNormalAsync(drawablep);
-                        }
-                        else
-                        {
-                            gPipeline.updateMoveDampedAsync(drawablep);
-                        }
-                    }
-
-                    // Updating only a moving linkset root leaves its children on the normal
-                    // update pass, which makes them appear dislocated from the root every few
-                    // frames when the root was updated first.
-                    // This is particularly noticeable on moving children or avatars (and avatar attachments).
-                    if (mFocusObject->isRoot())
-                    {
-                        for (LLViewerObject* childp : mFocusObject->getChildren())
-                        {
-                            LLDrawable* child_drawablep = childp ? childp->mDrawable.get() : nullptr;
-                            if (!child_drawablep || child_drawablep->isDead() || !child_drawablep->isActive())
-                            {
-                                continue;
-                            }
-
-                            child_drawablep->clearState(LLDrawable::EARLY_MOVE);
-
-                            if (childp->isSelected() ||
-                                child_drawablep->isState(LLDrawable::MOVE_UNDAMPED) ||
-                                !childp->getAngularVelocity().isExactlyZero())
-                            {
-                                gPipeline.updateMoveNormalAsync(child_drawablep);
-                            }
-                            else
-                            {
-                                gPipeline.updateMoveDampedAsync(child_drawablep);
-                            }
-
-                            // Also apply transform to any seated avatars
-                            if (LLVOAvatar* avatarp = childp->asAvatar())
-                            {
-                                if (LLJoint* root_jointp = avatarp->getRootJoint())
-                                {
-                                    root_jointp->touch();
-                                    root_jointp->updateWorldMatrixChildren();
-                                    const LLVector3 hud_name_pos =
-                                        avatarp->idleCalcNameTagPosition(root_jointp->getWorldPosition());
-                                    avatarp->idleUpdateNameTag(hud_name_pos);
-                                    avatarp->idleUpdateVoiceVisualizerPosition(hud_name_pos);
-                                }
-
-                                // ... and also the avatar's unrigged attachments (those are not
-                                // children of the vehicle, they are children of the avatar)
-                                for (LLVOAvatar::attachment_map_t::iterator iter = avatarp->mAttachmentPoints.begin();
-                                     iter != avatarp->mAttachmentPoints.end(); )
-                                {
-                                    LLVOAvatar::attachment_map_t::iterator curiter = iter++;
-                                    LLViewerJointAttachment* attachment = curiter->second;
-                                    if (!attachment)
-                                    {
-                                        continue;
-                                    }
-
-                                    for (LLViewerJointAttachment::attachedobjs_vec_t::iterator attachment_iter = attachment->mAttachedObjects.begin();
-                                         attachment_iter != attachment->mAttachedObjects.end();
-                                         ++attachment_iter)
-                                    {
-                                        LLViewerObject* attached_object = attachment_iter->get();
-                                        if (attached_object && !attached_object->isDead() && attached_object->mDrawable.notNull())
-                                        {
-                                            attached_object->mDrawable->clearState(LLDrawable::EARLY_MOVE);
-                                            gPipeline.updateMoveNormalAsync(attached_object->mDrawable);
-                                            attached_object->updateText();
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                updateFocusedLinksetObject(mFocusObject.get());
             }
             // if not tracking object, update offset based on new object position
-            else
+            else if (!mTrackFocusObject)
             {
                 updateFocusOffset();
             }

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -4795,7 +4795,8 @@ const LLVector3 LLViewerObject::getRenderPosition() const
         }
     }
 
-    if (mDrawable.isNull() || mDrawable->getGeneration() < 0)
+    if (mDrawable.isNull() ||
+        (!mDrawable->isActive() && mDrawable->getGeneration() < 0))
     {
         return getPositionAgent();
     }
@@ -8036,4 +8037,3 @@ public:
 
 LLHTTPRegistration<ObjectPhysicsProperties>
     gHTTPRegistrationObjectPhysicsProperties("/message/ObjectPhysicsProperties");
-

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -3015,8 +3015,16 @@ void LLVOAvatar::idleUpdateVoiceVisualizer(bool voice_enabled, const LLVector3 &
                 }
             }
         }
-        mVoiceVisualizer->setPositionAgent(position);
+        idleUpdateVoiceVisualizerPosition(position);
     }//if ( voiceEnabled )
+}
+
+void LLVOAvatar::idleUpdateVoiceVisualizerPosition(const LLVector3 &position)
+{
+    if (mVoiceVisualizer)
+    {
+        mVoiceVisualizer->setPositionAgent(position);
+    }
 }
 
 static void override_bbox(LLDrawable* drawable, LLVector4a* extents)

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -283,6 +283,7 @@ public:
     void            updateRootPositionAndRotation(LLAgent &agent, F32 speed, bool was_sit_ground_constrained);
 
     void            idleUpdateVoiceVisualizer(bool voice_enabled, const LLVector3 &position);
+    void            idleUpdateVoiceVisualizerPosition(const LLVector3 &position);
     void            idleUpdateMisc(bool detailed_update);
     virtual void    idleUpdateAppearanceAnimation();
     void            idleUpdateLipSync(bool voice_enabled);
@@ -1355,4 +1356,3 @@ void dump_sequential_xml(const std::string outprefix, const LLSD& content);
 void dump_visual_param(apr_file_t* file, LLVisualParam* viewer_param, F32 value);
 
 #endif // LL_VOAVATAR_H
-


### PR DESCRIPTION
Related to [this canny](https://feedback.secondlife.com/bug-reports/p/child-prims-and-avatars-of-a-moving-linkset-can-appear-dislocated-from-the-root)

Alt-clicking on a root prim of a moving object results in a long standing bug where the root will move faster than its child prims. This causes visual dislocation of any other moving parts of the object such as an avatar sitting on a vehicle or the wheels turning. This also extends to the nametag and voice visual indicator of an avatar.

This bug is 100% reproducible by taking any vehicle and focusing on the root while its in motion. The old tickets (MAINT-1742 MAINT-2247, MAINT-2275) are referenced in the code and mention that some stuff was reverted in the past due to doors breaking. The nature of the changes were different, and I could not spot any undesirable side effect of my version of this fix (including with doors). If anyone has history on these old tickets or suggestions to rework the nature of the fix, I'd love to hear it.

With this fix in place, focusing on the root of a moving object keeps all of its parts and seated avatars together as you would expect.