### PR TITLE
FIX - Follow Camera stays stuck when unexpectedly unsat

### DIFF
--- a/indra/newview/llfollowcam.cpp
+++ b/indra/newview/llfollowcam.cpp
@@ -845,6 +845,11 @@ void LLFollowCamMgr::removeFollowCamParams(const LLUUID& source)
     delete params;
 }
 
+void LLFollowCamMgr::clearActiveFollowCamParams()
+{
+    mParamStack.clear();
+}
+
 bool LLFollowCamMgr::isScriptedCameraSource(const LLUUID& source)
 {
     param_map_t::iterator found_it = mParamMap.find(source);

--- a/indra/newview/llfollowcam.h
+++ b/indra/newview/llfollowcam.h
@@ -217,6 +217,7 @@ public:
     LLFollowCamParams* getActiveFollowCamParams();
     LLFollowCamParams* getParamsForID(const LLUUID& source);
     void removeFollowCamParams(const LLUUID& source);
+    void clearActiveFollowCamParams();
     bool isScriptedCameraSource(const LLUUID& source);
     void dump();
 

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -4868,7 +4868,8 @@ bool LLVOAvatar::updateCharacter(LLAgent &agent)
         LLMotion *motionp = mMotionController.findMotion(ANIM_AGENT_SIT_GROUND_CONSTRAINED);
         if (!motionp || !mMotionController.isMotionLoading(motionp))
         {
-            getOffObject();
+            // Route through setParent(NULL) so self also resets its camera.
+            setParent(NULL);
         }
     }
 
@@ -8055,6 +8056,11 @@ void LLVOAvatar::getOffObject()
             stopMotionFromSource(child_objectp->getID());
             LLFollowCamMgr::getInstance()->setCameraActive(child_objectp->getID(), false);
         }
+    }
+    else if (isSelf())
+    {
+        // Recover from a missing seat parent without retaining a stale followcam.
+        LLFollowCamMgr::getInstance()->clearActiveFollowCamParams();
     }
 
     // assumes that transform will not be updated with drawable still having a parent
@@ -12230,4 +12236,3 @@ bool LLVOAvatar::isBuddy() const
     }
     return is_friend;
 }
-


### PR DESCRIPTION
When you cross a region and a vehicle gets deleted due to "The region you are trying to enter is currently experiencing issues" (and possibly in other cases as well), your avatar becomes forcibly unseated and may remain connected to the original sim.
In those situations, the viewer does not properly clear the active camera, making it impossible to turn your camera at all. The only way to fix this broken state is to sit on a seat with a scripted camera and unsit. (But most people end up relogging). Friends and I have experienced this bug in other situations as well, all of which were due to forced unsits.

Due to the nature of the bug, it is very difficult for me to test it, I've been sitting on this fix for half a year at this point. However, I've recently come across the region issue again and my camera was not trapped unlike the other passengers of the busted vehicle, I've also not had a camera stuck problem since including this fix which seems to prove it was a success. 

The fix comes in two parts -> 
1) avoid calling getOffObject() directly (my theory is that when it gets called, mDrawable is null so none of the logic the function does is performed) and instead setParent to NULL so it calls getOffObject and resets camera explicitly.  
2) recover from a missing object you got up from if you are not seated while getOffObject is called  (likely a bad state).

There may be more than one canny on the topic, but I have found this related canny: https://feedback.secondlife.com/server-bugs/p/when-avatar-on-vehicle-cannot-enter-a-parcel-avatar-is-left-in-a-stuck-state