### PR TITLE
Fix heap-use-after-free when removing items from your avatar

### DIFF
--- a/indra/newview/llappearancemgr.cpp
+++ b/indra/newview/llappearancemgr.cpp
@@ -4215,7 +4215,7 @@ void LLAppearanceMgr::removeItemsFromAvatar(const uuid_vec_t& ids_to_remove, nul
     for (uuid_vec_t::const_iterator it = ids_to_remove.begin(); it != ids_to_remove.end(); ++it)
     {
         const LLUUID& id_to_remove = *it;
-        const LLUUID& linked_item_id = gInventory.getLinkedItemID(id_to_remove);
+        const LLUUID linked_item_id = gInventory.getLinkedItemID(id_to_remove);
         LLViewerInventoryItem *item = gInventory.getItem(linked_item_id);
         if (item && item->getType() == LLAssetType::AT_OBJECT)
         {


### PR DESCRIPTION
Issue Fixed: https://github.com/secondlife/viewer/issues/6246

This PR simply fixes a possible heap-use-after-free by taking a copy of the LLUUID for the linked item instead of a reference, so it can't be freed when removing the item in LLAppearanceMgr::removeCOFItemLinks from your inventory and then used in LLAppearanceMgr::addDoomedTempAttachment.

ASan of the heap-use-after-free can be seen in the linked issue.