### PR TITLE
FIX - Closing minimized search floater should not reopen script floater

### DIFF
--- a/indra/newview/llpreviewscript.cpp
+++ b/indra/newview/llpreviewscript.cpp
@@ -188,7 +188,6 @@ public:
 
     virtual bool hasAccelerators() const;
     virtual bool handleKeyHere(KEY key, MASK mask);
-    void closeFloater(bool app_quitting = false) override;
 
 private:
 
@@ -210,6 +209,7 @@ LLFloaterScriptSearch::LLFloaterScriptSearch(LLScriptEdCore* editor_core)
     mEditorCore(editor_core)
 {
     buildFromFile("floater_script_search.xml");
+    setCanMinimize(false);
 
     sInstance = this;
 
@@ -269,21 +269,6 @@ void LLFloaterScriptSearch::show(LLScriptEdCore* editor_core)
 LLFloaterScriptSearch::~LLFloaterScriptSearch()
 {
     sInstance = NULL;
-}
-
-void LLFloaterScriptSearch::closeFloater(bool app_quitting)
-{
-    // If this floater is minimized while dependent on another window,
-    // closing it should not restore the dependee.
-    if (isMinimized())
-    {
-        if (LLFloater* dependee = getDependee())
-        {
-            dependee->removeDependentFloater(this);
-        }
-    }
-
-    LLFloater::closeFloater(app_quitting);
 }
 
 // static

--- a/indra/newview/llpreviewscript.cpp
+++ b/indra/newview/llpreviewscript.cpp
@@ -188,6 +188,7 @@ public:
 
     virtual bool hasAccelerators() const;
     virtual bool handleKeyHere(KEY key, MASK mask);
+    void closeFloater(bool app_quitting = false) override;
 
 private:
 
@@ -268,6 +269,21 @@ void LLFloaterScriptSearch::show(LLScriptEdCore* editor_core)
 LLFloaterScriptSearch::~LLFloaterScriptSearch()
 {
     sInstance = NULL;
+}
+
+void LLFloaterScriptSearch::closeFloater(bool app_quitting)
+{
+    // If this floater is minimized while dependent on another window,
+    // closing it should not restore the dependee.
+    if (isMinimized())
+    {
+        if (LLFloater* dependee = getDependee())
+        {
+            dependee->removeDependentFloater(this);
+        }
+    }
+
+    LLFloater::closeFloater(app_quitting);
 }
 
 // static


### PR DESCRIPTION
This is a minor UX issue found while editing several scripts at once.
Repro steps:
- Open the script editor
- Open the search floater (CTRL+F) for that script floater
- Minimize both floaters
- Close the search&replace floater
- Notice how closing the floater has re-maximized your script floater.

I could not find an issue/canny on this