### PR TITLE
#6219 Preserve Lua constant highlighting

### DIFF
--- a/indra/llui/llkeywords.cpp
+++ b/indra/llui/llkeywords.cpp
@@ -201,12 +201,7 @@ LLUIColor LLKeywords::getColorGroup(std::string_view key_in) const
         color_group = "SyntaxLslGodMode";
     }
     else if (key_in == "constants"
-             || key_in == "constants-integer"
-             || key_in == "constants-float"
-             || key_in == "constants-string"
-             || key_in == "constants-key"
-             || key_in == "constants-rotation"
-             || key_in == "constants-vector")
+             || key_in.compare(0, 10, "constants-") == 0)
     {
         color_group = "SyntaxLslConstant";
     }


### PR DESCRIPTION
Fix Lua constant syntax highlighting for types such as `boolean`, `nil`, and `number`.