### PR TITLE
Change/Fix - Retain newest notifications when trimming persisted notifications

### DIFF
--- a/indra/llui/llnotifications.h
+++ b/indra/llui/llnotifications.h
@@ -1094,6 +1094,8 @@ public:
     typedef std::vector<LLNotificationPtr> history_list_t;
     history_list_t::iterator beginHistory() { sortHistory(); return mHistory.begin(); }
     history_list_t::iterator endHistory() { return mHistory.end(); }
+    history_list_t::reverse_iterator rBeginHistory() { sortHistory(); return mHistory.rbegin(); }
+    history_list_t::reverse_iterator rEndHistory() { return mHistory.rend(); }
 
 private:
     struct sortByTime
@@ -1134,4 +1136,3 @@ private:
 };
 
 #endif//LL_LLNOTIFICATIONS_H
-

--- a/indra/newview/llpersistentnotificationstorage.cpp
+++ b/indra/newview/llpersistentnotificationstorage.cpp
@@ -61,9 +61,9 @@ void LLPersistentNotificationStorage::saveNotifications()
         return;
     }
 
-    const S32 max_to_save = llmax(1, gSavedSettings.getS32("MaxPersistentNotifications"));
-    std::vector<LLNotificationPtr> selected_notifications;
-    selected_notifications.reserve(max_to_save);
+const S32 max_to_save = llmax(1, gSavedSettings.getS32("MaxPersistentNotifications"));
+std::vector<LLNotificationPtr> selected_notifications;
+selected_notifications.reserve(std::min<size_t>(static_cast<size_t>(max_to_save), history_channel->size()));
 
     auto history_begin = history_channel->beginHistory();
     auto history_it = history_channel->endHistory();

--- a/indra/newview/llpersistentnotificationstorage.cpp
+++ b/indra/newview/llpersistentnotificationstorage.cpp
@@ -65,29 +65,30 @@ void LLPersistentNotificationStorage::saveNotifications()
     std::vector<LLNotificationPtr> selected_notifications;
     selected_notifications.reserve(std::min<size_t>(static_cast<size_t>(max_to_save), history_channel->size()));
 
-    auto history_begin = history_channel->beginHistory();
-    auto history_it = history_channel->endHistory();
-    while (history_it != history_begin)
+    for (auto history_it = history_channel->rBeginHistory(), history_end = history_channel->rEndHistory();
+        history_it != history_end;
+        ++history_it)
     {
-        --history_it;
         LLNotificationPtr notification = *history_it;
 
         // After a notification was placed in Persist channel, it can become
         // responded, expired or canceled - in this case we should not save it
-        if (!(notification->isRespondedTo() || notification->isCancelled() || notification->isExpired()))
+        if (notification->isRespondedTo() || notification->isCancelled() || notification->isExpired())
         {
-            if (static_cast<S32>(selected_notifications.size()) < max_to_save)
-            {
-                selected_notifications.push_back(notification);
-            }
-            else
-            {
-                LL_WARNS() << "Too many persistent notifications."
-                        << " Saved the " << selected_notifications.size() << " newest notifications;"
-                        << " older notifications were omitted."
-                        << LL_ENDL;
-                break;
-            }
+            continue;
+        }
+
+        if (static_cast<S32>(selected_notifications.size()) < max_to_save)
+        {
+            selected_notifications.push_back(notification);
+        }
+        else
+        {
+            LL_WARNS() << "Too many persistent notifications."
+                    << " Saved the " << selected_notifications.size() << " newest notifications;"
+                    << " older notifications were omitted."
+                    << LL_ENDL;
+            break;
         }
     }
 

--- a/indra/newview/llpersistentnotificationstorage.cpp
+++ b/indra/newview/llpersistentnotificationstorage.cpp
@@ -36,6 +36,9 @@
 #include "llscriptfloater.h"
 #include "llviewermessage.h"
 #include "llviewernetwork.h"
+
+#include <algorithm>
+
 LLPersistentNotificationStorage::LLPersistentNotificationStorage():
       LLNotificationStorage("")
     , mLoaded(false)
