### PR TITLE
Fix LLInlineViewSegment::getNumChars not accounting for padding

### DIFF
--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -4151,7 +4151,7 @@ S32 LLInlineViewSegment::getNumChars(S32 num_pixels, S32 segment_offset, S32 lin
     {
         return 0;
     }
-    else if (line_offset != 0 && num_pixels < mView->getRect().getWidth())
+    else if (line_offset != 0 && num_pixels < (mLeftPad + mRightPad + mView->getRect().getWidth()))
     {
         return 0;
     }


### PR DESCRIPTION
Related Issue: https://github.com/secondlife/viewer/issues/6225

The existing PR here: https://github.com/secondlife/viewer/pull/6230 fixes the issues specifically introduced in 26.4 regarding the conversation floaters horizontal bar bug. However a horizontal scroll bar can still sometimes appear in the conversation floater even with those fixes which was also occurring in 26.2 and 26.3 releases as well.

This PR specifically addresses LLInlineViewSegment::getNumChars not accounting for the left and right padding which resulted in a horizontal scrollbar appearing when there is text containing a SLURL icon (avatar profile, or group profile slurl) at the end of the line, and the conversation floater is sized so the icon is right up against the right side.

Here is a screenshot of the issue that was occuring with icons causing the horizontal scroll bar that this PR fixes-
<img width="287" height="249" alt="image" src="https://github.com/user-attachments/assets/1cf1631d-8be4-4983-8bed-9a40c2f7cde4" />

If you would prefer this targeting develop instead and bring the fix into a future release after 26.4, then feel free to change it to develop.

Testing required:
Make sure that UI elsewhere in the viewer isn't impacted and require small spacing adjustments where things may now wrap around when they didn't previously. I personally couldn't see anything else impacted, but definitely worth having QA double check

