### PR TITLE
Fix possible crash getting energy attribute for keywords

### DIFF
--- a/indra/llui/llkeywords.cpp
+++ b/indra/llui/llkeywords.cpp
@@ -364,7 +364,7 @@ void LLKeywords::processTokensGroup(const LLSD& tokens, std::string_view group)
                         break;
                     case LLKeywordToken::TT_FUNCTION:
                         tooltip = getAttribute("return") + " " + outer_itr->first + "(" + getArguments(arguments) + ");";
-                        if (std::stod(getAttribute("energy")) >= 0)
+                        if (getAttribute("energy").empty() || std::stod(getAttribute("energy")) >= 0)
                         {
                             tooltip.append("\nEnergy: ");
                             tooltip.append(getAttribute("energy").empty() ? "0.0" : getAttribute("energy"));
@@ -373,6 +373,7 @@ void LLKeywords::processTokensGroup(const LLSD& tokens, std::string_view group)
                         {
                             tooltip += ", Sleep: " + getAttribute("sleep");
                         }
+                        break;
                     default:
                         break;
                 }


### PR DESCRIPTION
Issue Fixed: https://github.com/secondlife/viewer/issues/6285

This PR simply checks if the energy attribute is empty before calling std::stod on the value to prevent an exception being thrown on an empty string.

Additionally, added the missing break that was causing a [ES.78 warning](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es78-dont-rely-on-implicit-fallthrough-in-switch-statements).

**Note:** If you believe it would be best to just drop the empty and std::stod check entirely, which returns it to how it used to be before 26.4, just let me know and I'll change it.