### PR TITLE
Skinned Mesh Shader Optimizations and C++ changes to support

### DIFF
--- a/indra/newview/app_settings/shaders/class1/avatar/objectSkinV.glsl
+++ b/indra/newview/app_settings/shaders/class1/avatar/objectSkinV.glsl
@@ -24,49 +24,30 @@
 
 in vec4 weight4;
 
-uniform mat3x4 matrixPalette[MAX_JOINTS_PER_MESH_OBJECT];
+uniform mat4 matrixPalette[MAX_JOINTS_PER_MESH_OBJECT];
 
 mat4 getObjectSkinnedTransform()
 {
-    int i;
 
-    vec4 w = fract(weight4);
     vec4 index = floor(weight4);
-
-    index = min(index, vec4(MAX_JOINTS_PER_MESH_OBJECT-1));
-    index = max(index, vec4( 0.0));
-
-    w *= 1.0/(w.x+w.y+w.z+w.w);
+    vec4 w   = fract(weight4)*2.0;
 
     int i1 = int(index.x);
     int i2 = int(index.y);
     int i3 = int(index.z);
     int i4 = int(index.w);
-
-    mat3 mat = mat3(matrixPalette[i1])*w.x;
-         mat += mat3(matrixPalette[i2])*w.y;
-         mat += mat3(matrixPalette[i3])*w.z;
-         mat += mat3(matrixPalette[i4])*w.w;
-
-    vec3 trans = vec3(matrixPalette[i1][0].w,matrixPalette[i1][1].w,matrixPalette[i1][2].w)*w.x;
-         trans += vec3(matrixPalette[i2][0].w,matrixPalette[i2][1].w,matrixPalette[i2][2].w)*w.y;
-         trans += vec3(matrixPalette[i3][0].w,matrixPalette[i3][1].w,matrixPalette[i3][2].w)*w.z;
-         trans += vec3(matrixPalette[i4][0].w,matrixPalette[i4][1].w,matrixPalette[i4][2].w)*w.w;
-
+     
     mat4 ret;
-
-    ret[0] = vec4(mat[0], 0);
-    ret[1] = vec4(mat[1], 0);
-    ret[2] = vec4(mat[2], 0);
-    ret[3] = vec4(trans, 1.0);
-
-    return ret;
-
+    ret = ((matrixPalette[i1] * w.x)
+          + (matrixPalette[i2] * w.y)
+          + (matrixPalette[i3] * w.z)
+          + (matrixPalette[i4] * w.w));
+     return ret;
 #ifdef IS_AMD_CARD
-   // If it's AMD make sure the GLSL compiler sees the arrays referenced once by static index. Otherwise it seems to optimise the storage awawy which leads to unfun crashes and artifacts.
-   mat3x4 dummy1 = matrixPalette[0];
-   mat3x4 dummy2 = matrixPalette[MAX_JOINTS_PER_MESH_OBJECT-1];
-#endif
-
+     // If it's AMD make sure the GLSL compiler sees the arrays referenced once by static index. Otherwise it seems to optimise the storage away which leads to unfun crashes and artifacts.
+     mat4 dummy1 = matrixPalette[0];
+     mat4 dummy2 = matrixPalette[MAX_JOINTS_PER_MESH_OBJECT-1];
+#endif  
 }
+
 

--- a/indra/newview/app_settings/shaders/class1/avatar/objectSkinV.glsl
+++ b/indra/newview/app_settings/shaders/class1/avatar/objectSkinV.glsl
@@ -36,7 +36,7 @@ mat4 getObjectSkinnedTransform()
     int i2 = int(index.y);
     int i3 = int(index.z);
     int i4 = int(index.w);
-     
+
     mat4 ret;
     ret = ((matrixPalette[i1] * w.x)
           + (matrixPalette[i2] * w.y)
@@ -47,7 +47,7 @@ mat4 getObjectSkinnedTransform()
      // If it's AMD make sure the GLSL compiler sees the arrays referenced once by static index. Otherwise it seems to optimise the storage away which leads to unfun crashes and artifacts.
      mat4 dummy1 = matrixPalette[0];
      mat4 dummy2 = matrixPalette[MAX_JOINTS_PER_MESH_OBJECT-1];
-#endif  
+#endif
 }
 
 

