### PR TITLE
Fix crash with the DisplayTimecode function

### DIFF
--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -2874,6 +2874,12 @@ void LLViewerWindow::draw()
         LLView::sDirtyRect = getWindowRectScaled();
     }
 
+    // Draw all nested UI views.
+    // No translation needed, this view is glued to 0,0
+
+    gUIProgram.bind();
+    gGL.color4f(1, 1, 1, 1);
+
     // HACK for timecode debugging
     if (gSavedSettings.getBOOL("DisplayTimecode"))
     {
@@ -2890,12 +2896,6 @@ void LLViewerWindow::draw()
             LLColor4( 1.f, 1.f, 1.f, 1.f ),
             LLFontGL::LEFT, LLFontGL::TOP);
     }
-
-    // Draw all nested UI views.
-    // No translation needed, this view is glued to 0,0
-
-    gUIProgram.bind();
-    gGL.color4f(1, 1, 1, 1);
 
     gGL.pushMatrix();
     LLUI::pushMatrix();


### PR DESCRIPTION
## Description

Currently, attempting to display the timecode using the `DisplayTimecode` function will crash the viewer because it attempts to use UI functions before the UI shader program is bound.
This moves the binding of the UI shader before the timecode display function calls, so that the program is bound before attempting to call UI functions.

Specific crash is:
```
ERROR # llrender/llrender.cpp(1498) flush : ASSERT (LLGLSLShader::sCurBoundShaderPtr != nullptr)
```

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

Test case:
1. Launch a release viewer
2. Login
3. Enable `DisplayTimecode` in debug settings
4. Confirm crash on production
5. Launch viewer with code patch
6. Login
7. Enable `DisplayTimecode` in debug settings
8. Confirm viewer no longer crashes