### PR TITLE
#6204 Switch the behavior of up/down arrow buttons in the chat history(Conversation) floater.

### DIFF
--- a/indra/llui/llspinctrl.cpp
+++ b/indra/llui/llspinctrl.cpp
@@ -54,6 +54,7 @@ LLSpinCtrl::Params::Params()
     allow_text_entry("allow_text_entry", true),
     allow_digits_only("allow_digits_only", false),
     label_wrap("label_wrap", false),
+    reverse_buttons("reverse_buttons", false),
     text_enabled_color("text_enabled_color"),
     text_disabled_color("text_disabled_color"),
     up_button("up_button"),
@@ -65,6 +66,7 @@ LLSpinCtrl::LLSpinCtrl(const LLSpinCtrl::Params& p)
     mLabelBox(NULL),
     mbHasBeenSet( false ),
     mPrecision(p.decimal_digits),
+    mReverseButtons(p.reverse_buttons),
     mTextEnabledColor(p.text_enabled_color()),
     mTextDisabledColor(p.text_disabled_color())
 {
@@ -170,6 +172,8 @@ F32 clamp_precision(F32 value, S32 decimal_precision)
 
 void LLSpinCtrl::onUpBtn( const LLSD& data )
 {
+    F32 step = mReverseButtons ? -mIncrement : mIncrement;
+
     if( getEnabled() )
     {
         std::string text = mEditor->getText();
@@ -180,9 +184,8 @@ void LLSpinCtrl::onUpBtn( const LLSD& data )
             F32 cur_val = (F32) atof(text.c_str());
 
             // use getValue()/setValue() to force reload from/to control
-            F32 val = cur_val + mIncrement;
+            F32 val = cur_val + step;
             val = clamp_precision(val, mPrecision);
-            val = llmin( val, mMaxValue );
             if (val < mMinValue) val = mMinValue;
             if (val > mMaxValue) val = mMaxValue;
 
@@ -204,6 +207,8 @@ void LLSpinCtrl::onUpBtn( const LLSD& data )
 
 void LLSpinCtrl::onDownBtn( const LLSD& data )
 {
+    F32 step = mReverseButtons ? mIncrement : -mIncrement;
+
     if( getEnabled() )
     {
         std::string text = mEditor->getText();
@@ -213,10 +218,8 @@ void LLSpinCtrl::onDownBtn( const LLSD& data )
             LLLocale locale(LLLocale::USER_LOCALE);
             F32 cur_val = (F32) atof(text.c_str());
 
-            F32 val = cur_val - mIncrement;
+            F32 val = cur_val + step;
             val = clamp_precision(val, mPrecision);
-            val = llmax( val, mMinValue );
-
             if (val < mMinValue) val = mMinValue;
             if (val > mMaxValue) val = mMaxValue;
 

--- a/indra/llui/llspinctrl.h
+++ b/indra/llui/llspinctrl.h
@@ -46,6 +46,7 @@ public:
         Optional<bool> allow_text_entry;
         Optional<bool> allow_digits_only;
         Optional<bool> label_wrap;
+        Optional<bool> reverse_buttons;
 
         Optional<LLUIColor> text_enabled_color;
         Optional<LLUIColor> text_disabled_color;
@@ -107,6 +108,7 @@ private:
     void            reportInvalidData();
 
     S32             mPrecision;
+    bool            mReverseButtons;
     class LLTextBox*    mLabelBox;
 
     class LLLineEditor* mEditor;

--- a/indra/newview/skins/default/xui/en/floater_conversation_preview.xml
+++ b/indra/newview/skins/default/xui/en/floater_conversation_preview.xml
@@ -48,6 +48,7 @@
      layout="topleft"
      left_pad="0"
      name="history_page_spin"
+     reverse_buttons="true"
      top_delta="-3"
      width="50"/>
     <text


### PR DESCRIPTION
According to the ticket: make the up arrow go to the previous page and the down arrow go to the next page.