### PR TITLE
On name change notify the plugin to update.

### DIFF
--- a/indra/newview/llscripteditorws.cpp
+++ b/indra/newview/llscripteditorws.cpp
@@ -1060,6 +1060,9 @@ LLSD LLScriptEditorWSServer::handleObjectModify(U32 connection_id, const LLSD& p
         msg->sendReliable(host);
     }
 
+    // Force a properties reply so the editor sees the change without an in-world selection.
+    LLSelectMgr::instance().requestObjectPropertiesFamily(prim);
+
     // Step 4: Return Success Response
     LLSD response;
     response["success"] = true;

--- a/indra/newview/llselectmgr.cpp
+++ b/indra/newview/llselectmgr.cpp
@@ -6108,11 +6108,13 @@ void LLSelectMgr::processObjectProperties(LLMessageSystem* msg, void** user_data
             node->mInventorySerial = inv_serial;
             node->mSitName.assign(sit_name);
             node->mTouchName.assign(touch_name);
+        }
 
-            if (auto ws_server = LLScriptEditorWSServer::getServer())
-            {
-                ws_server->onObjectPropertyChanged(id, name, desc, inv_serial);
-            }
+        // Published objects need property updates even when not selected.
+        LLScriptEditorWSServer::ptr_t ws_server = LLScriptEditorWSServer::getServer();
+        if (ws_server)
+        {
+            ws_server->onObjectPropertyChanged(id, name, desc, inv_serial);
         }
     }
 


### PR DESCRIPTION
## Description

Viewer was not notifying the plugin about a successful name change on the object.  
On an object property change, explicitly request the update and forward to the plugin if the server is active.

Issue #6304 