### PR TITLE
Fix LLWorld SpaceTime updating

### DIFF
--- a/indra/llmessage/CMakeLists.txt
+++ b/indra/llmessage/CMakeLists.txt
@@ -38,6 +38,7 @@ set(llmessage_SOURCE_FILES
     llioutil.cpp
     llmessagebuilder.cpp
     llmessageconfig.cpp
+    llmessagejsonbuilder.cpp
     llmessagereader.cpp
     llmessagetemplate.cpp
     llmessagetemplateparser.cpp
@@ -122,6 +123,7 @@ set(llmessage_HEADER_FILES
     llloginflags.h
     llmessagebuilder.h
     llmessageconfig.h
+    llmessagejsonbuilder.h
     llmessagereader.h
     llmessagetemplate.h
     llmessagetemplateparser.h

--- a/indra/llmessage/llmessagejsonbuilder.cpp
+++ b/indra/llmessage/llmessagejsonbuilder.cpp
@@ -1,0 +1,507 @@
+/**
+ * @file llmessagejsonbuilder.cpp
+ * @brief DEBUG/TESTING ONLY: build a message, or simulate receiving one,
+ * from a JSON description.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2026, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#include "linden_common.h"
+
+#include "llmessagejsonbuilder.h"
+
+#include <boost/json.hpp>
+
+#include "message.h"
+#include "llmessagetemplate.h"
+#include "lltemplatemessagereader.h"
+#include "llmessagebuilder.h"
+#include "lluuid.h"
+#include "llquaternion.h"
+#include "v3math.h"
+#include "v3dmath.h"
+#include "v4math.h"
+#include "net.h"
+
+namespace
+{
+    // Parses an integer field value that may be a JSON number, or a JSON
+    // string in decimal / "0x.." hex / "0b.." binary form, optionally
+    // sign-prefixed, e.g. "12345", "0xabcd1234", "-0xabcd1234", "0b1110111".
+    // The sign, if any, is applied by negating the parsed magnitude, giving
+    // the correct two's-complement bit pattern once the caller truncates
+    // `out` to the field's actual width.
+    bool parseJsonInteger(const boost::json::value& v, U64& out)
+    {
+        if (v.is_int64())  { out = (U64)v.get_int64();  return true; }
+        if (v.is_uint64()) { out = v.get_uint64();       return true; }
+        if (v.is_double())  { out = (U64)(S64)v.get_double(); return true; }
+        if (!v.is_string()) return false;
+
+        std::string s(v.get_string().c_str());
+        size_t pos = 0;
+        bool negative = false;
+        if (pos < s.size() && (s[pos] == '+' || s[pos] == '-'))
+        {
+            negative = (s[pos] == '-');
+            ++pos;
+        }
+
+        int base = 10;
+        if (pos + 1 < s.size() && s[pos] == '0' && (s[pos + 1] == 'x' || s[pos + 1] == 'X'))
+        {
+            base = 16;
+            pos += 2;
+        }
+        else if (pos + 1 < s.size() && s[pos] == '0' && (s[pos + 1] == 'b' || s[pos + 1] == 'B'))
+        {
+            base = 2;
+            pos += 2;
+        }
+
+        if (pos >= s.size()) return false;
+
+        U64 magnitude = 0;
+        for (; pos < s.size(); ++pos)
+        {
+            char c = s[pos];
+            int digit;
+            if (c >= '0' && c <= '9')      digit = c - '0';
+            else if (c >= 'a' && c <= 'f') digit = 10 + (c - 'a');
+            else if (c >= 'A' && c <= 'F') digit = 10 + (c - 'A');
+            else return false;
+            if (digit >= base) return false;
+            magnitude = magnitude * (U64)base + (U64)digit;
+        }
+
+        out = negative ? (U64)(-(S64)magnitude) : magnitude;
+        return true;
+    }
+
+    // Collects a JSON array of numbers as F64s. Used for vector/quaternion
+    // fields, which are always "an array of floats".
+    bool getNumberArray(const boost::json::value& v, std::vector<F64>& out)
+    {
+        if (!v.is_array()) return false;
+        out.clear();
+        for (const boost::json::value& e : v.get_array())
+        {
+            if (e.is_double())      out.push_back(e.get_double());
+            else if (e.is_int64())  out.push_back((F64)e.get_int64());
+            else if (e.is_uint64()) out.push_back((F64)e.get_uint64());
+            else return false;
+        }
+        return true;
+    }
+
+    // Decodes "\xHH" escapes (produced after JSON's own string decoding,
+    // so a literal backslash must already be doubled at the JSON layer) to
+    // single raw bytes; every other character passes through as its raw
+    // byte(s) unchanged. A plain string with no "\x" in it decodes to
+    // itself, which is what makes a plain JSON string usable as-is for a
+    // text field.
+    void decodeBinaryEscapes(const std::string& in, std::vector<U8>& out)
+    {
+        out.clear();
+        out.reserve(in.size());
+        auto hex_val = [](char c) -> int
+        {
+            if (c >= '0' && c <= '9') return c - '0';
+            if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+            if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+            return -1;
+        };
+        for (size_t i = 0; i < in.size(); )
+        {
+            if (in[i] == '\\' && i + 3 < in.size() && (in[i + 1] == 'x' || in[i + 1] == 'X'))
+            {
+                int hi = hex_val(in[i + 2]);
+                int lo = hex_val(in[i + 3]);
+                if (hi >= 0 && lo >= 0)
+                {
+                    out.push_back((U8)((hi << 4) | lo));
+                    i += 4;
+                    continue;
+                }
+            }
+            out.push_back((U8)in[i]);
+            ++i;
+        }
+    }
+
+    // Every failure path below logs why and returns false. A field that
+    // fails to convert must NOT be silently skipped: LLTemplateMessageBuilder
+    // treats every declared field as required and hard-LL_ERRS's (aborting
+    // the whole viewer) if buildMessage() finds one unset, so the only safe
+    // response to a bad test payload is to abort the entire build before
+    // buildMessage() is ever reached -- never partially build one.
+    bool addBinaryField(LLMessageSystem* msg, const char* varname, const boost::json::value& v,
+                         bool is_fixed, S32 fixed_size)
+    {
+        std::vector<U8> bytes;
+        bool as_string = false;
+
+        if (v.is_array())
+        {
+            for (const boost::json::value& e : v.get_array())
+            {
+                if (!e.is_int64() && !e.is_uint64())
+                {
+                    LL_WARNS("Messaging") << "LLMessageJsonBuilder: non-integer byte in binary array for field '"
+                        << varname << "'" << LL_ENDL;
+                    return false;
+                }
+                bytes.push_back((U8)(e.is_int64() ? e.get_int64() : (S64)e.get_uint64()));
+            }
+        }
+        else if (v.is_string())
+        {
+            as_string = true;
+            decodeBinaryEscapes(std::string(v.get_string().c_str()), bytes);
+        }
+        else
+        {
+            LL_WARNS("Messaging") << "LLMessageJsonBuilder: field '" << varname
+                << "' needs a byte array or a string" << LL_ENDL;
+            return false;
+        }
+
+        if (is_fixed)
+        {
+            if ((S32)bytes.size() != fixed_size)
+            {
+                LL_WARNS("Messaging") << "LLMessageJsonBuilder: field '" << varname << "' needs exactly "
+                    << fixed_size << " bytes, got " << bytes.size() << LL_ENDL;
+                return false;
+            }
+            msg->addBinaryDataFast(varname, bytes.data(), fixed_size);
+        }
+        else if (as_string)
+        {
+            // Plain text convention: include the trailing NUL a normal
+            // string field would get, using the size-based overload so any
+            // "\xHH"-decoded binary bytes still survive intact.
+            msg->addStringFast(varname, std::string(bytes.begin(), bytes.end()));
+        }
+        else
+        {
+            msg->addBinaryDataFast(varname, bytes.empty() ? nullptr : bytes.data(), (S32)bytes.size());
+        }
+        return true;
+    }
+
+    bool addField(LLMessageSystem* msg, const char* varname, const boost::json::value& v,
+                  EMsgVariableType type, S32 size)
+    {
+        switch (type)
+        {
+        case MVT_U8:
+        case MVT_U16:
+        case MVT_U32:
+        case MVT_U64:
+        case MVT_S8:
+        case MVT_S16:
+        case MVT_S32:
+        {
+            U64 n = 0;
+            if (!parseJsonInteger(v, n))
+            {
+                LL_WARNS("Messaging") << "LLMessageJsonBuilder: bad integer for field '" << varname << "'" << LL_ENDL;
+                return false;
+            }
+            switch (type)
+            {
+            case MVT_U8:  msg->addU8Fast(varname, (U8)n); break;
+            case MVT_U16: msg->addU16Fast(varname, (U16)n); break;
+            case MVT_U32: msg->addU32Fast(varname, (U32)n); break;
+            case MVT_U64: msg->addU64Fast(varname, n); break;
+            case MVT_S8:  msg->addS8Fast(varname, (S8)n); break;
+            case MVT_S16: msg->addS16Fast(varname, (S16)n); break;
+            case MVT_S32: msg->addS32Fast(varname, (S32)n); break;
+            default: break;
+            }
+            return true;
+        }
+
+        case MVT_F32:
+        case MVT_F64:
+        {
+            if (!v.is_double() && !v.is_int64() && !v.is_uint64())
+            {
+                LL_WARNS("Messaging") << "LLMessageJsonBuilder: bad float for field '" << varname << "'" << LL_ENDL;
+                return false;
+            }
+            F64 f = v.is_double() ? v.get_double() : v.is_int64() ? (F64)v.get_int64() : (F64)v.get_uint64();
+            if (type == MVT_F32) msg->addF32Fast(varname, (F32)f);
+            else                 msg->addF64Fast(varname, f);
+            return true;
+        }
+
+        case MVT_BOOL:
+        {
+            bool b = v.is_bool()    ? v.get_bool()
+                   : v.is_int64()   ? (v.get_int64() != 0)
+                   : v.is_uint64()  ? (v.get_uint64() != 0)
+                   : v.is_double()  ? (v.get_double() != 0.0)
+                   : false;
+            msg->addBOOLFast(varname, b);
+            return true;
+        }
+
+        case MVT_LLUUID:
+        {
+            if (!v.is_string())
+            {
+                LL_WARNS("Messaging") << "LLMessageJsonBuilder: field '" << varname << "' needs a UUID string" << LL_ENDL;
+                return false;
+            }
+            LLUUID id;
+            if (!LLUUID::parseUUID(std::string(v.get_string().c_str()), &id))
+            {
+                LL_WARNS("Messaging") << "LLMessageJsonBuilder: field '" << varname << "' is not a valid UUID" << LL_ENDL;
+                return false;
+            }
+            msg->addUUIDFast(varname, id);
+            return true;
+        }
+
+        case MVT_IP_ADDR:
+        {
+            U32 ip = 0;
+            if (v.is_string())      ip = ip_string_to_u32(v.get_string().c_str());
+            else if (v.is_int64())  ip = (U32)v.get_int64();
+            else if (v.is_uint64()) ip = (U32)v.get_uint64();
+            else
+            {
+                LL_WARNS("Messaging") << "LLMessageJsonBuilder: field '" << varname
+                    << "' needs a number or a dotted-quad string" << LL_ENDL;
+                return false;
+            }
+            msg->addIPAddrFast(varname, ip);
+            return true;
+        }
+
+        case MVT_IP_PORT:
+        {
+            U64 n = 0;
+            if (!parseJsonInteger(v, n))
+            {
+                LL_WARNS("Messaging") << "LLMessageJsonBuilder: bad port for field '" << varname << "'" << LL_ENDL;
+                return false;
+            }
+            msg->addIPPortFast(varname, (U16)n);
+            return true;
+        }
+
+        case MVT_LLVector3:
+        case MVT_LLVector3d:
+        case MVT_LLVector4:
+        {
+            std::vector<F64> nums;
+            S32 wanted = (type == MVT_LLVector4) ? 4 : 3;
+            if (!getNumberArray(v, nums) || (S32)nums.size() != wanted)
+            {
+                LL_WARNS("Messaging") << "LLMessageJsonBuilder: field '" << varname << "' needs an array of "
+                    << wanted << " floats" << LL_ENDL;
+                return false;
+            }
+            if (type == MVT_LLVector3)
+            {
+                F32 arr[3] = { (F32)nums[0], (F32)nums[1], (F32)nums[2] };
+                msg->addVector3Fast(varname, LLVector3(arr));
+            }
+            else if (type == MVT_LLVector3d)
+            {
+                F64 arr[3] = { nums[0], nums[1], nums[2] };
+                msg->addVector3dFast(varname, LLVector3d(arr));
+            }
+            else
+            {
+                F32 arr[4] = { (F32)nums[0], (F32)nums[1], (F32)nums[2], (F32)nums[3] };
+                msg->addVector4Fast(varname, LLVector4(arr));
+            }
+            return true;
+        }
+
+        case MVT_LLQuaternion:
+        {
+            std::vector<F64> nums;
+            if (!getNumberArray(v, nums) || (nums.size() != 3 && nums.size() != 4))
+            {
+                LL_WARNS("Messaging") << "LLMessageJsonBuilder: field '" << varname
+                    << "' needs an array of 3 or 4 floats" << LL_ENDL;
+                return false;
+            }
+            F32 x = (F32)nums[0], y = (F32)nums[1], z = (F32)nums[2];
+            F32 w = (nums.size() == 4) ? (F32)nums[3]
+                                        : sqrtf(llmax(0.f, 1.f - x * x - y * y - z * z));
+            msg->addQuatFast(varname, LLQuaternion(x, y, z, w));
+            return true;
+        }
+
+        case MVT_VARIABLE:
+            return addBinaryField(msg, varname, v, false, size);
+
+        case MVT_FIXED:
+            return addBinaryField(msg, varname, v, true, size);
+
+        default:
+            LL_WARNS("Messaging") << "LLMessageJsonBuilder: field '" << varname
+                << "' has unsupported wire type " << (S32)type << " -- skipped" << LL_ENDL;
+            return false;
+        }
+    }
+}
+
+bool LLMessageJsonBuilder::build(LLMessageSystem* msg, const std::string& msg_name,
+                                  const boost::json::value& body)
+{
+    if (!body.is_object())
+    {
+        LL_WARNS("Messaging") << "LLMessageJsonBuilder: body for '" << msg_name << "' is not a JSON object" << LL_ENDL;
+        return false;
+    }
+
+    char* name = LLMessageStringTable::getInstance()->getString(msg_name.c_str());
+    LLMessageSystem::message_template_name_map_t::const_iterator tmpl_it = msg->mMessageTemplates.find(name);
+    if (tmpl_it == msg->mMessageTemplates.end())
+    {
+        LL_WARNS("Messaging") << "LLMessageJsonBuilder: unknown message '" << msg_name << "'" << LL_ENDL;
+        return false;
+    }
+    const LLMessageTemplate* msg_template = tmpl_it->second;
+
+    // Every Single/Multiple block the template declares is required by
+    // LLTemplateMessageBuilder -- it hard-LL_ERRS's (aborting the whole
+    // viewer, not just this call) if buildMessage() below finds one whose
+    // fields were never set. A block entirely missing from `body` would
+    // never even enter the main loop below to be caught there, so check for
+    // that up front; per-field completeness for a block that *is* present
+    // is checked in the main loop, for every instance, further down.
+    for (LLMessageBlock* block_template_item : msg_template->mMemberBlocks)
+    {
+        if (block_template_item->mType == MBT_VARIABLE)
+        {
+            continue; // 0 instances is valid for a repeated/optional block
+        }
+        std::string block_name(block_template_item->mName);
+        if (!body.as_object().if_contains(block_name))
+        {
+            LL_WARNS("Messaging") << "LLMessageJsonBuilder: message '" << msg_name
+                << "' is missing required block '" << block_name << "'" << LL_ENDL;
+            return false;
+        }
+    }
+
+    msg->newMessageFast(name);
+
+    for (const boost::json::key_value_pair& block_kv : body.as_object())
+    {
+        std::string block_name(block_kv.key().data(), block_kv.key().size());
+        if (block_name == "Name") continue;
+
+        char* block_name_interned = LLMessageStringTable::getInstance()->getString(block_name.c_str());
+        const LLMessageBlock* block_template = msg_template->getBlock(block_name_interned);
+        if (!block_template)
+        {
+            LL_WARNS("Messaging") << "LLMessageJsonBuilder: unknown block '" << block_name
+                << "' in message '" << msg_name << "'" << LL_ENDL;
+            return false;
+        }
+
+        const boost::json::value& block_val = block_kv.value();
+        bool is_array = block_val.is_array();
+        size_t num_instances = is_array ? block_val.get_array().size() : 1;
+
+        if (block_template->mType == MBT_MULTIPLE && (S32)num_instances != block_template->mNumber)
+        {
+            LL_WARNS("Messaging") << "LLMessageJsonBuilder: block '" << block_name << "' in message '" << msg_name
+                << "' needs exactly " << block_template->mNumber << " instance(s), got " << num_instances << LL_ENDL;
+            return false;
+        }
+
+        for (size_t i = 0; i < num_instances; ++i)
+        {
+            msg->nextBlockFast(block_name_interned);
+            const boost::json::value& block_data = is_array ? block_val.get_array()[i] : block_val;
+            if (!block_data.is_object())
+            {
+                LL_WARNS("Messaging") << "LLMessageJsonBuilder: instance of block '" << block_name
+                    << "' is not a JSON object" << LL_ENDL;
+                return false;
+            }
+
+            for (LLMessageVariable* var_template_item : block_template->mMemberVariables)
+            {
+                if (!block_data.as_object().if_contains(var_template_item->getName()))
+                {
+                    LL_WARNS("Messaging") << "LLMessageJsonBuilder: instance of block '" << block_name
+                        << "' in message '" << msg_name << "' is missing required field '"
+                        << var_template_item->getName() << "'" << LL_ENDL;
+                    return false;
+                }
+            }
+
+            for (const boost::json::key_value_pair& field_kv : block_data.as_object())
+            {
+                std::string var_name(field_kv.key().data(), field_kv.key().size());
+                char* var_name_interned = LLMessageStringTable::getInstance()->getString(var_name.c_str());
+                const LLMessageVariable* var_template = block_template->getVariable(var_name_interned);
+                if (!var_template)
+                {
+                    LL_WARNS("Messaging") << "LLMessageJsonBuilder: unknown field '" << var_name
+                        << "' in block '" << block_name << "'" << LL_ENDL;
+                    return false;
+                }
+                if (!addField(msg, var_name_interned, field_kv.value(), var_template->getType(), var_template->getSize()))
+                {
+                    return false;
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
+bool LLMessageJsonBuilder::simulateReceived(LLMessageSystem* msg, const std::string& msg_name,
+                                             const boost::json::value& body, const LLHost& host)
+{
+    if (!build(msg, msg_name, body))
+    {
+        return false;
+    }
+
+    U8 buffer[MAX_BUFFER_SIZE];
+    U32 size = msg->mMessageBuilder->buildMessage(buffer, MAX_BUFFER_SIZE, 0);
+
+    if (!msg->mTemplateMessageReader->validateMessage(buffer, (S32)size, host, true))
+    {
+        LL_WARNS("Messaging") << "LLMessageJsonBuilder: built message for '" << msg_name
+            << "' failed to validate" << LL_ENDL;
+        return false;
+    }
+    msg->mTemplateMessageReader->readMessage(buffer, host);
+
+    LockMessageReader lock(msg->mMessageReader, msg->mTemplateMessageReader);
+    return msg->callHandler(LLMessageStringTable::getInstance()->getString(msg_name.c_str()), true, msg);
+}

--- a/indra/llmessage/llmessagejsonbuilder.h
+++ b/indra/llmessage/llmessagejsonbuilder.h
@@ -1,0 +1,71 @@
+/**
+ * @file llmessagejsonbuilder.h
+ * @brief DEBUG/TESTING ONLY: build a message, or simulate receiving one,
+ * from a JSON description.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2026, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#ifndef LL_LLMESSAGEJSONBUILDER_H
+#define LL_LLMESSAGEJSONBUILDER_H
+
+#include <string>
+#include <boost/json/fwd.hpp>
+
+class LLMessageSystem;
+class LLHost;
+
+// DEBUG/TESTING ONLY -- not used in production.
+//
+// Lets test/QA tooling fabricate an arbitrary message from a JSON
+// description instead of one built by real client code, so client-side
+// handling of a message (or a message the simulator understands but the
+// viewer's UI has no sender for yet) can be exercised ahead of real support
+// existing on the other end. Driven by the "#PKT<"/"#PKT>" chat convention
+// process_chat_from_simulator() recognizes on llOwnerSay in
+// indra/newview/llviewermessage.cpp -- see there for the trigger, and the
+// .cpp here for the JSON body format and per-field type-conversion rules.
+class LLMessageJsonBuilder
+{
+public:
+    // Builds a message of template `msg_name` into `msg` (calls
+    // msg->newMessageFast() itself) from `body`, a JSON object whose "Name"
+    // key (if present) is ignored -- the caller already used it to choose
+    // msg_name -- and whose other keys must each name a block in that
+    // template: an object for a single block, or an array of objects for a
+    // multiple/variable block, repeating the block once per array entry.
+    // Field values are plain JSON with no explicit wire-type tag; the type
+    // is looked up from the message template and used to convert the value
+    // automatically. Returns false, after logging why, if the template, a
+    // named block, or a named field can't be resolved, or a value can't be
+    // converted to its field's wire type.
+    static bool build(LLMessageSystem* msg, const std::string& msg_name,
+                       const boost::json::value& body);
+
+    // As build(), then loops the built message back through the local
+    // decode path and invokes msg_name's already-registered handler
+    // directly, exactly as if it had just been received from `host`.
+    static bool simulateReceived(LLMessageSystem* msg, const std::string& msg_name,
+                                  const boost::json::value& body, const LLHost& host);
+};
+
+#endif // LL_LLMESSAGEJSONBUILDER_H

--- a/indra/llmessage/message.h
+++ b/indra/llmessage/message.h
@@ -999,6 +999,11 @@ private:
 
     friend class LLMessageHandlerBridge;
     friend class LockMessageChecker;
+    // DEBUG/TESTING ONLY: lets LLMessageJsonBuilder (llmessagejsonbuilder.h)
+    // fabricate a message from a JSON description and, when simulating a
+    // received message, loop it back through the local decode path and
+    // invoke its registered handler -- see that class for details.
+    friend class LLMessageJsonBuilder;
 
     bool callHandler(const char *name, bool trustedSource,
                      LLMessageSystem* msg);

--- a/indra/lscript/liblscript/CMakeLists.txt
+++ b/indra/lscript/liblscript/CMakeLists.txt
@@ -1,0 +1,70 @@
+# -*- cmake -*-
+
+project(liblscript)
+
+include(00-Common)
+include(LLCommon)
+include(LLMath)
+include(LScript)
+
+set(liblscript_SOURCE_FILES
+    ../lscript_library/lscript_alloc.cpp
+    ../lscript_library/lscript_export.cpp
+    ../lscript_library/lscript_library.cpp
+    ../lscript_execute/llscriptresource.cpp
+    ../lscript_execute/llscriptresourceconsumer.cpp
+    ../lscript_execute/llscriptresourcepool.cpp
+    ../lscript_execute/lscript_execute.cpp
+    ../lscript_execute/lscript_heapruntime.cpp
+    ../lscript_execute/lscript_readlso.cpp
+    )
+
+set(liblscript_HEADER_FILES
+    CMakeLists.txt
+    liblscript.h
+    ../llscriptresource.h
+    ../llscriptresourceconsumer.h
+    ../llscriptresourcepool.h
+    ../lscript_alloc.h
+    ../lscript_byteconvert.h
+    ../lscript_byteformat.h
+    ../lscript_execute.h
+    ../lscript_export.h
+    ../lscript_library.h
+    ../lscript_rt_interface.h
+    )
+
+set_source_files_properties(${liblscript_HEADER_FILES}
+                            PROPERTIES HEADER_FILE_ONLY TRUE)
+
+list(APPEND liblscript_SOURCE_FILES ${liblscript_HEADER_FILES})
+
+add_library(liblscript STATIC ${liblscript_SOURCE_FILES})
+
+target_include_directories(liblscript
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+    PRIVATE
+        ${LLCOMMON_INCLUDE_DIRS}
+        ${LLMATH_INCLUDE_DIRS}
+        ${LSCRIPT_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../lscript_compile
+        ${CMAKE_CURRENT_SOURCE_DIR}/../lscript_execute
+        ${CMAKE_CURRENT_SOURCE_DIR}/../lscript_library
+        ${CMAKE_SOURCE_DIR}/llcommon
+        ${CMAKE_SOURCE_DIR}/llmath
+    )
+target_include_directories(liblscript SYSTEM PRIVATE
+    ${LLCOMMON_SYSTEM_INCLUDE_DIRS}
+    )
+
+target_link_libraries(liblscript
+    PUBLIC
+        llcommon
+        llmath
+    )
+
+set_target_properties(liblscript PROPERTIES
+    PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/liblscript.h;${CMAKE_CURRENT_SOURCE_DIR}/../lscript_library.h;${CMAKE_CURRENT_SOURCE_DIR}/../lscript_execute.h;${CMAKE_SOURCE_DIR}/llcommon/lluuid.h"
+    )

--- a/indra/lscript/liblscript/liblscript.h
+++ b/indra/lscript/liblscript/liblscript.h
@@ -1,0 +1,9 @@
+#ifndef LL_LIBLSCRIPT_H
+#define LL_LIBLSCRIPT_H
+
+#include "lluuid.h"
+#include "lscript_library.h"
+#include "lscript_execute.h"
+#include "lscript_rt_interface.h"
+
+#endif

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -2117,6 +2117,17 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>DebugInjectFakePackets</key>
+    <map>
+      <key>Comment</key>
+      <string>Testing only: let llOwnerSay chat starting with #PKT&lt; or #PKT&gt; fabricate a fake network message from JSON, either simulating receiving it or sending it to the region. Leave off outside of scripted test sessions.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
     <key>DebugPermissions</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -5309,7 +5309,7 @@ void LLAppViewer::idle()
     {
         LL_PROFILE_ZONE_NAMED_CATEGORY_NETWORK("network"); //LL_RECORD_BLOCK_TIME(FTM_NETWORK);
         // Update spaceserver timeinfo
-        LLWorld::getInstance()->setSpaceTimeUSec(LLWorld::getInstance()->getSpaceTimeUSec() + LLUnits::Seconds::fromValue(dt_raw));
+        LLWorld::getInstance()->setSpaceTimeUSec(LLWorld::getInstance()->getSpaceTimeUSec() + (U64)(dt_raw * 1.0e6));
 
 
         //////////////////////////////////////

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -74,6 +74,7 @@
 #include "llinventorypanel.h"
 #include "llfloaterimnearbychat.h"
 #include "llmarketplacefunctions.h"
+#include "llmessagejsonbuilder.h"
 #include "llnotifications.h"
 #include "llnotificationsutil.h"
 #include "llpanelgrouplandmoney.h"
@@ -2340,6 +2341,74 @@ void translateFailure(LLChat chat, LLSD toastArgs, int status, const std::string
 }
 
 
+// DEBUG/TESTING ONLY. Not used in production.
+//
+// Recognizes the "#PKT<"/"#PKT>" convention on llOwnerSay chat (see the
+// CHAT_TYPE_OWNER check at this function's only call site) that lets a
+// script fabricate a fake network packet for testing -- e.g. simulating the
+// viewer receiving a message the simulator can't send yet, or the viewer
+// sending one its UI has no builder for yet. Format:
+//   #PKT<{"Name":"MessageName", "SomeBlock":{...}, "SomeRepeatedBlock":[{...},{...}]}
+// "#PKT<" simulates *receiving* MessageName (built from the JSON, then run
+// through the message's real, already-registered handler). "#PKT>" builds
+// it the same way and actually *sends* it to the current region. Field
+// values need no wire-type tag -- see llmessagejsonbuilder.h/.cpp for the
+// per-field conversion rules, pulled from the message template. "@AGENTID@"
+// and "@SESSIONID@" anywhere in the JSON text are substituted with the
+// viewer's current agent/session UUID (as plain text, before parsing) so a
+// test payload can refer to "this session" without hardcoding a UUID.
+// Returns true if `mesg` matched the convention at all (so the caller
+// suppresses normal chat display even on a parse/build failure, which is
+// logged here).
+bool try_process_fake_packet_chat(const std::string& mesg)
+{
+    static const std::string RECEIVE_PREFIX("#PKT<");
+    static const std::string SEND_PREFIX("#PKT>");
+
+    bool is_receive = mesg.compare(0, RECEIVE_PREFIX.size(), RECEIVE_PREFIX) == 0;
+    bool is_send = !is_receive && mesg.compare(0, SEND_PREFIX.size(), SEND_PREFIX) == 0;
+    if (!is_receive && !is_send)
+    {
+        return false;
+    }
+
+    if (!gSavedSettings.getBOOL("DebugInjectFakePackets"))
+    {
+        return false;
+    }
+
+    std::string json_text = mesg.substr(RECEIVE_PREFIX.size());
+    LLStringUtil::replaceString(json_text, "@AGENTID@", gAgent.getID().asString());
+    LLStringUtil::replaceString(json_text, "@SESSIONID@", gAgent.getSessionID().asString());
+
+    boost::system::error_code ec;
+    boost::json::value body = boost::json::parse(json_text, ec);
+    if (ec.failed() || !body.is_object())
+    {
+        LL_WARNS("Messaging") << "Fake packet chat: invalid JSON: " << mesg << LL_ENDL;
+        return true;
+    }
+
+    const boost::json::value* name_val = body.as_object().if_contains("Name");
+    if (!name_val || !name_val->is_string())
+    {
+        LL_WARNS("Messaging") << "Fake packet chat: missing \"Name\": " << mesg << LL_ENDL;
+        return true;
+    }
+    std::string msg_name(name_val->get_string().c_str());
+
+    if (is_receive)
+    {
+        LLMessageJsonBuilder::simulateReceived(gMessageSystem, msg_name, body, gMessageSystem->getSender());
+    }
+    else if (LLMessageJsonBuilder::build(gMessageSystem, msg_name, body))
+    {
+        gMessageSystem->sendMessage(gAgent.getRegionHost());
+    }
+
+    return true;
+}
+
 void process_chat_from_simulator(LLMessageSystem *msg, void **user_data)
 {
     if (gNonInteractive)
@@ -2458,6 +2527,12 @@ void process_chat_from_simulator(LLMessageSystem *msg, void **user_data)
 
         color.setVec(1.f,1.f,1.f,1.f);
         msg->getStringFast(_PREHASH_ChatData, _PREHASH_Message, mesg);
+
+        if (chat.mChatType == CHAT_TYPE_OWNER && try_process_fake_packet_chat(mesg))
+        {
+            return;
+        }
+
         // Preserve tabs from scripts by expanding them to spaces before any sanitization/formatting.
         LLStringUtil::replaceTabsWithSpaces(mesg, 4);
 


### PR DESCRIPTION
## Description
Another tiny fix.

When attempting to make a animation sync, I noticed that there is a bug with LLWorld's `getSpaceTimeUSec()` function.
Presently, SpaceTime is stored as a U64, while LLUnit is F32. Because of the way C++ is compiling the code, it converts the U64 to a F32 before doing the addition, and ends up storing a invalid number for SpaceTime.
We could increase LLUnit to a F64, but I'm unsure of issues that may cause, or if we would still lose precision eventually, so doing it this way would potentially the better option.

Looking around the code, I don't see anywhere that this is used, as far as I am aware, it is completely unused, but I'm fixing it because I need to use it for feature development, and also it'd be nice if someone else comes around needing to use it doesn't spend time debugging why `getSpaceTimeUSec()` doesn't update properly.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

Not really a way to test this without a debug UI / logger, but the problem is it won't demonstrate the before and after.
I give my word that it was broken before hand, and this fixes it though.