### PR TITLE
Fix crash loading chatlogs with unicode in the names

### DIFF
--- a/indra/llfilesystem/lldir.cpp
+++ b/indra/llfilesystem/lldir.cpp
@@ -98,14 +98,28 @@ std::vector<std::string> LLDir::getFilesInDir(const std::string &dirname)
     if (std::filesystem::is_directory(dir_path, ec))
     {
         std::filesystem::directory_iterator end_iter;
-        for (std::filesystem::directory_iterator dir_itr(dir_path);
-             dir_itr != end_iter;
-             ++dir_itr)
+        try
         {
-            if (std::filesystem::is_regular_file(dir_itr->status()))
+            for (std::filesystem::directory_iterator dir_itr(dir_path);
+                 dir_itr != end_iter;
+                 ++dir_itr)
             {
-                v.push_back(dir_itr->path().filename().string());
+                try
+                {
+                    if (std::filesystem::is_regular_file(dir_itr->status()))
+                    {
+                        v.push_back(fsyspath(dir_itr->path().filename()).string());
+                    }
+                }
+                catch (const std::system_error& e)
+                {
+                    LL_WARNS() << "Exception accessing directory entry: " << e.what() << LL_ENDL;
+                }
             }
+        }
+        catch (const std::system_error& e)
+        {
+            LL_WARNS() << "Exception iterating directory: " << e.what() << LL_ENDL;
         }
     }
     return v;

--- a/indra/llfilesystem/lldiriterator.cpp
+++ b/indra/llfilesystem/lldiriterator.cpp
@@ -126,20 +126,27 @@ bool LLDirIterator::Impl::next(std::string &fname)
     {
         while (mIter != end_itr && !found)
         {
-            boost::smatch match;
-            std::string name = mIter->path().filename().string();
-            found = ll_regex_match(name, match, mFilterExp);
-            if (found)
+            try
             {
-                fname = name;
+                boost::smatch match;
+                std::string name = fsyspath(mIter->path().filename()).string();
+                found = ll_regex_match(name, match, mFilterExp);
+                if (found)
+                {
+                    fname = name;
+                }
+            }
+            catch (const std::system_error& e)
+            {
+                LL_WARNS() << "Exception accessing directory entry: " << e.what() << LL_ENDL;
             }
 
             ++mIter;
         }
     }
-    catch (const fs::filesystem_error& e)
+    catch (const std::system_error& e)
     {
-        LL_WARNS() << e.what() << LL_ENDL;
+        LL_WARNS() << "Exception iterating directory: " << e.what() << LL_ENDL;
     }
 
     return found;


### PR DESCRIPTION
Issue Fixed: https://github.com/secondlife/viewer/issues/6276

This PR simply fixes the crash caused when chat history is loaded that contains unicode characters in the filename.
This crash is new in 26.4 because boost::filesystem was replaced with std::filesystem which throws an exception instead of just returning a string of utf8 data like boost did.

I have it exception handling both on outside the loop and inside now for both functions. Outside the loop catches any possible exceptions thrown from iterating a fs::directory_iterator (as they can throw OS API errors), and the inside exception handles the string conversions and status check.