### PR TITLE
Fix file dialogs in fullscreen not being interactable

### DIFF
--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -2548,7 +2548,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                     // minimize the viewer and hide its owned dialog.
                     if (!activating && activating_same_process_thread)
                     {
-                        activating = TRUE;
+                        return;
                     }
 
                     if (window_imp->mFullscreen)


### PR DESCRIPTION
Issue Fixed: https://github.com/secondlife/viewer/issues/4569
Follow-up to this PR: https://github.com/secondlife/viewer/pull/6066

There is a new bug introduced in Release/26.4 as mentioned in my latest comment on the PR here- https://github.com/secondlife/viewer/pull/6193#issuecomment-5553277391, there is a bug introduced where if the viewer is in fullscreen, file dialogs can't be interacted with and prevents interacting both with the file dialog and the viewer itself as it is stuck.
This PR simply fixes that, while also retaining the original intention of the last PR to fix the other issues with file dialogs in fullscreen.