### PR TITLE
#5880 fix voice settings not reapplying when toggled to default

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -231,7 +231,8 @@ LLWebRTCVoiceClient::LLWebRTCVoiceClient() :
     mIsProcessingChannels(false),
     mIsCoroutineActive(false),
     mWebRTCPump("WebRTCClientPump"),
-    mWebRTCDeviceInterface(nullptr)
+    mWebRTCDeviceInterface(nullptr),
+    mAudioConfigInterface(nullptr)
 {
     sShuttingDown = false;
     sWebRTCTerminated = false;
@@ -483,9 +484,13 @@ void LLWebRTCVoiceClient::updateSettings()
         static LLCachedControl<F32> sMicLevel(gSavedSettings, "AudioLevelMic");
         setMicGain(sMicLevel);
 
-        llwebrtc::LLWebRTCDeviceInterface::AudioConfig config;
+        // Diff against the last-applied config, not a fresh AudioConfig, so
+        // prefs matching the struct's defaults are still detected as changes.
+        llwebrtc::LLWebRTCDeviceInterface::AudioConfig config = mAudioConfig;
 
-        bool audioConfigChanged = false;
+        // Also reapply if the interface was (re)created, since a new one's
+        // audio processing starts back at hardcoded defaults.
+        bool audioConfigChanged = (mWebRTCDeviceInterface != mAudioConfigInterface);
 
         static LLCachedControl<bool> sEchoCancellation(gSavedSettings, "VoiceEchoCancellation", true);
         if (sEchoCancellation != config.mEchoCancellation)
@@ -515,6 +520,8 @@ void LLWebRTCVoiceClient::updateSettings()
         if (audioConfigChanged && mWebRTCDeviceInterface)
         {
             mWebRTCDeviceInterface->setAudioConfig(config);
+            mAudioConfig          = config;
+            mAudioConfigInterface = mWebRTCDeviceInterface;
         }
     }
 }

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -484,6 +484,11 @@ private:
 
     llwebrtc::LLWebRTCDeviceInterface *mWebRTCDeviceInterface;
 
+    // Config + interface it was last applied to, used by updateSettings() to
+    // detect real changes and to reapply after the interface is recreated.
+    llwebrtc::LLWebRTCDeviceInterface::AudioConfig mAudioConfig;
+    llwebrtc::LLWebRTCDeviceInterface *mAudioConfigInterface;
+
     LLVoiceDeviceList mCaptureDevices;
     LLVoiceDeviceList mRenderDevices;
 


### PR DESCRIPTION
`LLWebRTCVoiceClient::updateSettings()` compared saved preferences against a freshly-constructed `AudioConfig`. If a preference matched those defaults, the code concluded nothing had changed and skipped calling `setAudioConfig()`, even though the live audio processor could be in a different state. 