### PR TITLE
Fix GCC 15+ build error in param block tag sorting

### DIFF
--- a/indra/llcommon/llinitparam.h
+++ b/indra/llcommon/llinitparam.h
@@ -45,7 +45,6 @@ namespace LLTypeTags
     template <typename INNER_TYPE, int _SORT_ORDER>
     struct TypeTagBase
     {
-        typedef void        is_tag_t;
         typedef INNER_TYPE  inner_t;
         static const int    SORT_ORDER=_SORT_ORDER;
     };
@@ -68,16 +67,10 @@ namespace LLTypeTags
         typedef typename REST::template Cons<Swap<ITEM, typename REST::inner_t>::value_t>::value_t value_t;
     };
 
-    template<typename T, typename SORTABLE = void>
+    template<typename T>
     struct IsSortable
     {
         static const bool value = false;
-    };
-
-    template<typename T>
-    struct IsSortable<T, typename T::is_tag_t>
-    {
-        static const bool value = true;
     };
 
     template<typename ITEM, typename REST, bool IS_REST_SORTABLE = IsSortable<REST>::value>
@@ -2830,5 +2823,26 @@ namespace LLInitParam
     };
 }
 
+namespace LLTypeTags
+{
+    // After BaseBlock so Sequential, Atomic, and Lazy are in scope.
+    template<typename T>
+    struct IsSortable<LLInitParam::BaseBlock::Sequential<T> >
+    {
+        static const bool value = true;
+    };
+
+    template<typename T>
+    struct IsSortable<LLInitParam::BaseBlock::Atomic<T> >
+    {
+        static const bool value = true;
+    };
+
+    template<typename T, typename BLOCK_T>
+    struct IsSortable<LLInitParam::BaseBlock::Lazy<T, BLOCK_T> >
+    {
+        static const bool value = true;
+    };
+}
 
 #endif // LL_LLPARAM_H


### PR DESCRIPTION
Fixes building the viewer with GCC 15 or newer: `llxuiparser.cpp` was tripping `-Wsfinae-incomplete` via tag sorting templates in `llinitparam.h`.

Patched this by moving the tag check out of the types.

---

**Error (gcc 16.2.1)**
```
  indra/llui/llxuiparser.cpp:155:8: error: defining ‘Sequence’, which previously failed to be
                                    complete in a SFINAE context [-Werror=sfinae-incomplete=]
    155 | struct Sequence : public LLInitParam::ChoiceBlock<Sequence, Occurs>
        |        ^~~~~~~~
  indra/llcommon/llinitparam.h:104:96: note: here.  Use ‘-Wsfinae-incomplete=2’ for a diagnostic at that point
    104 |     typedef typename InsertInto<T, typename Sorted<typename T::inner_t>::value_t>::value_t value_t;
        |                                                                                            ^~~~~~~

  indra/llui/llxuiparser.cpp:177:8: error: defining ‘Group’, which previously failed to be
                                    complete in a SFINAE context [-Werror=sfinae-incomplete=]
    177 | struct Group : public LLInitParam::Block<Group, GroupContents>

  indra/llui/llxuiparser.cpp:268:8: error: defining ‘Element’, which previously failed to be
                                    complete in a SFINAE context [-Werror=sfinae-incomplete=]
    268 | struct Element : public LLInitParam::Block<Element, ElementContents>

  cc1plus: all warnings being treated as errors
```