### PR TITLE
Fix SLPlugin error when it unloads libcef

### DIFF
--- a/indra/llplugin/llpluginprocesschild.cpp
+++ b/indra/llplugin/llpluginprocesschild.cpp
@@ -241,8 +241,10 @@ void LLPluginProcessChild::idle(void)
 
         case STATE_UNLOADED:
             killSockets();
-            delete mInstance;
-            mInstance = NULL;
+            // Deleting mInstance here causes apr_dso_unload() to trigger a fault on SLPlugin when it unloads libcef
+            // Instead, let the process exit on its own and allow the OS reclaim the memory to prevent the error
+            //delete mInstance;
+            //mInstance = NULL;
             setState(STATE_DONE);
             break;
 


### PR DESCRIPTION
Issue Fixed: https://github.com/secondlife/viewer/issues/1015

For years, the Windows Error reporter logs an SLPlugin.exe error regarding unloading libcef.dll, and on other platforms there is likely a similar issue happening but just silently ignored/handled.

Based off the information mentioned in the issues comment here- https://github.com/secondlife/viewer/issues/1015#issuecomment-5315373316 
I looked into it further and indeed the call to delete mInstance, which ends up calling apr_dso_unload() in the LLPluginInstance destructor, is the root cause of the fault.

However, their proposed fix of calling TerminateProcess where they suggested to, and only on Windows, is unnecessary and instead it would just be better to not call delete mInstance for all OS (as others may just silently be handling the fault), let the process gracefully exit, which then ends up calling exit(0) in the LLPluginProcessChild destructor instead due to a different issue noted about apr_dso_unload() here- https://github.com/secondlife/viewer/blob/3ac6222c27a24737b21d73a12337d39155ffc445/indra/llplugin/llpluginprocesschild.cpp#L57-L60
The OS will reclaim any memory used once it exits, and the memory footprint of not manually deleting mInstance when unloading is absolutely negligible and will only last a handful of frames at most before reclaimed by the OS after the process actually exits.

**NOTE- PLEASE READ/ANSWER:**
If instead you believe simply removing the call to apr_dso_unload() in the LLPluginInstance destructor altogether would be better, which then removes the necessary exit(0) mentioned above to fix the other deadlock problem, I can change the PR accordingly, keep the delete mInstance's, and remove the exit(0).