@@ -51,40 +54,54 @@ void LLPersistentNotificationStorage::saveNotifications()
 {
     LL_PROFILE_ZONE_SCOPED;
 
-    boost::intrusive_ptr<LLPersistentNotificationChannel> history_channel = boost::dynamic_pointer_cast<LLPersistentNotificationChannel>(LLNotifications::instance().getChannel("Persistent"));
+    auto history_channel = boost::dynamic_pointer_cast<LLPersistentNotificationChannel>(
+        LLNotifications::instance().getChannel("Persistent"));
     if (!history_channel)
     {
         return;
     }
 
-    LLSD output = LLSD::emptyMap();
-    LLSD& data = output["data"];
+    const S32 max_to_save = llmax(1, gSavedSettings.getS32("MaxPersistentNotifications"));
+    std::vector<LLNotificationPtr> selected_notifications;
+    selected_notifications.reserve(max_to_save);
 
-    for ( std::vector<LLNotificationPtr>::iterator it = history_channel->beginHistory(), end_it = history_channel->endHistory();
-        it != end_it;
-        ++it)
+    auto history_begin = history_channel->beginHistory();
+    auto history_it = history_channel->endHistory();
+    while (history_it != history_begin)
     {
-        LLNotificationPtr notification = *it;
+        --history_it;
+        LLNotificationPtr notification = *history_it;
 
         // After a notification was placed in Persist channel, it can become
-        // responded, expired or canceled - in this case we are should not save it
-        if(notification->isRespondedTo() || notification->isCancelled()
-            || notification->isExpired())
+        // responded, expired or canceled - in this case we should not save it
+        if (!(notification->isRespondedTo() || notification->isCancelled() || notification->isExpired()))
         {
-            continue;
+            if (static_cast<S32>(selected_notifications.size()) < max_to_save)
+            {
+                selected_notifications.push_back(notification);
+            }
+            else
+            {
+                LL_WARNS() << "Too many persistent notifications."
+                        << " Saved the " << selected_notifications.size() << " newest notifications;"
+                        << " older notifications were omitted."
+                        << LL_ENDL;
+                break;
+            }
         }
-
-        data.append(notification->asLLSD(true));
-        if (data.size() >= gSavedSettings.getS32("MaxPersistentNotifications"))
-        {
-            LL_WARNS() << "Too many persistent notifications."
-                    << " Saved " << gSavedSettings.getS32("MaxPersistentNotifications") << " of " << history_channel->size()
-                    << " persistent notifications." << LL_ENDL;
-            break;
-        }
-
     }
 
+    // History is saved oldest-to-newest so loadNotifications() retains its existing processing order.
+    std::reverse(selected_notifications.begin(), selected_notifications.end());
+
+    LLSD data = LLSD::emptyArray();
+    for (const LLNotificationPtr& notification : selected_notifications)
+    {
+        data.append(notification->asLLSD(true));
+    }
+
+    LLSD output = LLSD::emptyMap();
+    output["data"] = data;
     writeNotifications(output);
 }
 

--- a/indra/newview/llpersistentnotificationstorage.cpp
+++ b/indra/newview/llpersistentnotificationstorage.cpp
@@ -61,9 +61,9 @@ void LLPersistentNotificationStorage::saveNotifications()
         return;
     }
 
-const S32 max_to_save = llmax(1, gSavedSettings.getS32("MaxPersistentNotifications"));
-std::vector<LLNotificationPtr> selected_notifications;
-selected_notifications.reserve(std::min<size_t>(static_cast<size_t>(max_to_save), history_channel->size()));
+    const S32 max_to_save = llmax(1, gSavedSettings.getS32("MaxPersistentNotifications"));
+    std::vector<LLNotificationPtr> selected_notifications;
+    selected_notifications.reserve(std::min<size_t>(static_cast<size_t>(max_to_save), history_channel->size()));
 
     auto history_begin = history_channel->beginHistory();
     auto history_it = history_channel->endHistory();


### PR DESCRIPTION
Originally reported on Firestorm's Jira as [FIRE-36502](https://jira.firestormviewer.org/browse/FIRE-36502), I could not find a related canny.

Persisted notifications are trimmed naively, which causes the latest notifications to be dropped on relog instead of trimming starting from the oldest notifications.

These screenshots were taken on firestorm, but the behavior is identical on the current LL viewer.

Testing with a `MaxPersistentNotifications `of `2` persisted notifications:

Before logging out (4 notifs): https://gyazo.com/60b8ab529e447f7ba32623cc6372116a
After logging back in (2, the older ones): https://gyazo.com/44084cf468f849abd08059d2f95fbe47 

With the fix:
Before logging out (3 notifs):  https://gyazo.com/3f89f7352ab10e171226cb63f1f45b7b 
After logging in (2, the newer ones): https://gyazo.com/75e3ce3b038253209692a9d52bce7ac8 

This fix is a change in behavior, but I would argue it is the desired one.