--- a/indra/newview/gltf/primitive.cpp
+++ b/indra/newview/gltf/primitive.cpp
@@ -559,7 +559,7 @@ void Primitive::upload(LLVertexBuffer* buffer)
         mVertexBuffer->setTangentData(mTangents.data(), offset, count);
     }
 
-    
+
     if (!mWeights.empty())
     {
         auto weightsCopy = std::vector(mWeights);

--- a/indra/newview/gltf/primitive.cpp
+++ b/indra/newview/gltf/primitive.cpp
@@ -559,9 +559,27 @@ void Primitive::upload(LLVertexBuffer* buffer)
         mVertexBuffer->setTangentData(mTangents.data(), offset, count);
     }
 
+    
     if (!mWeights.empty())
     {
-        mVertexBuffer->setWeight4Data(mWeights.data(), offset, count);
+        auto weightsCopy = std::vector(mWeights);
+        // precompute normalized weights to avoid having to recompute for every vertex at runtime.
+        float wint[4];
+        float wfract[4];
+        for (auto& w : weightsCopy)
+        {
+            wfract[0] = std::modf(w[0], &wint[0]);
+            wfract[1] = std::modf(w[1], &wint[1]);
+            wfract[2] = std::modf(w[2], &wint[2]);
+            wfract[3] = std::modf(w[3], &wint[3]);
+            float norm_factor = (0.5f) / (wfract[0] + wfract[1] + wfract[2] + wfract[3]);
+            wfract[0] *= norm_factor;
+            wfract[1] *= norm_factor;
+            wfract[2] *= norm_factor;
+            wfract[3] *= norm_factor;
+            w.set(wint[0] + wfract[0], wint[1] + wfract[1], wint[2] + wfract[2], wint[3] + wfract[3]);
+        }
+        mVertexBuffer->setWeight4Data(weightsCopy.data(), offset, count);
         mVertexBuffer->setJointData(mJoints.data(), offset, count);
     }
 

--- a/indra/newview/lldrawpool.cpp
+++ b/indra/newview/lldrawpool.cpp
@@ -680,7 +680,7 @@ bool LLRenderPass::uploadMatrixPalette(LLVOAvatar* avatar, LLMeshSkinInfo* skinI
         return false;
     }
 
-    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix3x4fv(LLViewerShaderMgr::AVATAR_MATRIX,
+    LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLViewerShaderMgr::AVATAR_MATRIX,
         count,
         false,
         (GLfloat*)&(mpc.mGLMp[0]));
