### PR TITLE
FIX - Max camera distance limitation should be friendly to avatars in motion

### DIFF
--- a/indra/newview/llfollowcam.cpp
+++ b/indra/newview/llfollowcam.cpp
@@ -415,10 +415,12 @@ void LLFollowCam::update()
         //--------------------------------------------------------------------
         // don't let the camera get farther than its official max distance
         //--------------------------------------------------------------------
-        if ( distanceFromCameraToSubject > mMaxCameraDistantFromSubject )
+        const F32 target_camera_distance = llmin(mSimulatedDistance, mMaxCameraDistantFromSubject);
+        const F32 updated_distance_from_camera_to_subject = (offsetSubjectPosition - simulated_pos_agent).magVec();
+        if ( updated_distance_from_camera_to_subject > target_camera_distance )
         {
-            LLVector3 directionFromCameraToSubject = vectorFromCameraToSubject / distanceFromCameraToSubject;
-            simulated_pos_agent = offsetSubjectPosition - directionFromCameraToSubject * mMaxCameraDistantFromSubject;
+            simulated_pos_agent = offsetSubjectPosition -
+                (positionOffsetFromSubject * (target_camera_distance / mSimulatedDistance));
         }
 
         ////-------------------------------------------------------------------------------------------------
@@ -875,4 +877,3 @@ void LLFollowCamMgr::dump()
             " pos_thresh: " << (*param_it)->getPositionThreshold() << LL_ENDL;
     }
 }
-

--- a/indra/newview/llfollowcam.cpp
+++ b/indra/newview/llfollowcam.cpp
@@ -293,7 +293,7 @@ void LLFollowCam::update()
 
     LLVector3 simulated_pos_agent = gAgent.getPosAgentFromGlobal(mSimulatedPositionGlobal);
     LLVector3 vectorFromCameraToSubject = offsetSubjectPosition - simulated_pos_agent;
-    F32 distanceFromCameraToSubject = vectorFromCameraToSubject.magVec();
+    // F32 distanceFromCameraToSubject = vectorFromCameraToSubject.magVec();
 
     LLVector3 whereFocusWantsToBe = mFocus;
     LLVector3 focus_pt_agent = gAgent.getPosAgentFromGlobal(mSimulatedFocusGlobal);
@@ -412,15 +412,20 @@ void LLFollowCam::update()
             simulated_pos_agent = lerp( simulated_pos_agent, whereCameraPositionWantsToBe, positionPullLerp );
         }
 
-        //--------------------------------------------------------------------
-        // don't let the camera get farther than its official max distance
-        //--------------------------------------------------------------------
-        const F32 target_camera_distance = llmin(mSimulatedDistance, mMaxCameraDistantFromSubject);
-        const F32 updated_distance_from_camera_to_subject = (offsetSubjectPosition - simulated_pos_agent).magVec();
-        if ( updated_distance_from_camera_to_subject > target_camera_distance )
+        // Keep the simulated camera within the effective follow distance:
+        // - Keep requested distance capped by the viewer's maximum.
+        // - Rebuild its position from the subject-relative offset so a moving
+        // avatar follows the intended camera geometry rather than the prior
+        // camera position.
+        // - Applied after position lag, which can move the simulated camera beyond
+        //  its distance limit.
+        const F32 camera_distance_limit = llmin(mSimulatedDistance, mMaxCameraDistantFromSubject);
+        const F32 distance_after_position_lag = (offsetSubjectPosition - simulated_pos_agent).magVec();
+        if ( distance_after_position_lag > camera_distance_limit )
         {
+            const F32 camera_distance_scale = camera_distance_limit / mSimulatedDistance;
             simulated_pos_agent = offsetSubjectPosition -
-                (positionOffsetFromSubject * (target_camera_distance / mSimulatedDistance));
+                (positionOffsetFromSubject * camera_distance_scale);
         }
 
         ////-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The max camera distance enforcement does not account for avatars in movement (sitting on a vehicle).
It is possible for your follow camera to get stuck at max distance while in motion.

To replicate this bug, you can do the following (much easier to test as a passenger of a moving vehicle, so I recommend using a vehicle/object that moves on its own or having 2 avatars to test): 
1) Sit on a vehicle that uses the follow camera
2) Be in motion while doing the steps below
3) Scroll out to the max camera distance
4) Alt-click somewhere far from the vehicle so your cam no longer follows the vehicle while it remains in motion.
5) Return to your follow camera
6) Notice how when you try to zoom in, you are unable to and are stuck at max camera distance
7) Keep trying to scroll to zoom in and notice how at some point, you will enter mouselook despite your camera being far away at the time of entering mouselook.

This fix keeps the camera limit while accounting for the fact you might be in motion.

I could not find a canny referencing this issue.