### PR TITLE
#6258 Fix Slua Editor crash and obsolete state

### DIFF
--- a/indra/newview/llscripteditorws.cpp
+++ b/indra/newview/llscripteditorws.cpp
@@ -300,6 +300,13 @@ LLScriptEditorWSServer::ptr_t LLScriptEditorWSServer::ensureServerRunning()
     ptr_t server = std::static_pointer_cast<LLScriptEditorWSServer>(
         wsmgr.findServerByName(DEFAULT_SERVER_NAME));
 
+    if (server && !server->isRunning())
+    {
+        // thread stopped/was joined
+        wsmgr.removeServer(DEFAULT_SERVER_NAME);
+        server.reset();
+    }
+
     if (!server)
     {
         U16  port       = static_cast<U16>(gSavedSettings.getS32("ExternalWebsocketSyncPort"));

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -5872,6 +5872,11 @@ class LLToolsToggleScriptEditorServer : public view_listener_t
                 LLScriptEditorWSServer::ensureServerRunning();
             }
         }
+
+        if (gFloaterTools)
+        {
+            gFloaterTools->dirty();
+        }
         return true;
     }
 };


### PR DESCRIPTION
When 'server' was disabled, tools floater retained button state, clicking button toggled startServer, which crashed.

1. Clear server when it was stopped to enable reinit
2. Update state of tools floater.