@@ -716,7 +716,7 @@ bool LLRenderPass::uploadMatrixPalette(LLVOAvatar* avatar, LLMeshSkinInfo* skinI
 
     if (!skipLastSkin)
     {
-        LLGLSLShader::sCurBoundShaderPtr->uniformMatrix3x4fv(LLViewerShaderMgr::AVATAR_MATRIX,
+        LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLViewerShaderMgr::AVATAR_MATRIX,
             count,
             false,
             (GLfloat*)&(mpc.mGLMp[0]));
@@ -754,7 +754,7 @@ bool LLRenderPass::uploadMatrixPalette(LLVOAvatar* avatar, LLMeshSkinInfo* skinI
 
     if (!skipLastSkin)
     {
-        LLGLSLShader::sCurBoundShaderPtr->uniformMatrix3x4fv(LLViewerShaderMgr::AVATAR_MATRIX,
+        LLGLSLShader::sCurBoundShaderPtr->uniformMatrix4fv(LLViewerShaderMgr::AVATAR_MATRIX,
             count,
             false,
             (GLfloat*)&(mpc.mGLMp[0]));

--- a/indra/newview/llface.cpp
+++ b/indra/newview/llface.cpp
@@ -2103,7 +2103,7 @@ bool LLFace::getGeometryVolume(const LLVolume& volume,
         // precompute normalized weights to avoid having to recompute for every vertex at runtime.
         float wint[4];
         float wfract[4];
-        
+
         for (S32 i = 0; i<num_vertices; i++)
         {
             wfract[0]         = std::modf(vf.mWeights[i][0], &wint[0]);

--- a/indra/newview/llface.cpp
+++ b/indra/newview/llface.cpp
@@ -2096,13 +2096,34 @@ bool LLFace::getGeometryVolume(const LLVolume& volume,
             }
         }
 
-        if (rebuild_weights && vf.mWeights)
+    if (rebuild_weights && vf.mWeights)
+    {
+        LL_PROFILE_ZONE_NAMED_CATEGORY_FACE("getGeometryVolume - weight");
+        auto weightsCopy = std::vector<F32>(num_vertices*4);
+        // precompute normalized weights to avoid having to recompute for every vertex at runtime.
+        float wint[4];
+        float wfract[4];
+        
+        for (S32 i = 0; i<num_vertices; i++)
         {
-            LL_PROFILE_ZONE_NAMED_CATEGORY_FACE("getGeometryVolume - weight");
-            mVertexBuffer->getWeight4Strider(wght, mGeomIndex, mGeomCount);
-            F32* weights = (F32*) wght.get();
-            LLVector4a::memcpyNonAliased16(weights, (F32*) vf.mWeights, num_vertices*4*sizeof(F32));
+            wfract[0]         = std::modf(vf.mWeights[i][0], &wint[0]);
+            wfract[1]         = std::modf(vf.mWeights[i][1], &wint[1]);
+            wfract[2]         = std::modf(vf.mWeights[i][2], &wint[2]);
+            wfract[3]         = std::modf(vf.mWeights[i][3], &wint[3]);
+            float norm_factor = (0.5f) / (wfract[0] + wfract[1] + wfract[2] + wfract[3]);
+            wfract[0] *= norm_factor;
+            wfract[1] *= norm_factor;
+            wfract[2] *= norm_factor;
+            wfract[3] *= norm_factor;
+            weightsCopy[i * 4 + 0] = wint[0] + wfract[0];
+            weightsCopy[i * 4 + 1] = wint[1] + wfract[1];
+            weightsCopy[i * 4 + 2] = wint[2] + wfract[2];
+            weightsCopy[i * 4 + 3] = wint[3] + wfract[3];
         }
+        mVertexBuffer->getWeight4Strider(wght, mGeomIndex, mGeomCount);
+        F32* weights = (F32*) wght.get();
+        LLVector4a::memcpyNonAliased16(weights, (F32*) weightsCopy.data(), num_vertices*4*sizeof(F32));
+    }
 
         if (rebuild_color && mVertexBuffer->hasDataType(LLVertexBuffer::TYPE_COLOR) )
         {

--- a/indra/newview/llskinningutil.cpp
+++ b/indra/newview/llskinningutil.cpp
@@ -100,7 +100,7 @@ U32 LLSkinningUtil::getMeshJointCount(const LLMeshSkinInfo *skin)
 S32 LLSkinningUtil::getMaxGLTFJointCount()
 {
     // this is the maximum number of 3x4 matrices than can fit in a UBO
-    return gGLManager.mMaxUniformBlockSize / 48;
+    return gGLManager.mMaxUniformBlockSize / 64;
 }
 
 void LLSkinningUtil::scrubInvalidJoints(LLVOAvatar *avatar, LLMeshSkinInfo* skin)

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -10052,7 +10052,6 @@ const LLVOAvatar::MatrixPaletteCache& LLVOAvatar::updateSkinInfoMatrixPalette(co
         entry.mGLMp.resize(count * 16);
 
         F32* mp = &(entry.mGLMp[0]);
-
         for (U32 i = 0; i < count; ++i)
         {
             F32* m = (F32*)mat[i].mMatrix[0].getF32ptr();
@@ -10062,23 +10061,22 @@ const LLVOAvatar::MatrixPaletteCache& LLVOAvatar::updateSkinInfoMatrixPalette(co
             mp[idx + 0] = m[0];
             mp[idx + 1] = m[1];
             mp[idx + 2] = m[2];
-            mp[idx + 3] = m[3];
+            mp[idx + 3] = 0.0f;
 
             mp[idx + 4] = m[4];
             mp[idx + 5] = m[5];
             mp[idx + 6] = m[6];
-            mp[idx + 7] = m[7];
+            mp[idx + 7] = 0.0f;
 
             mp[idx + 8] = m[8];
             mp[idx + 9] = m[9];
             mp[idx + 10] = m[10];
-            mp[idx + 11] = m[11];
+            mp[idx + 11] = 0.0f;
 
             mp[idx + 12] = m[12];
             mp[idx + 13] = m[13];
             mp[idx + 14] = m[14];
-            mp[idx + 15] = m[15];
-            
+            mp[idx + 15] = 1.0f;
         }
     }
 

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -10049,7 +10049,7 @@ const LLVOAvatar::MatrixPaletteCache& LLVOAvatar::updateSkinInfoMatrixPalette(co
 
         const LLMatrix4a* mat = &(entry.mMatrixPalette[0]);
 
-        entry.mGLMp.resize(count * 12);
+        entry.mGLMp.resize(count * 16);
 
         F32* mp = &(entry.mGLMp[0]);
 
@@ -10057,22 +10057,28 @@ const LLVOAvatar::MatrixPaletteCache& LLVOAvatar::updateSkinInfoMatrixPalette(co
         {
             F32* m = (F32*)mat[i].mMatrix[0].getF32ptr();
 
-            U32 idx = i * 12;
+            U32 idx = i * 16;
 
             mp[idx + 0] = m[0];
             mp[idx + 1] = m[1];
             mp[idx + 2] = m[2];
-            mp[idx + 3] = m[12];
+            mp[idx + 3] = m[3];
 
             mp[idx + 4] = m[4];
             mp[idx + 5] = m[5];
             mp[idx + 6] = m[6];
-            mp[idx + 7] = m[13];
+            mp[idx + 7] = m[7];
 
             mp[idx + 8] = m[8];
             mp[idx + 9] = m[9];
             mp[idx + 10] = m[10];
-            mp[idx + 11] = m[14];
+            mp[idx + 11] = m[11];
+
+            mp[idx + 12] = m[12];
+            mp[idx + 13] = m[13];
+            mp[idx + 14] = m[14];
+            mp[idx + 15] = m[15];
+            
         }
     }
 


### PR DESCRIPTION
## Description

This PR moves some processing that used to run on the GPU for every skinned vertex into a precomputed step on the CPU to hopefully improve frame rates with lots of visible avatars.

Here is the linked issue:  https://github.com/secondlife/viewer/issues/6255

---

## Checklist

Please ensure the following before requesting review:

- [Y] I have provided a clear title and detailed description for this pull request.
- [Y] If useful, I have included media such as screenshots and video to show off my changes.
- [Y] The PR is linked to a relevant issue with sufficient context.
- [M] I have tested the changes locally and verified they work as intended.  (I cherrypicked the changes from a local branch with my other modifications to Alchemy Viewer.  They work on Alchemy Viewer with my local build.)
- [?] All new and existing tests pass.
- [?] Code follows the project's style guidelines.
- [?] Documentation has been updated if needed.
- [Y] Any dependent changes have been merged and published in downstream modules
- [Y] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes
This is my first time creating a pull request for Second Life.
Please let me know if I can do anything to improve the next pull requests I make or if there are any code quality issues that I can fix.
I mostly wrote these changes to improve the frame rate for my new version of the viewer with Stereo 3D Virtual Reality rendering that I've been working on but I think they might help with normal rendering too.
I don't have a large number of different GPUs to test on so I'm leaving this pull request as a draft until more people are able to test it on their hardware.
