### PR TITLE
Fix LLWorld SpaceTime updating

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -5309,7 +5309,7 @@ void LLAppViewer::idle()
     {
         LL_PROFILE_ZONE_NAMED_CATEGORY_NETWORK("network"); //LL_RECORD_BLOCK_TIME(FTM_NETWORK);
         // Update spaceserver timeinfo
-        LLWorld::getInstance()->setSpaceTimeUSec(LLWorld::getInstance()->getSpaceTimeUSec() + LLUnits::Seconds::fromValue(dt_raw));
+        LLWorld::getInstance()->setSpaceTimeUSec(LLWorld::getInstance()->getSpaceTimeUSec() + (U64)(dt_raw * 1000000.0));
 
 
         //////////////////////////////////////

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -5309,7 +5309,7 @@ void LLAppViewer::idle()
     {
         LL_PROFILE_ZONE_NAMED_CATEGORY_NETWORK("network"); //LL_RECORD_BLOCK_TIME(FTM_NETWORK);
         // Update spaceserver timeinfo
-        LLWorld::getInstance()->setSpaceTimeUSec(LLWorld::getInstance()->getSpaceTimeUSec() + (U64)(dt_raw * 1000000.0));
+        LLWorld::getInstance()->setSpaceTimeUSec(LLWorld::getInstance()->getSpaceTimeUSec() + (U64)(dt_raw * USEC_PER_SEC));
 
 
         //////////////////////////////////////

--- a/indra/newview/llworld.h
+++ b/indra/newview/llworld.h
@@ -199,6 +199,9 @@ private:
     S32 mLastPacketsOut;
     S32 mLastPacketsLost;
     U32 mNumOfActiveCachedObjects;
+    
+    // Authoritative time source from the simulator
+    // Not currently used by viewer but might be in use by 3p branches
     U64MicrosecondsImplicit mSpaceTimeUSec;
 
     ////////////////////////////


### PR DESCRIPTION
## Description
Another tiny fix.

When attempting to make a animation sync, I noticed that there is a bug with LLWorld's `getSpaceTimeUSec()` function.
Presently, SpaceTime is stored as a U64, while LLUnit is F32. Because of the way C++ is compiling the code, it converts the U64 to a F32 before doing the addition, and ends up storing a invalid number for SpaceTime.
We could increase LLUnit to a F64, but I'm unsure of issues that may cause, or if we would still lose precision eventually, so doing it this way would potentially the better option.

Looking around the code, I don't see anywhere that this is used, as far as I am aware, it is completely unused, but I'm fixing it because I need to use it for feature development, and also it'd be nice if someone else comes around needing to use it doesn't spend time debugging why `getSpaceTimeUSec()` doesn't update properly.

I'm not 100% positive if this is the *correct* solution though, replacing `LLUnits::Seconds::fromValue(dt_raw)` with `(U64)(dt_raw * 1000000.0)` does fix it. I'm open to suggestions on a better way to do this.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

Not really a way to test this without a debug UI / logger, but the problem is that it wouldn't demonstrate the before, only the after.
I give my word that it was broken before hand, and this fixes it though.